### PR TITLE
Add auto_mode flag to claude_code() agent

### DIFF
--- a/src/inspect_swe/_claude_code/claude_code.py
+++ b/src/inspect_swe/_claude_code/claude_code.py
@@ -77,6 +77,7 @@ def claude_code(
     debug: bool | None = None,
     sandbox: str | None = None,
     version: Literal["auto", "sandbox", "stable", "latest"] | str = "auto",
+    auto_mode: bool = False,
 ) -> Agent:
     """Claude Code agent.
 
@@ -168,9 +169,15 @@ def claude_code(
                 claude_code_binary_source(), version, user, sandbox_env(sandbox)
             )
 
-            # base options
+            # base options — auto_mode uses --permission-mode auto (monitor active);
+            # otherwise --dangerously-skip-permissions (no permission gating).
+            permission_flag = (
+                ["--permission-mode", "auto"]
+                if auto_mode
+                else ["--dangerously-skip-permissions"]
+            )
             cmd = [
-                "--dangerously-skip-permissions",
+                *permission_flag,
                 "--model",
                 model,
             ]


### PR DESCRIPTION
## Summary

Adds an `auto_mode: bool = False` parameter to `claude_code()`.

When `True`, passes `--permission-mode auto` to the Claude Code CLI instead of `--dangerously-skip-permissions`. This activates the auto-mode monitor (two-stage classifier) which evaluates each Tier-3 tool call before execution and can deny it with a reason.

**Why:** `--dangerously-skip-permissions` bypasses all permission checks including the monitor. `--permission-mode auto` is the intended production mode for autonomous deployments — it keeps the classifier active while still running unattended.

## Changes

- `src/inspect_swe/_claude_code/claude_code.py`: add `auto_mode` param, select permission flag accordingly