### PR TITLE
cc link + typo fix

### DIFF
--- a/docs/_snippets/agent_intro.md
+++ b/docs/_snippets/agent_intro.md
@@ -17,7 +17,7 @@ from inspect_ai import Task, task
 from inspect_ai.dataset import json_dataset
 from inspect_ai.scorer import model_graded_qa
 
-from inspect_swe import codex_cli
+from inspect_swe import {{< meta agent >}}
 
 @task
 def system_explorer() -> Task:

--- a/docs/_snippets/agent_mcp_servers.md
+++ b/docs/_snippets/agent_mcp_servers.md
@@ -1,8 +1,8 @@
 ## MCP Servers {#mcp-servers}
 
-You can specify one or more [Model Context Protocol](https://modelcontextprotocol.io/docs/getting-started/intro) (MCP) servers to provide additional tools to Codex CLI. Servers are specified via the [`MCPServerConfig`](https://inspect.aisi.org.uk/reference/inspect_ai.tool.html#mcpserverconfig) class and its Stdio and HTTP variants.
+You can specify one or more [Model Context Protocol](https://modelcontextprotocol.io/docs/getting-started/intro) (MCP) servers to provide additional tools to {{< meta agent_name >}}. Servers are specified via the [`MCPServerConfig`](https://inspect.aisi.org.uk/reference/inspect_ai.tool.html#mcpserverconfig) class and its Stdio and HTTP variants.
 
-For example, here is a Dockerfile that makes the `server-memory` MPC server available in the sandbox container:
+For example, here is a Dockerfile that makes the `server-memory` MCP server available in the sandbox container:
 
 ``` dockerfile
 FROM python:3.12-bookworm
@@ -30,7 +30,7 @@ We can then use this MCP server in a task as follows:
 from inspect_ai import Task, task
 from inspect_ai.dataset import Sample
 from inspect_ai.tool import MCPServerConfigStdio
-from inspect_swe import codex_cli
+from inspect_swe import {{< meta agent >}}
 
 @task
 def investigator() -> Task:

--- a/docs/claude_code.qmd
+++ b/docs/claude_code.qmd
@@ -29,7 +29,7 @@ The following options are supported for customizing the behavior of the agent:
 | `subagent_model` | The model to use for [subagents](https://code.claude.com/docs/en/sub-agents). Defaults to `model`. |
 | `filter` | Filter for intercepting bridged model requests. |
 | `retry_refusals` | Should refusals be retried? (pass number of times to retry) |
-| `cwd` | Workding directory for {{< meta agent_name >}} session. |
+| `cwd` | Working directory for {{< meta agent_name >}} session. |
 | `env` | Environment variables to set for {{< meta agent_name >}}. |
 | `version` | Version of {{< meta agent_name >}} to use (see [Installation](#installation) below for details) |
 

--- a/docs/codex_cli.qmd
+++ b/docs/codex_cli.qmd
@@ -27,7 +27,7 @@ The following options are supported for customizing the behavior of the agent:
 | `filter` | Filter for intercepting bridged model requests. |
 | `retry_refusals` | Should refusals be retried? (pass number of times to retry) |
 | `home_dir` | Home directory to use for codex cli. When set, AGENTS.md and the MCP configuration will be written here rather than to .codex
-| `cwd` | Workding directory for {{< meta agent_name >}} session. |
+| `cwd` | Working directory for {{< meta agent_name >}} session. |
 | `env` | Environment variables to set for {{< meta agent_name >}}. |
 | `version` | Version of {{< meta agent_name >}} to use (see [Installation](#installation) below for details) |
 


### PR DESCRIPTION
the [previous claude code link](https://docs.anthropic.com/en/docs/claude-code/overview) led to a 404 + other small typos after a llm sweep across the docs