### PR TITLE
Run ACP Codex CLI with approval_policy: never and sandbox_mode: danger_full_access

### DIFF
--- a/src/inspect_swe/acp/_agents/codex_cli/codex_cli.py
+++ b/src/inspect_swe/acp/_agents/codex_cli/codex_cli.py
@@ -112,6 +112,8 @@ class CodexCli(ACPAgent):
             toml_config: dict[str, Any] = {
                 "model": default_model,
                 "preferred_auth_method": "apikey",
+                "approval_policy": "never",
+                "sandbox_mode": "danger-full-access",
                 "model_provider": "openai-proxy",
                 "model_providers.openai-proxy": {
                     "name": "OpenAI Proxy",


### PR DESCRIPTION
By default, we want Codex CLI evaluations to run with full permissions so it can execute long running, autonomous tasks. This changes Codex CLI in ACP to be consistent with the non-ACP version: https://github.com/meridianlabs-ai/inspect_swe/blob/0e18e418a9f00c633ca589da15c48a6fa851e046/src/inspect_swe/_codex_cli/codex_cli.py#L206 

Testing: Ran locally with my changes and now I see 
```
<permissions instructions>
Filesystem sandboxing defines which files can be read or written. sandbox_mode is danger-full-access: No filesystem sandboxing - all commands are permitted. Network access is enabled.
Approval policy is currently never. Do not provide the sandbox_permissions for any reason, commands will be rejected.
</permissions instructions>
``` 

instead of 

```
<permissions instructions>
Filesystem sandboxing defines which files can be read or written. sandbox_mode is read-only: The sandbox only permits reading files. Network access is restricted.

Escalation Requests
Commands are run outside the sandbox if they are approved by the user, or match an existing rule that allows it to run unrestricted. The command string is split into independent command segments at shell control operators, including but not limited to:

Pipes: |
Logical operators: &&, ||
Command separators: ;
Subshell boundaries: (...), $(...)
Each resulting segment is evaluated independently for sandbox restrictions and approval requirements.

Example:

git pull | tee output.txt

This is treated as two command segments:

["git", "pull"]

["tee", "output.txt"]

Commands that use more advanced shell features like redirection (>, >>, <), substitutions ($(...), ...), environment variables (FOO=bar), or wildcard patterns (*, ?) will not be evaluated against rules, to limit the scope of what an approved rule allows.

How to request escalation
IMPORTANT: To request approval to execute a command that will require escalated privileges:

Provide the sandbox_permissions parameter with the value "require_escalated"
Include a short question asking the user if they want to allow the action in justification parameter. e.g. "Do you want to download and install dependencies for this project?"
Optionally suggest a prefix_rule - this will be shown to the user with an option to persist the rule approval for future sessions.
If you run a command that is important to solving the user's query, but it fails because of sandboxing or with a likely sandbox-related network error (for example DNS/host resolution, registry/index access, or dependency download failure), rerun the command with "require_escalated". ALWAYS proceed to use the justification parameter - do not message the user before requesting approval for the command.

When to request escalation
While commands are running inside the sandbox, here are some scenarios that will require escalation outside the sandbox:

You need to run a command that writes to a directory that requires it (e.g. running tests that write to /var)
You need to run a GUI app (e.g., open/xdg-open/osascript) to open browsers or files.
If you run a command that is important to solving the user's query, but it fails because of sandboxing or with a likely sandbox-related network error (for example DNS/host resolution, registry/index access, or dependency download failure), rerun the command with require_escalated. ALWAYS proceed to use the sandbox_permissions and justification parameters. do not message the user before requesting approval for the command.
You are about to take a potentially destructive action such as an rm or git reset that the user did not explicitly ask for.
Be judicious with escalating, but if completing the user's request requires it, you should do so - don't try and circumvent approvals by using other tools.
prefix_rule guidance
When choosing a prefix_rule, request one that will allow you to fulfill similar requests from the user in the future without re-requesting escalation. It should be categorical and reasonably scoped to similar capabilities. You should rarely pass the entire command into prefix_rule.

Banned prefix_rules
Avoid requesting overly broad prefixes that the user would be ill-advised to approve. For example, do not request ["python3"], ["python", "-"], or other similar prefixes that would allow arbitrary scripting.
NEVER provide a prefix_rule argument for destructive commands like rm.
NEVER provide a prefix_rule if your command uses a heredoc or herestring.

Examples
Good examples of prefixes:

["npm", "run", "dev"]
["gh", "pr", "check"]
["cargo", "test"]
</permissions instructions>
```

in the system message for Codex