### PR TITLE
Fix deprecated claude-agent-acp package name

### DIFF
--- a/src/inspect_swe/acp/_agents/claude_code/agentbinary.py
+++ b/src/inspect_swe/acp/_agents/claude_code/agentbinary.py
@@ -23,7 +23,7 @@ from inspect_swe._util.sandbox import (
 
 logger = logging.getLogger(__name__)
 
-_ACP_ADAPTER_PACKAGE = "@zed-industries/claude-agent-acp"
+_ACP_ADAPTER_PACKAGE = "@agentclientprotocol/claude-agent-acp"
 
 
 async def ensure_claude_code_acp_setup(


### PR DESCRIPTION
The ACP adapter for `interactive_claude_code` installs from `@zed-industries/claude-agent-acp`, which has been deprecated and renamed. This updates the constant to `@agentclientprotocol/claude-agent-acp`.

Fixes #55 