### PR TITLE
Claude Code: fix system prompt duplicated on resumed turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Claude Code: Fix system prompt being re-sent on resumed turns. The sandbox bridge captures Claude Code's own system prompt back into `state.messages` as a `ChatMessageSystem`; this was re-forwarded via `--append-system-prompt` on every continuation turn (and every retried attempt), concatenating the entire system prompt onto itself (2x on turn 2, 3x on turn 3, ...). The system prompt (caller `ChatMessageSystem`s and the `system_prompt` argument) is now sent only when creating the session — never on resume, where the session already contains it.
+
 ## 0.2.60 (02 June 2026)
 
 - Update Inspect AI dependency to 0.3.234

--- a/src/inspect_swe/_claude_code/claude_code.py
+++ b/src/inspect_swe/_claude_code/claude_code.py
@@ -199,15 +199,6 @@ def claude_code(
                 if debug:
                     cmd.append("--debug")
 
-            # system prompt
-            system_messages = [
-                m.text for m in state.messages if isinstance(m, ChatMessageSystem)
-            ]
-            if system_prompt is not None:
-                system_messages.append(system_prompt)
-            if system_messages:
-                cmd.extend(["--append-system-prompt", "\n\n".join(system_messages)])
-
             # mcp servers (combine static configs with bridged tools)
             cmd_allowed_tools: list[str] = []
             all_mcp_servers = list(mcp_servers or []) + bridge.mcp_server_configs
@@ -278,21 +269,48 @@ def claude_code(
                 uncaught_error_count = 0
                 try:
                     while True:
-                        # resume previous conversation
-                        if (
+                        is_resume = (
                             has_assistant_response
                             or attempt_count > 0
                             or uncaught_error_count > 0
-                        ):
+                        )
+
+                        # System prompt is sent only when creating the session.
+                        # On resume the session already contains system messages, so send
+                        # nothing: the bridge round-trips Claude Code's own
+                        # system prompt back into state.messages as a
+                        # ChatMessageSystem, and re-passing it via
+                        # --append-system-prompt would duplicate the entire
+                        # system prompt on every resumed turn (the flag is
+                        # applied per-invocation, not persisted anyway).
+                        system_args: list[str] = []
+                        if not is_resume:
+                            system_texts = [
+                                m.text
+                                for m in state.messages
+                                if isinstance(m, ChatMessageSystem)
+                            ]
+                            if system_prompt is not None:
+                                system_texts.append(system_prompt)
+                            if system_texts:
+                                system_args = [
+                                    "--append-system-prompt",
+                                    "\n\n".join(system_texts),
+                                ]
+
+                        # resume previous conversation
+                        if is_resume:
                             agent_cmd = (
                                 [claude_binary, "--resume", session_id]
                                 + cmd
+                                + system_args
                                 + ["--", agent_prompt]
                             )
                         else:
                             agent_cmd = (
                                 [claude_binary, "--session-id", session_id]
                                 + cmd
+                                + system_args
                                 + ["--", agent_prompt]
                             )
 

--- a/tests/test_multi_call.py
+++ b/tests/test_multi_call.py
@@ -1,6 +1,7 @@
-from typing import Literal
+from typing import Any, Literal
 
 import pytest
+from inspect_ai.log import EvalSample, resolve_sample_attachments
 from inspect_ai.model import ChatMessageAssistant, ChatMessageUser
 
 from tests.conftest import (
@@ -18,6 +19,67 @@ from tests.conftest import (
 @pytest.mark.parametrize("sandbox", get_available_sandboxes())
 def test_claude_code_multi_call(sandbox: str) -> None:
     check_multi_call("claude_code", "anthropic/claude-sonnet-4-0", sandbox)
+
+
+@skip_if_no_anthropic
+@skip_if_no_docker
+@pytest.mark.parametrize("sandbox", get_available_sandboxes())
+def test_claude_code_system_prompt_not_duplicated(sandbox: str) -> None:
+    """Regression test: the system prompt must be sent exactly once per turn.
+
+    The bridge captures Claude Code's own system prompt back into
+    ``state.messages`` as a ``ChatMessageSystem``. A previous bug re-passed that
+    captured prompt via ``--append-system-prompt`` on every resumed turn, so the
+    entire system prompt was concatenated onto itself (2x on turn 2, 3x on turn
+    3, ...). We verify against the *raw* Anthropic request payload
+    (``ModelEvent.call.request``).
+    """
+    log = run_example(
+        "multi_call", "claude_code", "anthropic/claude-sonnet-4-0", sandbox=sandbox
+    )[0]
+    assert log.samples
+    sample = log.samples[0]
+
+    counts = _env_block_counts(sample)
+    assert counts, "expected at least one model call carrying the system prompt"
+    # No single request may contain the Claude Code system prompt more than once.
+    assert max(counts) == 1, (
+        f"system prompt duplicated in a resumed-turn request: per-call "
+        f"'# Environment' counts were {counts}"
+    )
+
+
+# Marker that appears exactly once in the Claude Code system prompt.
+_ENV_MARKER = "# Environment"
+
+
+def _flatten_system(value: Any) -> str:
+    """Flatten an Anthropic ``system`` field (str, or list of text blocks) to text."""
+    if isinstance(value, list):
+        return " ".join(_flatten_system(block) for block in value)
+    if isinstance(value, dict):
+        return str(value.get("text", ""))
+    return str(value)
+
+
+def _env_block_counts(sample: EvalSample) -> list[int]:
+    """Per-model-call occurrences of the system-prompt env block in the raw request."""
+    sample = resolve_sample_attachments(sample, "full")
+
+    counts: list[int] = []
+    for event in sample.events:
+        if getattr(event, "event", None) != "model":
+            continue
+        call = getattr(event, "call", None)
+        if call is None:
+            continue
+        system = call.request.get("system")
+        if system is None:
+            continue
+        n = _flatten_system(system).count(_ENV_MARKER)
+        if n:
+            counts.append(n)
+    return counts
 
 
 @skip_if_no_openai


### PR DESCRIPTION
## Summary

When a `claude_code()` agent is run over multiple turns in one sample (calling `inspect_ai.agent.run()` more than once on the same agent, so later turns resume the session), the **entire Claude Code system prompt was sent to the model N times on the Nth turn** — 2× on turn 2, 3× on turn 3, and so on. The first turn was correct.

## Root cause

The sandbox bridge captures Claude Code's *own* emitted system prompt back into `state.messages` as a `ChatMessageSystem` at index 0 (via `_track_state`, which sets `state.messages = input + [output]`). On a resumed turn, `claude_code` collected every `ChatMessageSystem` from `state.messages` and re-passed it via `--append-system-prompt` — while `--resume <session_id>` had *already* restored that same system prompt into the session. The request Claude built therefore carried the system prompt twice (and compounding each further turn). The same flaw affected retried attempts within a single turn.

## Fix

Send the system prompt (caller `ChatMessageSystem`s + the `system_prompt` argument) **only when creating the session** — never on resume, where the session already contains it.

## Scope

Scoped to **Claude Code only**. The other CLI agents (`codex_cli`, `gemini_cli`, `opencode`, `mini_swe_agent`) and the ACP agents share the same bridge round-trip and migtht exhibit the same bug, but I'm not sure how they handle system messages passed by the user.

I'm also unsure about the goal of the deleted code here. Non-system messages in `state.messages` are silently ignored AFAICT, concatenating only the system messages to `--append-system-prompt` seems somewhat counterintuitive.
