### PR TITLE
Move Claude Code binary to /var/tmp/

### DIFF
--- a/src/inspect_swe/_util/agentbinary.py
+++ b/src/inspect_swe/_util/agentbinary.py
@@ -86,7 +86,9 @@ async def ensure_agent_binary_installed(
             resolved_version = version
 
         # write it into the container and return it
-        binary_path = f"/var/tmp/.5c95f967ca830048/{source.binary}-{resolved_version}-{platform}"
+        binary_path = (
+            f"/var/tmp/.5c95f967ca830048/{source.binary}-{resolved_version}-{platform}"
+        )
         await sandbox.write_file(binary_path, binary_bytes)
         await sandbox_exec(sandbox, f"chmod +x {binary_path}")
         if source.post_install:


### PR DESCRIPTION
Move the Claude Code binary into `/var/tmp/.5c95f967ca830048/`. This mirrors [this change](https://github.com/UKGovernmentBEIS/inspect_ai/commit/ad4fc229d26640d05b4c07e0dc34accf3e1c65ca) in inspect_ai.

Motivations are the same as for the change made to inspect_ai
1) it is accessible in all major linux distributions
2) all users have permissions to read/write to it (i.e. world-writable)
3) it is unlikely to be cleared during an evaluation (https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard)
4) it is unlikely to be accidentally stumbled upon by an LLM solving a taks that requires interacting with temp files

We additionally choose a dot-prefixed random hash sub-directory to further attempt to prevent LLMs from stumbling on the injected tools.