### PR TITLE
claude_code (ACP): allocate per-invocation bridge port

### DIFF
--- a/src/inspect_swe/acp/_agents/claude_code/claude_code.py
+++ b/src/inspect_swe/acp/_agents/claude_code/claude_code.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from inspect_ai.agent import AgentState, SandboxAgentBridge, agent, sandbox_agent_bridge
 from inspect_ai.model import Model, get_model
 from inspect_ai.tool import Skill, install_skills, read_skills
-from inspect_ai.util import ExecRemoteProcess, ExecRemoteStreamingOptions
+from inspect_ai.util import ExecRemoteProcess, ExecRemoteStreamingOptions, store
 from inspect_ai.util import sandbox as sandbox_env
 from typing_extensions import Unpack
 
@@ -68,6 +68,13 @@ class ClaudeCode(ACPAgent):
         sbox = sandbox_env(self.sandbox)
         default_model = get_model(self.model).canonical_name()
 
+        # Use a unique port per agent invocation so re-running the agent in the
+        # same sandbox doesn't collide with a stale model_proxy on 13131
+        # (mirrors the non-ACP claude_code and the ACP codex/gemini agents).
+        MODEL_PORT = "claude_code_acp_model_port"
+        port = store().get(MODEL_PORT, 3000) + 1
+        store().set(MODEL_PORT, port)
+
         async with sandbox_agent_bridge(
             state,
             model=None,
@@ -75,6 +82,7 @@ class ClaudeCode(ACPAgent):
             filter=self.filter,
             retry_refusals=self.retry_refusals,
             bridged_tools=self.bridged_tools or None,
+            port=port,
         ) as bridge:
             # Install node and claude-agent-acp in the sandbox.
             acp_binary, node_binary = await ensure_claude_code_acp_setup(


### PR DESCRIPTION
## Summary
The ACP `claude_code` agent was the only inspect_swe agent that didn't pass a per-invocation `port=` to `sandbox_agent_bridge`, falling through to the default `13131`. When a caller runs the agent more than once against the same sandbox (e.g. petri-dish creates a fresh `ACPAgent` per trajectory on rollback/restart), the second invocation's `model_proxy` hits `EADDRINUSE` if the previous trajectory's proxy hasn't fully exited — `ExecRemoteProcess.kill()` swallows RPC failures at debug level, so a stale proxy can survive a cancellation-driven teardown.

This adds the same `store()`-backed port counter that the non-ACP `claude_code` and the ACP `codex_cli`/`gemini_cli` already use.

## Test plan
- [x] `ruff` / `mypy` on the changed file
- [x] Reproduced `[Errno 98] address already in use` in a 20-sample petri-dish run with rollbacks; verified the same run with this patch applied no longer collides

🤖 Generated with [Claude Code](https://claude.com/claude-code)