### PR TITLE
Checkpointer support for Codex CLI & Claude Code; run agents in home dir when sandbox default workdir is /

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,8 @@
   "[python]": {
     "editor.defaultFormatter": "charliermarsh.ruff"
   },
+  "mypy-type-checker.importStrategy": "fromEnvironment",
+  "mypy-type-checker.args": ["--config-file=pyproject.toml"],
   "search.exclude": {
     "logs/**": true
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- All agents: When no `cwd` is specified and the sandbox's default working directory is `/` (i.e. the image has no `WORKDIR`), run the agent in the user's home directory instead of the container root.
+
 ## 0.2.63 (10 June 2026)
 
 - Remove ACP patch for connection initialization order issue (resolved in ACP 0.10.1).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Codex CLI and Claude Code: Support checkpointing and resuming runs via `checkpointer()`, restoring session/attempt state across resumes.
 - All agents: When no `cwd` is specified and the sandbox's default working directory is `/` (i.e. the image has no `WORKDIR`), run the agent in the user's home directory instead of the container root.
 
 ## 0.2.63 (10 June 2026)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ requires-python = ">=3.10"
 license = { text = "MIT License" }
 dependencies = [
     "httpx",
-    "inspect_ai>=0.3.235",
+    "inspect_ai@git+https://github.com/UKGovernmentBEIS/inspect_ai@main",
     "nest_asyncio",
     "platformdirs",
     "pydantic>=2.13.0",

--- a/src/inspect_swe/_claude_code/_events/live_consumer.py
+++ b/src/inspect_swe/_claude_code/_events/live_consumer.py
@@ -64,6 +64,7 @@ from inspect_ai.model._chat_message import (
     ChatMessageUser,
 )
 from inspect_ai.model._model import ModelEventSink
+from inspect_ai.util._span import current_span_id
 
 from .toolview import tool_view
 
@@ -92,9 +93,7 @@ class LiveConsumer(ModelEventSink):
     by Claude Code.
     """
 
-    def __init__(self, outer_span_id: str | None) -> None:
-        self.outer_span_id = outer_span_id
-
+    def __init__(self) -> None:
         # tool_use_id → _OpenAgent for currently-open agent spans (Task/Agent
         # tool_use blocks we've SpanBegin'd, not yet SpanEnd'd).
         self._open_agents: dict[str, _OpenAgent] = {}
@@ -110,6 +109,16 @@ class LiveConsumer(ModelEventSink):
         # knows whether to emit _event_updated (yes if we emitted) vs swallow
         # (no if we didn't — shouldn't happen with current logic but defensive).
         self._emitted_events: set[int] = set()
+
+    @property
+    def outer_span_id(self) -> str | None:
+        """Span for main-agent attribution, resolved at emission time.
+
+        Must not be captured once at construction: with checkpointing
+        active, the enclosing checkpoint span rotates at each fire and a
+        frozen id would pin every event to the first checkpoint.
+        """
+        return current_span_id()
 
     def reset(self) -> None:
         """Close any open spans and clear per-attempt state.

--- a/src/inspect_swe/_claude_code/claude_code.py
+++ b/src/inspect_swe/_claude_code/claude_code.py
@@ -43,6 +43,7 @@ from inspect_swe._util.path import join_path
 from .._util._async import is_callable_coroutine
 from .._util.agentbinary import ensure_agent_binary_installed
 from .._util.messages import build_user_prompt
+from .._util.sandbox import resolve_agent_cwd
 from .._util.trace import trace
 from .agentbinary import claude_code_binary_source
 from .model import resolve_claude_code_models
@@ -237,12 +238,12 @@ def claude_code(
             # resolve sandbox
             sbox = sandbox_env(sandbox)
 
+            # resolve working directory (home dir if sandbox default is '/')
+            agent_cwd = await resolve_agent_cwd(sbox, user, cwd)
+
             # install skills
             if resolved_skills is not None:
-                CLAUDE_SKILLS = ".claude/skills"
-                skills_dir = (
-                    join_path(cwd, CLAUDE_SKILLS) if cwd is not None else CLAUDE_SKILLS
-                )
+                skills_dir = join_path(agent_cwd, ".claude/skills")
                 await install_skills(resolved_skills, sbox, user, skills_dir)
 
             # define agent env
@@ -266,7 +267,7 @@ def claude_code(
             # output).  Providing an apiKeyHelper in settings.json
             # supplies a key through a path that does work.
             api_key = agent_env.get("ANTHROPIC_AUTH_TOKEN", "dummy-key-for-bridge")
-            await _seed_claude_config(sbox, api_key, user, cwd)
+            await _seed_claude_config(sbox, api_key, user, agent_cwd)
 
             # centaur mode uses human_cli with custom instructions and bash rc
             if centaur:
@@ -343,7 +344,7 @@ def claude_code(
                             cmd=["bash", "-c", 'exec 0</dev/null; "$@"', "bash"]
                             + agent_cmd,
                             options=ExecRemoteStreamingOptions(
-                                cwd=cwd,
+                                cwd=agent_cwd,
                                 env=agent_env,
                                 user=user,
                                 concurrency=False,
@@ -449,7 +450,7 @@ async def _seed_claude_config(
     sbox: Any,
     api_key: str,
     user: str | None,
-    cwd: str | None,
+    cwd: str,
 ) -> None:
     """Write ~/.claude/settings.json with an apiKeyHelper.
 

--- a/src/inspect_swe/_claude_code/claude_code.py
+++ b/src/inspect_swe/_claude_code/claude_code.py
@@ -19,6 +19,7 @@ from inspect_ai.tool import MCPServerConfig, Skill, install_skills, read_skills
 from inspect_ai.util import (
     ExecRemoteStreamingOptions,
     StoreModel,
+    checkpointer,
     store,
     store_as,
 )
@@ -180,17 +181,31 @@ def claude_code(
             model_aliases=model_aliases,
         )
 
-        async with sandbox_agent_bridge(
-            state,
-            model=models.bridge_model,
-            model_aliases=models.aliases,
-            filter=filter,
-            sandbox=sandbox,
-            retry_refusals=retry_refusals,
-            port=port,
-            bridged_tools=bridged_tools,
-            model_event_sink=consumer,
-        ) as bridge:
+        async with (
+            checkpointer() as cp,
+            sandbox_agent_bridge(
+                state,
+                model=models.bridge_model,
+                model_aliases=models.aliases,
+                filter=filter,
+                sandbox=sandbox,
+                retry_refusals=retry_refusals,
+                port=port,
+                bridged_tools=bridged_tools,
+                model_event_sink=consumer,
+                checkpointer=cp,
+            ) as bridge,
+        ):
+            if cp.attempt == "resume_for_scoring":
+                return bridge.state
+
+            # restore session_id from checkpoint so --resume targets the
+            # session that exists in the restored sandbox
+            nonlocal session_id
+            session_id = cp.track(
+                "claude_code_session_id", lambda: session_id, session_id
+            )
+
             # ensure claude is installed and get binary location
             claude_binary = await ensure_agent_binary_installed(
                 claude_code_binary_source(), version, user, sandbox_env(sandbox)
@@ -281,7 +296,9 @@ def claude_code(
                 # execute the agent (track debug output)
                 debug_output: list[str] = []
                 agent_prompt = prompt
-                attempt_count = 0
+                attempt_count = cp.track(
+                    "claude_code_attempt_count", lambda: attempt_count, 0
+                )
                 uncaught_error_count = 0
                 try:
                     while True:
@@ -289,6 +306,7 @@ def claude_code(
                             has_assistant_response
                             or attempt_count > 0
                             or uncaught_error_count > 0
+                            or cp.attempt == "resume"
                         )
 
                         # System prompt is sent only when creating the session.

--- a/src/inspect_swe/_claude_code/claude_code.py
+++ b/src/inspect_swe/_claude_code/claude_code.py
@@ -26,7 +26,6 @@ from inspect_ai.util import (
 from inspect_ai.util import (
     sandbox as sandbox_env,
 )
-from inspect_ai.util._span import current_span_id
 from pydantic import Field
 from pydantic_core import to_json
 
@@ -163,10 +162,11 @@ def claude_code(
         # bridge's ModelEventSink — the bridge hands us every ModelEvent
         # instead of emitting it to the transcript, and we attribute each
         # to the correct agent span using parent_tool_use_id from the JSONL
-        # stream. Captures the outer span_id (this @agent's span) so
-        # sub-agent spans we discover from JSONL can be parented correctly.
-        # See live_consumer.py for full mechanism.
-        consumer = LiveConsumer(outer_span_id=current_span_id())
+        # stream. The outer span (used for main-agent attribution and
+        # sub-agent span parenting) is resolved at emission time so it
+        # tracks the rotating checkpoint span. See live_consumer.py for
+        # full mechanism.
+        consumer = LiveConsumer()
 
         # Resolve the (cosmetic) model identities Claude Code presents to itself
         # and the bridge aliases that route them to the real served model. The

--- a/src/inspect_swe/_codex_cli/_events/consumer.py
+++ b/src/inspect_swe/_codex_cli/_events/consumer.py
@@ -45,6 +45,7 @@ from inspect_ai.model._chat_message import (
     ChatMessageUser,
 )
 from inspect_ai.model._model import ModelEventSink
+from inspect_ai.util._span import current_span_id
 
 from .detection import (
     completed_thread_ids,
@@ -74,9 +75,7 @@ class _OpenAgent:
 
 
 class CodexConsumer(ModelEventSink):
-    def __init__(self, outer_span_id: str | None) -> None:
-        self.outer_span_id = outer_span_id
-
+    def __init__(self) -> None:
         # spawn tool_call_id → open sub-agent span. Insertion order = open order
         # (used to close innermost-first in reset()).
         self._agents: dict[str, _OpenAgent] = {}
@@ -89,6 +88,16 @@ class CodexConsumer(ModelEventSink):
 
         # ModelEvents we've _event()'d, so on_complete knows to _event_updated.
         self._emitted_events: set[int] = set()
+
+    @property
+    def outer_span_id(self) -> str | None:
+        """Span for main-agent attribution, resolved at emission time.
+
+        Must not be captured once at construction: with checkpointing
+        active, the enclosing checkpoint span rotates at each fire and a
+        frozen id would pin every event to the first checkpoint.
+        """
+        return current_span_id()
 
     def reset(self) -> None:
         """Close any open spans and clear per-attempt state.

--- a/src/inspect_swe/_codex_cli/codex_cli.py
+++ b/src/inspect_swe/_codex_cli/codex_cli.py
@@ -32,7 +32,7 @@ from inspect_swe._util._async import is_callable_coroutine
 from inspect_swe._util.centaur import CentaurOptions, run_centaur
 from inspect_swe._util.messages import build_user_prompt
 from inspect_swe._util.path import join_path
-from inspect_swe._util.sandbox import sandbox_exec
+from inspect_swe._util.sandbox import resolve_agent_cwd, sandbox_exec
 from inspect_swe._util.toml import to_toml
 from inspect_swe._util.trace import trace
 
@@ -201,19 +201,21 @@ def codex_cli(
             # resolve sandbox
             sbox = sandbox_env(sandbox)
 
+            # resolve working directory (home dir if sandbox default is '/')
+            agent_cwd = await resolve_agent_cwd(sbox, user, cwd)
+
             # align Codex's `--model` slug to the real bridged model
             codex_model = await resolve_codex_model(
                 model, model_config, sbox, codex_binary, user
             )
 
-            # determine CODEX_HOME (default to whatever sandbox working dir is)
+            # determine CODEX_HOME (default to agent working dir)
             if home_dir is None:
-                working_dir = await sandbox_exec(sbox, "pwd", user=user, cwd=cwd)
-                codex_home = join_path(working_dir, ".codex")
+                codex_home = join_path(agent_cwd, ".codex")
             else:
                 # Resolve ~ and $VARS inside the sandbox
                 codex_home = await sandbox_exec(
-                    sbox, f'eval echo "{home_dir}"', user=user, cwd=cwd
+                    sbox, f'eval echo "{home_dir}"', user=user, cwd=agent_cwd
                 )
             await sandbox_exec(sbox, cmd=f"mkdir -p {codex_home}", user=user)
 
@@ -222,10 +224,8 @@ def codex_cli(
                 AGENTS_MD = "AGENTS.md"
                 if home_dir is not None:
                     return join_path(codex_home, AGENTS_MD)
-                elif cwd is not None:
-                    return join_path(cwd, AGENTS_MD)
                 else:
-                    return AGENTS_MD
+                    return join_path(agent_cwd, AGENTS_MD)
 
             # location for config_toml (either codex_home or cwd/.codex )
             async def codex_config_toml() -> str:
@@ -233,7 +233,7 @@ def codex_cli(
                 if home_dir is not None:
                     return join_path(codex_home, CONFIG_TOML)
                 else:
-                    dir = ".codex" if cwd is None else join_path(cwd, ".codex")
+                    dir = join_path(agent_cwd, ".codex")
                     await sandbox_exec(sbox, cmd=f"mkdir -p {dir}", user=user)
                     return join_path(dir, CONFIG_TOML)
 
@@ -351,7 +351,7 @@ def codex_cli(
                         cmd=["bash", "-c", 'exec 0</dev/null; "$@"', "bash"]
                         + agent_cmd,
                         options=ExecRemoteAwaitableOptions(
-                            cwd=cwd, env=agent_env, user=user, concurrency=False
+                            cwd=agent_cwd, env=agent_env, user=user, concurrency=False
                         ),
                         stream=False,
                     )

--- a/src/inspect_swe/_codex_cli/codex_cli.py
+++ b/src/inspect_swe/_codex_cli/codex_cli.py
@@ -22,7 +22,7 @@ from inspect_ai.model import (
 )
 from inspect_ai.scorer import score
 from inspect_ai.tool import MCPServerConfig, Skill, install_skills, read_skills
-from inspect_ai.util import SandboxEnvironment, store
+from inspect_ai.util import SandboxEnvironment, checkpointer, store
 from inspect_ai.util import sandbox as sandbox_env
 from inspect_ai.util._sandbox import ExecRemoteAwaitableOptions
 from inspect_ai.util._span import current_span_id
@@ -168,17 +168,24 @@ def codex_cli(
         # bridge-only (no Codex --json parsing); see consumer.py.
         consumer = CodexConsumer(outer_span_id=current_span_id())
 
-        async with sandbox_agent_bridge(
-            state,
-            model=bridge_model,
-            model_aliases=model_aliases,
-            filter=filter,
-            sandbox=sandbox,
-            retry_refusals=retry_refusals,
-            port=port,
-            bridged_tools=bridged_tools,
-            model_event_sink=consumer,
-        ) as bridge:
+        async with (
+            checkpointer() as cp,
+            sandbox_agent_bridge(
+                state,
+                model=bridge_model,
+                model_aliases=model_aliases,
+                filter=filter,
+                sandbox=sandbox,
+                retry_refusals=retry_refusals,
+                port=port,
+                bridged_tools=bridged_tools,
+                model_event_sink=consumer,
+                checkpointer=cp,
+            ) as bridge,
+        ):
+            if cp.attempt == "resume_for_scoring":
+                return bridge.state
+
             # ensure codex is installed and get binary location
             codex_binary = await ensure_agent_binary_installed(
                 codex_cli_binary_source(), version, user, sandbox_env(sandbox)
@@ -323,14 +330,20 @@ def codex_cli(
                 # execute the agent (track debug output)
                 debug_output: list[str] = []
                 agent_prompt = prompt
-                attempt_count = 0
+                attempt_count = cp.track(
+                    "codex_attempt_count", lambda: attempt_count, 0
+                )
                 while True:
                     # append prompt
                     agent_cmd = cmd.copy()
                     agent_cmd.append(agent_prompt)
 
                     # resume previous conversation
-                    if has_assistant_response or attempt_count > 0:
+                    if (
+                        has_assistant_response
+                        or attempt_count > 0
+                        or cp.attempt == "resume"
+                    ):
                         agent_cmd.extend(["resume", "--last"])
 
                     # run agent

--- a/src/inspect_swe/_codex_cli/codex_cli.py
+++ b/src/inspect_swe/_codex_cli/codex_cli.py
@@ -25,7 +25,6 @@ from inspect_ai.tool import MCPServerConfig, Skill, install_skills, read_skills
 from inspect_ai.util import SandboxEnvironment, checkpointer, store
 from inspect_ai.util import sandbox as sandbox_env
 from inspect_ai.util._sandbox import ExecRemoteAwaitableOptions
-from inspect_ai.util._span import current_span_id
 from typing_extensions import Unpack
 
 from inspect_swe._util._async import is_callable_coroutine
@@ -163,10 +162,11 @@ def codex_cli(
 
         # Bridge ModelEventSink: the bridge hands us every ModelEvent instead of
         # emitting it to the transcript, and we attribute each to the correct
-        # (sub-)agent span. Captures this @agent's span as the outer span so
-        # sub-agent spans we discover are parented correctly. Reconstructs spans
-        # bridge-only (no Codex --json parsing); see consumer.py.
-        consumer = CodexConsumer(outer_span_id=current_span_id())
+        # (sub-)agent span. The outer span (main-agent attribution + sub-agent
+        # span parenting) is resolved at emission time so it tracks the
+        # rotating checkpoint span. Reconstructs spans bridge-only (no Codex
+        # --json parsing); see consumer.py.
+        consumer = CodexConsumer()
 
         async with (
             checkpointer() as cp,

--- a/src/inspect_swe/_gemini_cli/gemini_cli.py
+++ b/src/inspect_swe/_gemini_cli/gemini_cli.py
@@ -25,6 +25,7 @@ from inspect_swe._util._async import is_callable_coroutine
 from inspect_swe._util.centaur import CentaurOptions, run_centaur
 from inspect_swe._util.messages import build_user_prompt
 from inspect_swe._util.path import join_path
+from inspect_swe._util.sandbox import resolve_agent_cwd
 from inspect_swe._util.trace import trace
 
 from .agentbinary import ensure_gemini_cli_setup
@@ -124,12 +125,12 @@ def gemini_cli(
             # resolve sandbox
             sbox = sandbox_env(sandbox)
 
+            # resolve working directory (home dir if sandbox default is '/')
+            agent_cwd = await resolve_agent_cwd(sbox, user, cwd)
+
             # install skills
             if resolved_skills is not None:
-                GEMINI_SKILLS = ".gemini/skills"
-                skills_dir = (
-                    join_path(cwd, GEMINI_SKILLS) if cwd is not None else GEMINI_SKILLS
-                )
+                skills_dir = join_path(agent_cwd, ".gemini/skills")
                 await install_skills(resolved_skills, sbox, user, skills_dir)
 
             # install node and gemini-cli in sandbox
@@ -229,7 +230,7 @@ def gemini_cli(
                         cmd=["bash", "-c", 'exec 0</dev/null; "$@"', "bash"]
                         + agent_cmd,
                         options=ExecRemoteAwaitableOptions(
-                            cwd=cwd,
+                            cwd=agent_cwd,
                             env=agent_env,
                             user=user,
                             concurrency=False,

--- a/src/inspect_swe/_mini_swe_agent/mini_swe_agent.py
+++ b/src/inspect_swe/_mini_swe_agent/mini_swe_agent.py
@@ -28,6 +28,7 @@ from .._util._async import is_callable_coroutine
 from .._util.agentwheel import AgentWheelSource, ensure_agent_wheel_installed
 from .._util.centaur import CentaurOptions, run_centaur
 from .._util.messages import build_user_prompt
+from .._util.sandbox import resolve_agent_cwd
 from .._util.trace import trace
 from .setup import (
     RESUMABLE_AGENT_PATH,
@@ -143,6 +144,9 @@ def mini_swe_agent(
             # resolve sandbox
             sbox = sandbox_env(sandbox)
 
+            # resolve working directory (home dir if sandbox default is '/')
+            agent_cwd = await resolve_agent_cwd(sbox, user, cwd)
+
             # ensure mini-swe-agent is installed
             mini_binary = await ensure_agent_wheel_installed(
                 source=MINI_SWE_AGENT_SOURCE,
@@ -222,7 +226,7 @@ def mini_swe_agent(
                         cmd=["bash", "-c", 'exec 0</dev/null; "$@"', "bash"]
                         + agent_cmd,
                         options=ExecRemoteAwaitableOptions(
-                            cwd=cwd,
+                            cwd=agent_cwd,
                             env=run_env,
                             user=user,
                             concurrency=False,
@@ -238,7 +242,7 @@ def mini_swe_agent(
                     # raise for error
                     if not result.success:
                         raise RuntimeError(
-                            f"Error executing mini-swe-agent (cwd={cwd or 'default'}):\n"
+                            f"Error executing mini-swe-agent (cwd={agent_cwd}):\n"
                             f"stdout: {result.stdout}\n"
                             f"stderr: {result.stderr}"
                         )

--- a/src/inspect_swe/_opencode/opencode.py
+++ b/src/inspect_swe/_opencode/opencode.py
@@ -24,6 +24,7 @@ from inspect_ai.util._sandbox import ExecRemoteAwaitableOptions
 from inspect_swe._util._async import is_callable_coroutine
 from inspect_swe._util.centaur import CentaurOptions, run_centaur
 from inspect_swe._util.messages import build_user_prompt
+from inspect_swe._util.sandbox import resolve_agent_cwd
 from inspect_swe._util.trace import trace
 
 from .agentbinary import ensure_opencode_setup
@@ -131,6 +132,9 @@ def opencode(
         ) as bridge:
             # resolve sandbox
             sbox = sandbox_env(sandbox)
+
+            # resolve working directory (home dir if sandbox default is '/')
+            agent_cwd = await resolve_agent_cwd(sbox, user, cwd)
 
             # install opencode and its runtime dependencies in sandbox
             opencode_binary, dependency_bin_dirs = await ensure_opencode_setup(
@@ -252,7 +256,7 @@ def opencode(
                         cmd=["bash", "-c", 'exec 0</dev/null; "$@"', "bash"]
                         + agent_cmd,
                         options=ExecRemoteAwaitableOptions(
-                            cwd=cwd,
+                            cwd=agent_cwd,
                             env=agent_env,
                             user=user,
                             concurrency=False,

--- a/src/inspect_swe/_util/sandbox.py
+++ b/src/inspect_swe/_util/sandbox.py
@@ -1,6 +1,10 @@
+from logging import getLogger
+from pathlib import PurePosixPath
 from typing import Literal, TypeAlias, cast
 
 from inspect_ai.util import SandboxEnvironment
+
+logger = getLogger(__name__)
 
 SandboxPlatform: TypeAlias = Literal[
     "linux-x64", "linux-arm64", "linux-x64-musl", "linux-arm64-musl"
@@ -49,6 +53,45 @@ async def detect_sandbox_platform(sandbox: SandboxEnvironment) -> SandboxPlatfor
 
 def bash_command(cmd: str) -> list[str]:
     return ["bash", "-c", cmd]
+
+
+async def resolve_agent_cwd(
+    sandbox: SandboxEnvironment, user: str | None, cwd: str | None
+) -> str:
+    """Resolve the working directory to run an agent within.
+
+    An explicit `cwd` is always honored: absolute paths are returned as-is,
+    relative paths are canonicalized to absolute inside the sandbox (the
+    result feeds env vars like CODEX_HOME that resolve against the agent
+    process's cwd, where a relative path would point elsewhere). Otherwise
+    the sandbox's default working directory is used — except when it is `/`,
+    which almost always means the image has no WORKDIR (docker's default)
+    rather than a deliberate choice, in which case the user's home directory
+    is used (agents writing to the container root is never what the task
+    intended, and typically fails outright for non-root users).
+
+    This fallback would arguably be better placed in inspect_ai's sandbox
+    working-directory resolution, but changing it there would affect every
+    `sandbox.exec()` caller in every eval (bash tool, setup scripts,
+    scorers, ...) rather than just sandbox agents, so the policy is
+    applied here at the agent layer instead.
+    """
+    if cwd is not None:
+        if PurePosixPath(cwd).is_absolute():
+            return cwd
+        return await sandbox_exec(sandbox, "pwd", user=user, cwd=cwd)
+    working_dir = await sandbox_exec(sandbox, "pwd", user=user)
+    if working_dir != "/":
+        return working_dir
+    home_dir = await sandbox_exec(
+        sandbox, 'cd ~ 2>/dev/null && pwd || echo "/"', user=user
+    )
+    if home_dir != "/":
+        logger.info(
+            f"Sandbox default working directory is '/' (image likely has no "
+            f"WORKDIR); running agent in home directory '{home_dir}' instead."
+        )
+    return home_dir
 
 
 async def sandbox_exec(

--- a/tests/test_resolve_agent_cwd.py
+++ b/tests/test_resolve_agent_cwd.py
@@ -1,0 +1,62 @@
+from typing import Any
+
+import anyio
+from inspect_ai.util import ExecResult
+from inspect_swe._util.sandbox import resolve_agent_cwd
+
+PWD_CMD = "pwd"
+HOME_CMD = 'cd ~ 2>/dev/null && pwd || echo "/"'
+
+
+class StubSandbox:
+    """Sandbox stub answering bash -c scripts from a canned mapping."""
+
+    def __init__(self, responses: dict[str, str]) -> None:
+        self.responses = responses
+        self.commands: list[tuple[str, str | None]] = []
+
+    async def exec(
+        self, cmd: list[str], cwd: str | None = None, **kwargs: Any
+    ) -> ExecResult[str]:
+        script = cmd[-1]
+        self.commands.append((script, cwd))
+        return ExecResult(
+            success=True, returncode=0, stdout=self.responses[script] + "\n", stderr=""
+        )
+
+
+def resolve(
+    responses: dict[str, str], cwd: str | None
+) -> tuple[str, list[tuple[str, str | None]]]:
+    sandbox = StubSandbox(responses)
+    result = anyio.run(resolve_agent_cwd, sandbox, None, cwd)  # type: ignore[arg-type]
+    return result, sandbox.commands
+
+
+def test_explicit_absolute_cwd_returned_verbatim() -> None:
+    result, commands = resolve({}, "/workspace")
+    assert result == "/workspace"
+    assert commands == []
+
+
+def test_explicit_relative_cwd_canonicalized_in_sandbox() -> None:
+    result, commands = resolve({PWD_CMD: "/app/workspace"}, "workspace")
+    assert result == "/app/workspace"
+    assert commands == [(PWD_CMD, "workspace")]
+
+
+def test_default_working_dir_used_when_not_root() -> None:
+    result, commands = resolve({PWD_CMD: "/app"}, None)
+    assert result == "/app"
+    assert commands == [(PWD_CMD, None)]
+
+
+def test_root_working_dir_falls_back_to_home() -> None:
+    result, commands = resolve({PWD_CMD: "/", HOME_CMD: "/root"}, None)
+    assert result == "/root"
+    assert commands == [(PWD_CMD, None), (HOME_CMD, None)]
+
+
+def test_root_home_stays_at_root() -> None:
+    result, _ = resolve({PWD_CMD: "/", HOME_CMD: "/"}, None)
+    assert result == "/"


### PR DESCRIPTION
## Changes

### Checkpointer support for Codex CLI & Claude Code

Both agents now wrap execution in `checkpointer()` so runs can be checkpointed and resumed (incl. `resume_for_scoring`):

- **Codex CLI** — wrap execution in `checkpointer()`, return bridged state on `resume_for_scoring`, track attempt count across resumes, and pass `resume --last` when resuming from a checkpoint.
- **Claude Code** — wrap execution in `checkpointer()`, return `bridge.state` on `resume_for_scoring`, and track state across resumes: `claude_code_session_id` is restored so `--resume` targets the session that exists in the restored sandbox, and `claude_code_attempt_count` is tracked so attempt numbering survives a resume. Force `--resume` when `cp.attempt == "resume"`.

**Span attribution fix (both consumers).** `LiveConsumer`/`CodexConsumer` previously froze `outer_span_id` at construction — before `checkpointer()` was entered — which pinned main-agent model events and sub-agent span parents to the pre-checkpoint agent span. They now resolve the span lazily via `current_span_id()` at emission time, so attribution tracks the rotating checkpoint span (inspect_ai `SpanRotationScope`).

### All agents: home-dir fallback for WORKDIR-less sandboxes

When no `cwd` is specified and the sandbox's default working directory is `/` (image has no `WORKDIR`), run the agent in the exec user's home directory instead of the container root. New `resolve_agent_cwd()` in `_util/sandbox.py`, used by claude_code, codex_cli, gemini_cli, opencode, and mini_swe_agent. Unit tests in `tests/test_resolve_agent_cwd.py`.

#### Behavior change for existing users

Behavior is unchanged when `cwd` is passed explicitly (absolute or relative), or when the image defines a `WORKDIR` / compose `working_dir`, or when the exec user's home resolves to `/`.

**The changed case: `cwd=None` AND default workdir is `/` AND the exec user's home ≠ `/`** (i.e., image has no `WORKDIR` and no compose `working_dir` — Docker's default). Home is resolved as the `user` param's home (`cd ~` runs as that user), so e.g. `/root` for root, `/home/agent` for a non-root user.

| Agent | Old | New |
|---|---|---|
| all 5 | agent process runs in `/` | runs in `~` |
| claude_code | skills → `/.claude/skills` | `~/.claude/skills` |
| codex_cli (`home_dir=None`) | `CODEX_HOME=/.codex`, `AGENTS.md` → `/AGENTS.md`, config → `/.codex/config.toml` | all under `~` |
| codex_cli (`home_dir` set) | only the exec cwd changes (`CODEX_HOME`, AGENTS.md, config.toml all derive from `home_dir` — unchanged) | |
| gemini_cli | skills → `/.gemini/skills` | `~/.gemini/skills` |
| opencode, mini_swe_agent | only the exec cwd changes (config is `$HOME`-based both before and after) | |

Downstream consequences in that case:

- **Anything the agent writes/reads via relative paths moves from `/` to `~`.** Scorers or setup scripts that assumed artifacts at container root (e.g. `/output.txt`) will look in the wrong place; files pre-staged at `/` are no longer in the agent's cwd. This is the deliberate fix, but it's the user-visible break.
- **Resume/checkpoint identity changes across the upgrade.** Codex sessions live under `CODEX_HOME` — a checkpoint recorded pre-upgrade points at `/.codex`, post-upgrade runs use `~/.codex`. Claude Code keys project session state by cwd, so `/` vs `~` is a different project. Mixing versions across a resume in this configuration won't find prior state.
- Non-root users that previously **failed outright** (couldn't write to `/`) now succeed — a fix, but still a behavior change.
