### PR TITLE
Fix gemini_cli: pin auth selectedType to bypass GATEWAY inference

### DIFF
--- a/src/inspect_swe/_gemini_cli/gemini_cli.py
+++ b/src/inspect_swe/_gemini_cli/gemini_cli.py
@@ -284,6 +284,11 @@ def build_gemini_settings(mcp_servers: Sequence[MCPServerConfig]) -> str:
     """Build Gemini CLI settings.json content (privacy + MCP server configs)."""
     settings: dict[str, Any] = {
         "privacy": {"usageStatisticsEnabled": False},
+        # gemini-cli v0.13+ getAuthTypeFromEnv() maps GOOGLE_GEMINI_BASE_URL to
+        # AuthType.GATEWAY, which validateAuthMethod() rejects in non-interactive
+        # mode ("Invalid auth method selected"). Pinning selectedType here
+        # short-circuits the env-based inference.
+        "security": {"auth": {"selectedType": "gemini-api-key"}},
     }
     if mcp_servers:
         mcp_servers_config: dict[str, Any] = {}


### PR DESCRIPTION
## Problem

With gemini-cli **v0.13+**, running the `gemini_cli()` agent against a proxy (i.e. with `GOOGLE_GEMINI_BASE_URL` set) fails immediately with:

```
Invalid auth method selected.
```

## Root cause

gemini-cli v0.13 changed [`getAuthTypeFromEnv()`](https://github.com/google-gemini/gemini-cli) so that the presence of `GOOGLE_GEMINI_BASE_URL` now infers `AuthType.GATEWAY`. However, `validateAuthMethod()` does not accept `GATEWAY` in non-interactive mode, so the CLI exits before the agent can do anything.

## Fix

Pin `security.auth.selectedType` to `"gemini-api-key"` in the generated `~/.gemini/settings.json`. An explicit `selectedType` short-circuits the env-based inference, so gemini-cli uses the API-key path (with `GEMINI_API_KEY` + `GOOGLE_GEMINI_BASE_URL`) as before.

## Verification

Reproduced the failure with gemini-cli v0.13 against an API proxy; after adding `security.auth.selectedType = "gemini-api-key"` to settings.json the agent runs to completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)