### PR TITLE
fix: pass port parameter to sandbox_agent_bridge in codex_cli

### DIFF
--- a/src/inspect_swe/_codex_cli/codex_cli.py
+++ b/src/inspect_swe/_codex_cli/codex_cli.py
@@ -93,7 +93,7 @@ def codex_cli(
         store().set(MODEL_PORT, port)
 
         async with sandbox_agent_bridge(
-            state, model=model, filter=filter, retry_refusals=retry_refusals
+            state, model=model, filter=filter, retry_refusals=retry_refusals, port=port
         ) as bridge:
             # ensure codex is installed and get binary location
             codex_binary = await ensure_agent_binary_installed(


### PR DESCRIPTION
The port was being calculated but not passed to sandbox_agent_bridge() in commit 2591b2e.

This causes 'address already in use' errors when running multiple agent invocations within a sample.

This PR adds the missing port parameter.