### PR TITLE
Codex CLI: use releases/latest endpoint to avoid 504s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Remove ACP patch for connection initialization order issue (resolved in ACP 0.10.1).
+- Codex CLI: Resolve "stable"/"latest" via the GitHub `releases/latest` endpoint — the full releases listing for openai/codex frequently 504s.
 
 ## 0.2.62 (05 June 2026)
 

--- a/src/inspect_swe/_codex_cli/agentbinary.py
+++ b/src/inspect_swe/_codex_cli/agentbinary.py
@@ -93,22 +93,11 @@ def _platform_to_codex_arch(platform: SandboxPlatform) -> str:
 
 async def _fetch_latest_stable_version() -> str:
     """Fetch the latest stable version from GitHub releases."""
-    releases_url = "https://api.github.com/repos/openai/codex/releases"
-    releases_json = await download_text_file(releases_url)
-    releases = json.loads(releases_json)
-
-    # Filter out pre-releases and alpha versions
-    stable_releases = [
-        r
-        for r in releases
-        if not r.get("prerelease", False) and "-alpha" not in r.get("tag_name", "")
-    ]
-
-    if not stable_releases:
-        raise RuntimeError("No stable releases found for codex")
-
-    # Get the most recent stable release
-    latest = stable_releases[0]
+    # Use the single-release `latest` endpoint (excludes prereleases/drafts by
+    # definition). The full releases listing is so large for openai/codex that
+    # GitHub's API frequently 504s generating it.
+    latest_url = "https://api.github.com/repos/openai/codex/releases/latest"
+    latest = json.loads(await download_text_file(latest_url))
     tag_name = latest["tag_name"]
 
     # Extract version from tag (e.g., "rust-v0.29.0" -> "0.29.0")


### PR DESCRIPTION
## Summary
- Resolve `"stable"`/`"latest"` codex versions via GitHub's single-release `releases/latest` endpoint instead of the full releases listing. The listing for openai/codex is large enough that the API frequently 504s generating it.
- `releases/latest` excludes prereleases/drafts by definition, so the manual prerelease/`-alpha` filtering is no longer needed (codex alpha releases are marked prerelease). Verified the endpoint currently returns `rust-v0.139.0` with `prerelease: false`.