### PR TITLE
feat: Add model_aliases parameter to agent functions

### DIFF
--- a/src/inspect_swe/_claude_code/claude_code.py
+++ b/src/inspect_swe/_claude_code/claude_code.py
@@ -18,7 +18,7 @@ from inspect_ai.agent import (
 )
 from inspect_ai.event import ModelEvent
 from inspect_ai.log import transcript
-from inspect_ai.model import ChatMessageSystem, GenerateFilter
+from inspect_ai.model import ChatMessageSystem, GenerateFilter, Model
 from inspect_ai.scorer import score
 from inspect_ai.tool import MCPServerConfig, Skill, install_skills, read_skills
 from inspect_ai.util import (
@@ -64,6 +64,7 @@ def claude_code(
     centaur: bool | CentaurOptions = False,
     attempts: int | AgentAttempts = 1,
     model: str | None = None,
+    model_aliases: dict[str, str | Model] | None = None,
     opus_model: str | None = None,
     sonnet_model: str | None = None,
     haiku_model: str | None = None,
@@ -101,6 +102,9 @@ def claude_code(
         centaur: Run in 'centaur' mode, which makes Claude Code available to an Inspect `human_cli()` agent rather than running it unattended.
         attempts: Configure agent to make multiple attempts. When this is specified, the task will be scored when the agent stops calling tools. If the scoring is successful, execution will stop. Otherwise, the agent will be prompted to pick up where it left off for another attempt.
         model: Model name to use for Opus and Sonnet calls (defaults to main model for task).
+        model_aliases: Optional mapping of model names to Model instances or model name strings.
+            Allows using custom Model implementations (e.g., wrapped Agents) instead of standard models.
+            When a model name in the mapping is referenced, the corresponding Model/string is used.
         opus_model: The model to use for `opus`, or for `opusplan` when Plan Mode is active. Defaults to `model`.
         sonnet_model: The model to use for `sonnet`, or for `opusplan` when Plan Mode is not active. Defaults to `model`.
         haiku_model: The model to use for haiku, or [background functionality](https://code.claude.com/docs/en/costs#background-token-usage). Defaults to `model`.
@@ -149,6 +153,7 @@ def claude_code(
             sandbox_agent_bridge(
                 state,
                 model=model,
+                model_aliases=model_aliases,
                 filter=filter,
                 retry_refusals=retry_refusals,
                 port=port,

--- a/src/inspect_swe/_codex_cli/codex_cli.py
+++ b/src/inspect_swe/_codex_cli/codex_cli.py
@@ -13,7 +13,7 @@ from inspect_ai.agent import (
     agent_with,
     sandbox_agent_bridge,
 )
-from inspect_ai.model import ChatMessageSystem, GenerateFilter
+from inspect_ai.model import ChatMessageSystem, GenerateFilter, Model
 from inspect_ai.scorer import score
 from inspect_ai.tool import MCPServerConfig, Skill, install_skills, read_skills
 from inspect_ai.util import SandboxEnvironment, store
@@ -50,6 +50,7 @@ def codex_cli(
     centaur: bool | CentaurOptions = False,
     attempts: int | AgentAttempts = 1,
     model: str | None = None,
+    model_aliases: dict[str, str | Model] | None = None,
     filter: GenerateFilter | None = None,
     retry_refusals: int | None = None,
     home_dir: str | None = None,
@@ -81,6 +82,9 @@ def codex_cli(
         centaur: Run in 'centaur' mode, which makes Codex CLI available to an Inspect `human_cli()` agent rather than running it unattended.
         attempts: Configure agent to make multiple attempts. When this is specified, the task will be scored when the agent stops calling tools. If the scoring is successful, execution will stop. Otherwise, the agent will be prompted to pick up where it left off for another attempt.
         model: Model name to use (defaults to main model for task).
+        model_aliases: Optional mapping of model names to Model instances or model name strings.
+            Allows using custom Model implementations (e.g., wrapped Agents) instead of standard models.
+            When a model name in the mapping is referenced, the corresponding Model/string is used.
         filter: Filter for intercepting bridged model requests.
         retry_refusals: Should refusals be retried? (pass number of times to retry)
         home_dir: Home directory to use for codex cli. If set, AGENTS.md, skills, and the MCP configuration will be written here.
@@ -121,6 +125,7 @@ def codex_cli(
         async with sandbox_agent_bridge(
             state,
             model=model,
+            model_aliases=model_aliases,
             filter=filter,
             retry_refusals=retry_refusals,
             port=port,

--- a/src/inspect_swe/_gemini_cli/gemini_cli.py
+++ b/src/inspect_swe/_gemini_cli/gemini_cli.py
@@ -13,7 +13,7 @@ from inspect_ai.agent import (
     agent_with,
     sandbox_agent_bridge,
 )
-from inspect_ai.model import ChatMessageSystem, GenerateFilter
+from inspect_ai.model import ChatMessageSystem, GenerateFilter, Model
 from inspect_ai.scorer import score
 from inspect_ai.tool import MCPServerConfig, Skill, install_skills, read_skills
 from inspect_ai.tool._mcp._config import MCPServerConfigHTTP
@@ -44,6 +44,7 @@ def gemini_cli(
     centaur: bool | CentaurOptions = False,
     attempts: int | AgentAttempts = 1,
     model: str | None = None,
+    model_aliases: dict[str, str | Model] | None = None,
     gemini_model: str = "gemini-2.5-pro",
     filter: GenerateFilter | None = None,
     retry_refusals: int | None = None,
@@ -71,6 +72,9 @@ def gemini_cli(
         centaur: Run in 'centaur' mode, which makes Gemini CLI available to an Inspect `human_cli()` agent rather than running it unattended.
         attempts: Configure agent to make multiple attempts
         model: Model name to use for inspect bridge (defaults to main model for task)
+        model_aliases: Optional mapping of model names to Model instances or model name strings.
+            Allows using custom Model implementations (e.g., wrapped Agents) instead of standard models.
+            When a model name in the mapping is referenced, the corresponding Model/string is used.
         gemini_model: Gemini model name to pass to CLI. This bypasses the auto-router.
             Use "gemini-2.5-pro" (default) or "gemini-2.5-flash". The actual model
             calls still go through the inspect bridge, but this disables the router.
@@ -108,6 +112,7 @@ def gemini_cli(
         async with sandbox_agent_bridge(
             state,
             model=model,
+            model_aliases=model_aliases,
             filter=filter,
             retry_refusals=retry_refusals,
             port=port,


### PR DESCRIPTION
Adds support for the `model_aliases` parameter (introduced in Inspect AI 0.3.183) to `claude_code()`, `codex_cli()`, and `gemini_cli()` functions.

This parameter allows users to pass custom Model implementations (e.g., wrapped Agents) instead of just model name strings. The parameter is passed through to the underlying `sandbox_agent_bridge` call.

**Use case**: Enables control-arena to use inspect_swe agents as orchestration scaffolds while running custom control protocols as the underlying model.

**Changes**:
- Add `model_aliases` parameter to function signatures
- Pass parameter through to `sandbox_agent_bridge`
- Add documentation

**Breaking**: No - optional parameter with default `None`

**Example**:
```python
from inspect_swe import claude_code
from my_framework import CustomModel

model = CustomModel()
agent = claude_code(
    model_aliases={"custom": model},
    model="custom",
)
```