### PR TITLE
Fix Gemini CLI ACP bridge tools

### DIFF
--- a/src/inspect_swe/acp/_agents/gemini_cli/gemini_cli.py
+++ b/src/inspect_swe/acp/_agents/gemini_cli/gemini_cli.py
@@ -14,6 +14,7 @@ from inspect_ai.util import sandbox as sandbox_env
 from typing_extensions import Unpack
 
 from inspect_swe._gemini_cli.agentbinary import ensure_gemini_cli_setup
+from inspect_swe._gemini_cli.gemini_cli import build_gemini_settings
 from inspect_swe._util.path import join_path
 from inspect_swe.acp import ACPAgent
 from inspect_swe.acp.agent import ACPAgentParams
@@ -86,6 +87,12 @@ class GeminiCli(ACPAgent):
             home_result = await sbox.exec(["sh", "-c", "echo $HOME"], user=self.user)
             sandbox_home = home_result.stdout.strip() or "/root"
 
+            all_mcp_servers = list(self.mcp_servers) + list(bridge.mcp_server_configs)
+            settings_json = build_gemini_settings(all_mcp_servers)
+            gemini_settings_dir = f"{sandbox_home}/.gemini"
+            await sbox.exec(["mkdir", "-p", gemini_settings_dir], user=self.user)
+            await sbox.write_file(f"{gemini_settings_dir}/settings.json", settings_json)
+
             # Install skills.
             if self._resolved_skills:
                 GEMINI_SKILLS = ".gemini/skills"
@@ -123,6 +130,13 @@ class GeminiCli(ACPAgent):
                 "--model",
                 model.name,
             ]
+            if all_mcp_servers:
+                cmd.extend(
+                    [
+                        "--allowed-mcp-server-names",
+                        ",".join(server.name for server in all_mcp_servers),
+                    ]
+                )
             if self._debug:
                 # In ACP mode console.* is redirected away from stderr by
                 # ConsolePatcher, so --debug/DEBUG produce nothing observable.


### PR DESCRIPTION
## Summary

Fix Gemini CLI ACP sessions by writing Gemini CLI's native `.gemini/settings.json` MCP configuration before starting the agent.

Gemini CLI relies on `settings.json` to get its configured MCP server list. The ACP agent was passing MCP servers through `new_session(mcp_servers=...)`, but Gemini CLI's own MCP discovery path still needs those servers in its settings file. As a result, bridge-generated MCP servers could be absent from Gemini CLI's tool registry even though the ACP session was created with MCP metadata.

This mirrors the existing non-ACP Gemini scaffold behavior: collect user MCP servers plus bridge-generated MCP servers, write them into Gemini's settings format, and allow those server names when launching Gemini CLI.

## Root Cause

Gemini CLI treats MCP server configuration as native CLI settings. ACP session metadata alone is not enough for Gemini's MCP startup path.

The fix writes:

- `.gemini/settings.json` with the combined MCP server list
- `--allowed-mcp-server-names` with the same server names, using Gemini CLI's documented comma-separated form

## Validation

- `uv run --extra dev ruff format src/inspect_swe/acp/_agents/gemini_cli/gemini_cli.py`
- `uv run --extra dev ruff check src/inspect_swe/acp/_agents/gemini_cli/gemini_cli.py --output-format concise`
- `uv run pytest tests/test_bridged_tools.py::test_gemini_cli_bridged_tools -q`
- Downstream Petri DISH smoke with Gemini CLI + direct `google/gemini-3.5-flash` using `GOOGLE_API_KEY` reached `initialize_target()` exit, repeated `query_target()` calls, and normal `send_tool_call_result(...)` traffic.