### PR TITLE
fix: cache GitHub API responses in Codex version resolution to avoid rate limit errors

### DIFF
--- a/src/inspect_swe/_codex_cli/agentbinary.py
+++ b/src/inspect_swe/_codex_cli/agentbinary.py
@@ -2,7 +2,6 @@ import json
 from pathlib import Path
 from typing import Any
 
-import anyio
 from typing_extensions import Literal
 
 from .._util.agentbinary import AgentBinarySource, AgentBinaryVersion
@@ -10,15 +9,6 @@ from .._util.appdirs import package_cache_dir
 from .._util.download import download_text_file
 from .._util.sandbox import SandboxPlatform
 from .._util.tarball import extract_tarball
-
-# In-process cache for GitHub API responses to avoid rate limiting.
-# GitHub's unauthenticated API limit is 60 req/hour. Without caching,
-# each sample resolves the version separately, quickly exhausting the limit.
-# The cache lives for the process lifetime, so each eval run gets a
-# consistent version and the next run picks up any new releases.
-_github_api_lock = anyio.Lock()
-_cached_latest_version: str | None = None
-_cached_release_assets: dict[str, dict[str, Any]] = {}
 
 
 def codex_cli_binary_source() -> AgentBinarySource:
@@ -96,58 +86,37 @@ def _platform_to_codex_arch(platform: SandboxPlatform) -> str:
 
 
 async def _fetch_latest_stable_version() -> str:
-    """Fetch the latest stable version from GitHub releases.
+    """Fetch the latest stable version from GitHub releases."""
+    releases_url = "https://api.github.com/repos/openai/codex/releases"
+    releases_json = await download_text_file(releases_url)
+    releases = json.loads(releases_json)
 
-    Results are cached in-process so only the first call hits the GitHub API.
-    Subsequent calls return the cached version, avoiding rate limit exhaustion
-    when running many concurrent samples.
-    """
-    global _cached_latest_version
+    # Filter out pre-releases and alpha versions
+    stable_releases = [
+        r
+        for r in releases
+        if not r.get("prerelease", False) and "-alpha" not in r.get("tag_name", "")
+    ]
 
-    async with _github_api_lock:
-        if _cached_latest_version is not None:
-            return _cached_latest_version
+    if not stable_releases:
+        raise RuntimeError("No stable releases found for codex")
 
-        releases_url = "https://api.github.com/repos/openai/codex/releases"
-        releases_json = await download_text_file(releases_url)
-        releases = json.loads(releases_json)
+    # Get the most recent stable release
+    latest = stable_releases[0]
+    tag_name = latest["tag_name"]
 
-        # Filter out pre-releases and alpha versions
-        stable_releases = [
-            r
-            for r in releases
-            if not r.get("prerelease", False) and "-alpha" not in r.get("tag_name", "")
-        ]
-
-        if not stable_releases:
-            raise RuntimeError("No stable releases found for codex")
-
-        # Get the most recent stable release
-        latest = stable_releases[0]
-        tag_name = latest["tag_name"]
-
-        # Extract version from tag (e.g., "rust-v0.29.0" -> "0.29.0")
-        if tag_name.startswith("rust-v"):
-            result: str = tag_name[6:]  # Remove "rust-v" prefix
-            _cached_latest_version = result
-            return result
-        else:
-            raise RuntimeError(f"Unexpected tag format: {tag_name}")
+    # Extract version from tag (e.g., "rust-v0.29.0" -> "0.29.0")
+    if tag_name.startswith("rust-v"):
+        result: str = tag_name[6:]  # Remove "rust-v" prefix
+        return result
+    else:
+        raise RuntimeError(f"Unexpected tag format: {tag_name}")
 
 
 async def _fetch_release_assets(version: str) -> dict[str, Any]:
-    """Fetch release assets for a specific version.
-
-    Results are cached in-process so repeated lookups for the same version
-    (across samples) don't make additional GitHub API calls.
-    """
-    async with _github_api_lock:
-        if version in _cached_release_assets:
-            return _cached_release_assets[version]
-
-        tag = f"rust-v{version}"
-        release_url = f"https://api.github.com/repos/openai/codex/releases/tags/{tag}"
-        release_json = await download_text_file(release_url)
-        result: dict[str, Any] = json.loads(release_json)
-        _cached_release_assets[version] = result
-        return result
+    """Fetch release assets for a specific version."""
+    tag = f"rust-v{version}"
+    release_url = f"https://api.github.com/repos/openai/codex/releases/tags/{tag}"
+    release_json = await download_text_file(release_url)
+    result: dict[str, Any] = json.loads(release_json)
+    return result


### PR DESCRIPTION
## Problem

When running evals with multiple concurrent samples, each sample independently calls `resolve_version()` on its agent binary source, hitting upstream APIs (e.g. GitHub for Codex CLI, GCS for Claude Code). For rate-limited APIs like GitHub's unauthenticated endpoint (60 req/hour), this quickly leads to `403 rate limit exceeded` errors.

## What was observed

1. The error occurs during binary installation (`ensure_agent_binary_installed` → `resolve_version`), not during LLM API calls.
2. With `max_tasks=50`, up to 100 GitHub API calls are made per eval run (2 per sample for Codex CLI). This quickly exhausts the 60 req/hour unauthenticated limit.
3. The existing concurrency lock (`concurrency("codex-install", 1)`) serializes binary downloads but doesn't prevent repeated version resolution calls — each sample still resolves the version independently.

## Change

Cache `resolve_version()` results in the shared orchestration layer (`_util/agentbinary.py`) rather than in individual providers. The `download_agent_binary_async()` function now holds an `anyio.Lock` and caches results keyed on `(binary, version, platform)`. The first caller hits the upstream API; all subsequent callers with the same arguments return the cached result immediately.

This benefits all agent binary providers (Codex CLI, Claude Code, and any future ones) without each needing to implement its own caching. The cache lives for the process lifetime, so each new eval run starts fresh.
