### PR TITLE
Bootstrap pip for wheel downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Mini SWE Agent: Ensure that pip is available before attempting installation.
+
 ## 0.2.50 (29 April 2026)
 
 - Codex CLI: Run ACP mode with approval_policy: never and sandbox_mode: danger_full_access

--- a/src/inspect_swe/_util/agentwheel.py
+++ b/src/inspect_swe/_util/agentwheel.py
@@ -1,3 +1,4 @@
+import importlib.util
 import subprocess
 import sys
 import tarfile
@@ -340,6 +341,7 @@ def download_wheels_tarball(
     with tempfile.TemporaryDirectory() as tmpdir:
         wheel_dir = Path(tmpdir) / "wheels"
         wheel_dir.mkdir()
+        _ensure_pip_available()
         # pip download docs https://pip.pypa.io/en/stable/cli/pip_download/
         cmd = [
             sys.executable,
@@ -402,3 +404,21 @@ def download_wheels_tarball(
         )
 
         return tarball, resolved_version
+
+
+def _ensure_pip_available() -> None:
+    if importlib.util.find_spec("pip") is not None:
+        return
+
+    result = subprocess.run(
+        [sys.executable, "-m", "ensurepip", "--upgrade", "--default-pip"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        message = result.stderr.strip() or result.stdout.strip()
+        detail = f": {message}" if message else ""
+        raise RuntimeError(
+            "pip is required to download wheels and could not be bootstrapped"
+            f" via ensurepip{detail}."
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -218,7 +218,13 @@ def mock_pip_download_failure() -> Any:
     from unittest.mock import patch
 
     # Mock cache to return None (force download path)
-    with patch("inspect_swe._util.agentwheel.read_cached_wheels", return_value=None):
+    with (
+        patch("inspect_swe._util.agentwheel.read_cached_wheels", return_value=None),
+        patch(
+            "inspect_swe._util.agentwheel.importlib.util.find_spec",
+            return_value=MagicMock(),
+        ),
+    ):
         # Mock subprocess.run to simulate pip download failure
         with patch("inspect_swe._util.agentwheel.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,6 +1,7 @@
+import sys
 from pathlib import Path
 from typing import Literal
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from inspect_swe import (
@@ -174,3 +175,52 @@ def test_mini_swe_agent_cache_hit(wheels_cache_cleanup: Path) -> None:
 
     # Verify cache file access time was updated (file was touched)
     assert cache_file.stat().st_atime >= cache_mtime
+
+
+def test_ensure_pip_available_noop_when_present() -> None:
+    from inspect_swe._util.agentwheel import _ensure_pip_available
+
+    with (
+        patch(
+            "inspect_swe._util.agentwheel.importlib.util.find_spec",
+            return_value=MagicMock(),
+        ),
+        patch("inspect_swe._util.agentwheel.subprocess.run") as mock_run,
+    ):
+        _ensure_pip_available()
+        mock_run.assert_not_called()
+
+
+def test_ensure_pip_available_bootstraps_when_missing() -> None:
+    from inspect_swe._util.agentwheel import _ensure_pip_available
+
+    with (
+        patch("inspect_swe._util.agentwheel.importlib.util.find_spec", return_value=None),
+        patch("inspect_swe._util.agentwheel.subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+
+        _ensure_pip_available()
+
+        mock_run.assert_called_once_with(
+            [sys.executable, "-m", "ensurepip", "--upgrade", "--default-pip"],
+            capture_output=True,
+            text=True,
+        )
+
+
+def test_ensure_pip_available_raises_on_failure() -> None:
+    from inspect_swe._util.agentwheel import _ensure_pip_available
+
+    with (
+        patch("inspect_swe._util.agentwheel.importlib.util.find_spec", return_value=None),
+        patch("inspect_swe._util.agentwheel.subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(
+            returncode=1, stderr="ensurepip disabled", stdout=""
+        )
+
+        with pytest.raises(RuntimeError, match="pip is required") as exc_info:
+            _ensure_pip_available()
+
+        assert "ensurepip disabled" in str(exc_info.value)


### PR DESCRIPTION
## Summary

https://github.com/UKGovernmentBEIS/inspect_evals/pull/1496 found that pip not being available would raise an error.

- bootstrap pip via ensurepip when missing before running pip download
- include ensurepip failure details in the raised error

