### PR TITLE
Chmod agent binary as root

### DIFF
--- a/src/inspect_swe/_util/agentbinary.py
+++ b/src/inspect_swe/_util/agentbinary.py
@@ -88,7 +88,7 @@ async def ensure_agent_binary_installed(
         # write it into the container and return it
         binary_path = f"/opt/{source.binary}-{resolved_version}-{platform}"
         await sandbox.write_file(binary_path, binary_bytes)
-        await sandbox_exec(sandbox, f"chmod +x {binary_path}")
+        await sandbox_exec(sandbox, f"chmod +x {binary_path}", user="root")
         if source.post_install:
             await sandbox_exec(
                 sandbox, f"{binary_path} {source.post_install}", user=user


### PR DESCRIPTION
## What is the current behavior?

Installation of the agent binary fails where the container user is `root` but the [default sandbox tool user](https://github.com/UKGovernmentBEIS/inspect_k8s_sandbox/pull/97) is not `root` (i.e. most METR environments).

This is because the agent binary is written using `write_file`, which runs as the container user (i.e. `root`), but the subsequent `chmod +x {binary_path}` command runs as the default sandbox tool user (which for us is usually `agent`), and so gets an "operation not permitted" error because the `agent` user can't change the mode of a file owned by `root`.

## What is the new behavior?

Specify the `root` user when running `chmod` on the agent binary.

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No, should be backwards compatible.

## Other information:

See https://github.com/UKGovernmentBEIS/inspect_ai/pull/2746 for a fix to a similar issue we recently encountered in Inspect.

I've run this successfully on a local k8s cluster and can confirm that the bug no longer occurs with the fix applied (but does if it is not applied).

I ran `make check` locally and all appears good there. I also ran `make test`, which ran fine for Claude Code on Docker but failed repeatedly on the Codex CLI tests with the error `HTTPStatusError: Client error '403 rate limit exceeded' for url  'https://api.github.com/repos/openai/codex/releases'`. (We also get this in production, looks like the GitHub API is rate limiting requests)

I couldn't find any relevant tests or docs to update.