### PR TITLE
Disable codex_cli and gemini_cli telemetry by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- Codex CLI: Disable telemetry by default.
+- Gemini CLI: Disable telemetry by default.
+
 ## 0.2.51 (07 May 2026)
 
 - Gemini CLI: Fix MCP registration via GEMINI_CLI_TRUST_WORKSPACE.

--- a/src/inspect_swe/_codex_cli/codex_cli.py
+++ b/src/inspect_swe/_codex_cli/codex_cli.py
@@ -219,6 +219,10 @@ def codex_cli(
             # build toml config
             toml_config: dict[str, Any] = {}
 
+            # disable codex analytics (both the chatgpt.com analytics-events
+            # sink and the always-on Statsig OTel metrics to ab.chatgpt.com)
+            toml_config["analytics"] = {"enabled": False}
+
             # register mcp servers (combine static configs with bridged tools)
             all_mcp_servers = list(mcp_servers or []) + bridge.mcp_server_configs
             if all_mcp_servers:

--- a/src/inspect_swe/_gemini_cli/gemini_cli.py
+++ b/src/inspect_swe/_gemini_cli/gemini_cli.py
@@ -148,9 +148,7 @@ def gemini_cli(
             settings_json = build_gemini_settings(all_mcp_servers)
             gemini_settings_dir = f"{sandbox_home}/.gemini"
             await sbox.exec(["mkdir", "-p", gemini_settings_dir], user=user)
-            await sbox.write_file(
-                f"{gemini_settings_dir}/settings.json", settings_json
-            )
+            await sbox.write_file(f"{gemini_settings_dir}/settings.json", settings_json)
 
             # build system prompt
             system_messages = [

--- a/src/inspect_swe/_gemini_cli/gemini_cli.py
+++ b/src/inspect_swe/_gemini_cli/gemini_cli.py
@@ -142,15 +142,15 @@ def gemini_cli(
             home_result = await sbox.exec(["sh", "-c", "echo $HOME"], user=user)
             sandbox_home = home_result.stdout.strip() or "/root"
 
-            # write MCP server configs to settings.json in actual home
-            # (not /tmp, so MCP servers can use npm cache from the real home)
-            if all_mcp_servers:
-                settings_json = resolve_mcp_servers(all_mcp_servers)
-                gemini_settings_dir = f"{sandbox_home}/.gemini"
-                await sbox.exec(["mkdir", "-p", gemini_settings_dir], user=user)
-                await sbox.write_file(
-                    f"{gemini_settings_dir}/settings.json", settings_json
-                )
+            # write settings.json: disable Clearcut usage-statistics telemetry
+            # (on by default; only disable is via this settings key — env
+            # vars / DO_NOT_TRACK are not honoured) and register MCP servers
+            settings_json = build_gemini_settings(all_mcp_servers)
+            gemini_settings_dir = f"{sandbox_home}/.gemini"
+            await sbox.exec(["mkdir", "-p", gemini_settings_dir], user=user)
+            await sbox.write_file(
+                f"{gemini_settings_dir}/settings.json", settings_json
+            )
 
             # build system prompt
             system_messages = [
@@ -282,18 +282,25 @@ def gemini_cli(
     return agent_with(execute, name=name, description=description)
 
 
-def resolve_mcp_servers(mcp_servers: Sequence[MCPServerConfig]) -> str:
-    """Build Gemini CLI settings.json content from MCP server configs."""
-    mcp_servers_config: dict[str, Any] = {}
-    for server in mcp_servers:
-        config = server.model_dump(exclude={"name", "tools", "type"}, exclude_none=True)
-        # For HTTP transport, Gemini CLI uses 'httpUrl' field
-        if isinstance(server, MCPServerConfigHTTP) and "url" in config:
-            config["httpUrl"] = config.pop("url")
-        if "cwd" in config and not isinstance(config["cwd"], str):
-            config["cwd"] = str(config["cwd"])
-        mcp_servers_config[server.name] = config
-    return json.dumps({"mcpServers": mcp_servers_config}, indent=2)
+def build_gemini_settings(mcp_servers: Sequence[MCPServerConfig]) -> str:
+    """Build Gemini CLI settings.json content (privacy + MCP server configs)."""
+    settings: dict[str, Any] = {
+        "privacy": {"usageStatisticsEnabled": False},
+    }
+    if mcp_servers:
+        mcp_servers_config: dict[str, Any] = {}
+        for server in mcp_servers:
+            config = server.model_dump(
+                exclude={"name", "tools", "type"}, exclude_none=True
+            )
+            # For HTTP transport, Gemini CLI uses 'httpUrl' field
+            if isinstance(server, MCPServerConfigHTTP) and "url" in config:
+                config["httpUrl"] = config.pop("url")
+            if "cwd" in config and not isinstance(config["cwd"], str):
+                config["cwd"] = str(config["cwd"])
+            mcp_servers_config[server.name] = config
+        settings["mcpServers"] = mcp_servers_config
+    return json.dumps(settings, indent=2)
 
 
 def _clean_gemini_error(stdout: str, stderr: str) -> str:


### PR DESCRIPTION
## Disable codex_cli and gemini_cli telemetry by default

Brings these two agents in line with `claude_code`, which already sets `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1`.

### codex_cli

Codex's OTel `metrics_exporter` defaults to `Statsig` ([config/src/types.rs#L509](https://github.com/openai/codex/blob/main/codex-rs/config/src/types.rs)) → `https://ab.chatgpt.com/otlp/v1/metrics` in release builds, gated only by `analytics_enabled` ([core/src/otel_init.rs#L70-77](https://github.com/openai/codex/blob/main/codex-rs/core/src/otel_init.rs)). `codex exec` defaults that to `true` ([exec/src/lib.rs#L155](https://github.com/openai/codex/blob/main/codex-rs/exec/src/lib.rs)). Confirmed via mitmproxy: a single `codex exec` run with our existing config emits one POST to `ab.chatgpt.com` carrying `model`, `session_source`, `os`, `app.version` tags. The separate analytics-events sink (`chatgpt.com/backend-api/codex/analytics-events/events`, which carries repo URL/cwd) was already suppressed for us by API-key auth ([analytics/src/client.rs#L365-367](https://github.com/openai/codex/blob/main/codex-rs/analytics/src/client.rs)), but `[analytics] enabled=false` is the documented switch for both and doesn't depend on auth mode.

### gemini_cli

Clearcut usage-stats default to on (`usageStatisticsEnabled ?? true`, [core/src/config/config.ts#L1086](https://github.com/google-gemini/gemini-cli/blob/main/packages/core/src/config/config.ts)) and POST to `https://play.googleapis.com/log` on every session ([clearcut-logger.ts#L244](https://github.com/google-gemini/gemini-cli/blob/main/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts)). The only disable is `~/.gemini/settings.json` `privacy.usageStatisticsEnabled` — `GEMINI_TELEMETRY_ENABLED` controls a separate (default-off) OTel layer and does **not** stop Clearcut. We were only writing `settings.json` when MCP servers were configured; now we always write it with the privacy block.

Both fixes verified via mitmproxy capture (host and Docker-sandbox runs).
