### PR TITLE
Handle claude_code refusals gracefully

### DIFF
--- a/src/inspect_swe/_claude_code/_events/live_consumer.py
+++ b/src/inspect_swe/_claude_code/_events/live_consumer.py
@@ -64,6 +64,7 @@ from inspect_ai.model._chat_message import (
     ChatMessageUser,
 )
 from inspect_ai.model._model import ModelEventSink
+from inspect_ai.model._model_output import StopReason
 from inspect_ai.util._span import current_span_id
 
 from .toolview import tool_view
@@ -110,6 +111,16 @@ class LiveConsumer(ModelEventSink):
         # (no if we didn't — shouldn't happen with current logic but defensive).
         self._emitted_events: set[int] = set()
 
+        # Stop reason of the most recent completed ModelEvent. Used by the
+        # runner loop to distinguish an Anthropic refusal (content_filter)
+        # from a genuine scaffold crash when Claude Code exits non-zero.
+        self._last_stop_reason: StopReason | None = None
+
+    @property
+    def last_stop_reason(self) -> StopReason | None:
+        """Stop reason of the last completed model event this attempt."""
+        return self._last_stop_reason
+
     @property
     def outer_span_id(self) -> str | None:
         """Span for main-agent attribution, resolved at emission time.
@@ -134,6 +145,7 @@ class LiveConsumer(ModelEventSink):
             transcript()._event(SpanEndEvent(id=agent.span_id))
         self._pending_subagents.clear()
         self._emitted_events.clear()
+        self._last_stop_reason = None
 
     # ------------------------------------------------------------------
     # ModelEventSink callbacks (called from the bridge)
@@ -145,6 +157,12 @@ class LiveConsumer(ModelEventSink):
         transcript()._event(event)
 
     def on_complete(self, event: ModelEvent) -> None:
+        # Record the terminal stop reason (guard against empty choices, where
+        # ModelOutput.stop_reason raises). This fires for sub-agent calls too,
+        # but the runner only consults it on a non-zero exit.
+        if event.output and event.output.choices:
+            self._last_stop_reason = event.output.stop_reason
+
         msg = event.output.message if event.output else None
         if msg is not None and msg.tool_calls:
             # Attach custom rendering for Claude Code's built-in tools.

--- a/src/inspect_swe/_claude_code/claude_code.py
+++ b/src/inspect_swe/_claude_code/claude_code.py
@@ -13,7 +13,7 @@ from inspect_ai.agent import (
     agent_with,
     sandbox_agent_bridge,
 )
-from inspect_ai.model import ChatMessageSystem, GenerateFilter, Model
+from inspect_ai.model import ChatMessageSystem, GenerateFilter, Model, StopReason
 from inspect_ai.scorer import score
 from inspect_ai.tool import MCPServerConfig, Skill, install_skills, read_skills
 from inspect_ai.util import (
@@ -373,19 +373,10 @@ def claude_code(
                         cc_debug = store_as(ClaudeCodeDebug) if debug else None
                         stderr_data = ""
                         exit_code = 0
-                        terminal_stop_reason: str | None = None
-                        saw_result_event = False
 
                         async for cc_event in claude_code_event_stream(proc):
                             if isinstance(cc_event, JsonlEvent):
                                 consumer.process_jsonl_line(cc_event.raw)
-                                terminal_stop_reason, saw_result_event = (
-                                    _update_terminal_stop_reason(
-                                        cc_event.raw,
-                                        terminal_stop_reason,
-                                        saw_result_event,
-                                    )
-                                )
                                 if cc_debug is not None:
                                     cc_debug.stdout.append(cc_event.line)
                             elif isinstance(cc_event, JsonlParseError):
@@ -411,7 +402,7 @@ def claude_code(
                             if not _is_claude_code_refusal_exit(
                                 exit_code,
                                 stderr_data,
-                                terminal_stop_reason,
+                                consumer.last_stop_reason,
                             ):
                                 # if claude code exits with code 1 and no stderr,
                                 # this means an uncaught exception reached the top
@@ -570,50 +561,15 @@ class ClaudeCodeDebug(StoreModel):
     stdout: list[str] = Field(default_factory=list)
 
 
-def _claude_code_stop_reason(raw: dict[str, Any]) -> str | None:
-    event_type = raw.get("type")
-    if event_type == "assistant":
-        message = raw.get("message")
-        if not isinstance(message, dict):
-            return None
-        stop_reason = message.get("stop_reason")
-    elif event_type == "result":
-        stop_reason = raw.get("stop_reason")
-    else:
-        return None
-
-    return stop_reason if isinstance(stop_reason, str) else None
-
-
-def _update_terminal_stop_reason(
-    raw: dict[str, Any],
-    terminal_stop_reason: str | None,
-    saw_result_event: bool,
-) -> tuple[str | None, bool]:
-    """Fold a single Claude Code event into the running terminal stop reason.
-
-    The terminal `result` event is authoritative when it carries a stop_reason,
-    but Claude Code's result event often omits it -- in that case keep the
-    stop_reason already derived from the last assistant message (e.g. a refusal)
-    rather than clobbering it. Assistant stop reasons only count before any
-    result event is seen.
-    """
-    stop_reason = _claude_code_stop_reason(raw)
-    if raw.get("type") == "result":
-        saw_result_event = True
-        if stop_reason is not None:
-            terminal_stop_reason = stop_reason
-    elif stop_reason is not None and not saw_result_event:
-        terminal_stop_reason = stop_reason
-    return terminal_stop_reason, saw_result_event
-
-
 def _is_claude_code_refusal_exit(
     exit_code: int,
     stderr_data: str,
-    stop_reason: str | None,
+    stop_reason: StopReason | None,
 ) -> bool:
     if exit_code != 1 or len(stderr_data.strip()) > 0:
         return False
 
-    return stop_reason == "refusal"
+    # Anthropic refusals surface as Inspect's "content_filter" stop reason
+    # (mapped from the raw "refusal"). This matches the native react agent,
+    # which keys refusal handling on the same value (see inspect_ai react).
+    return stop_reason == "content_filter"

--- a/src/inspect_swe/_claude_code/claude_code.py
+++ b/src/inspect_swe/_claude_code/claude_code.py
@@ -379,13 +379,13 @@ def claude_code(
                         async for cc_event in claude_code_event_stream(proc):
                             if isinstance(cc_event, JsonlEvent):
                                 consumer.process_jsonl_line(cc_event.raw)
-                                stop_reason = _claude_code_stop_reason(cc_event.raw)
-                                event_type = cc_event.raw.get("type")
-                                if event_type == "result":
-                                    terminal_stop_reason = stop_reason
-                                    saw_result_event = True
-                                elif stop_reason is not None and not saw_result_event:
-                                    terminal_stop_reason = stop_reason
+                                terminal_stop_reason, saw_result_event = (
+                                    _update_terminal_stop_reason(
+                                        cc_event.raw,
+                                        terminal_stop_reason,
+                                        saw_result_event,
+                                    )
+                                )
                                 if cc_debug is not None:
                                     cc_debug.stdout.append(cc_event.line)
                             elif isinstance(cc_event, JsonlParseError):
@@ -583,6 +583,29 @@ def _claude_code_stop_reason(raw: dict[str, Any]) -> str | None:
         return None
 
     return stop_reason if isinstance(stop_reason, str) else None
+
+
+def _update_terminal_stop_reason(
+    raw: dict[str, Any],
+    terminal_stop_reason: str | None,
+    saw_result_event: bool,
+) -> tuple[str | None, bool]:
+    """Fold a single Claude Code event into the running terminal stop reason.
+
+    The terminal `result` event is authoritative when it carries a stop_reason,
+    but Claude Code's result event often omits it -- in that case keep the
+    stop_reason already derived from the last assistant message (e.g. a refusal)
+    rather than clobbering it. Assistant stop reasons only count before any
+    result event is seen.
+    """
+    stop_reason = _claude_code_stop_reason(raw)
+    if raw.get("type") == "result":
+        saw_result_event = True
+        if stop_reason is not None:
+            terminal_stop_reason = stop_reason
+    elif stop_reason is not None and not saw_result_event:
+        terminal_stop_reason = stop_reason
+    return terminal_stop_reason, saw_result_event
 
 
 def _is_claude_code_refusal_exit(

--- a/src/inspect_swe/_claude_code/claude_code.py
+++ b/src/inspect_swe/_claude_code/claude_code.py
@@ -373,10 +373,19 @@ def claude_code(
                         cc_debug = store_as(ClaudeCodeDebug) if debug else None
                         stderr_data = ""
                         exit_code = 0
+                        terminal_stop_reason: str | None = None
+                        saw_result_event = False
 
                         async for cc_event in claude_code_event_stream(proc):
                             if isinstance(cc_event, JsonlEvent):
                                 consumer.process_jsonl_line(cc_event.raw)
+                                stop_reason = _claude_code_stop_reason(cc_event.raw)
+                                event_type = cc_event.raw.get("type")
+                                if event_type == "result":
+                                    terminal_stop_reason = stop_reason
+                                    saw_result_event = True
+                                elif stop_reason is not None and not saw_result_event:
+                                    terminal_stop_reason = stop_reason
                                 if cc_debug is not None:
                                     cc_debug.stdout.append(cc_event.line)
                             elif isinstance(cc_event, JsonlParseError):
@@ -396,24 +405,32 @@ def claude_code(
 
                         # raise for error
                         if exit_code != 0:
-                            # if claude code exits with code 1 and no stderr,
-                            # this means an uncaught exception reached the top
-                            # of its main loop -- we treat this as a scaffold
-                            # bug and retry/resume a configurable number of
-                            # times
-                            if (
-                                exit_code == 1
-                                and len(stderr_data.strip()) == 0
-                                and retry_uncaught_errors is not None
-                                and uncaught_error_count < retry_uncaught_errors
+                            # Claude Code exits 1 after Anthropic refusal
+                            # responses even though the refusal has already
+                            # been recorded in bridge.state and can be scored.
+                            if not _is_claude_code_refusal_exit(
+                                exit_code,
+                                stderr_data,
+                                terminal_stop_reason,
                             ):
-                                uncaught_error_count += 1
-                                continue
+                                # if claude code exits with code 1 and no stderr,
+                                # this means an uncaught exception reached the top
+                                # of its main loop -- we treat this as a scaffold
+                                # bug and retry/resume a configurable number of
+                                # times
+                                if (
+                                    exit_code == 1
+                                    and len(stderr_data.strip()) == 0
+                                    and retry_uncaught_errors is not None
+                                    and uncaught_error_count < retry_uncaught_errors
+                                ):
+                                    uncaught_error_count += 1
+                                    continue
 
-                            # otherwise this is a hard failure
-                            raise RuntimeError(
-                                f"Error executing claude code agent {exit_code}: {stderr_data}"
-                            )
+                                # otherwise this is a hard failure
+                                raise RuntimeError(
+                                    f"Error executing claude code agent {exit_code}: {stderr_data}"
+                                )
 
                         # reset uncaught error counter
                         uncaught_error_count = 0
@@ -551,3 +568,29 @@ async def run_claude_code_centaur(
 class ClaudeCodeDebug(StoreModel):
     stderr: list[str] = Field(default_factory=list)
     stdout: list[str] = Field(default_factory=list)
+
+
+def _claude_code_stop_reason(raw: dict[str, Any]) -> str | None:
+    event_type = raw.get("type")
+    if event_type == "assistant":
+        message = raw.get("message")
+        if not isinstance(message, dict):
+            return None
+        stop_reason = message.get("stop_reason")
+    elif event_type == "result":
+        stop_reason = raw.get("stop_reason")
+    else:
+        return None
+
+    return stop_reason if isinstance(stop_reason, str) else None
+
+
+def _is_claude_code_refusal_exit(
+    exit_code: int,
+    stderr_data: str,
+    stop_reason: str | None,
+) -> bool:
+    if exit_code != 1 or len(stderr_data.strip()) > 0:
+        return False
+
+    return stop_reason == "refusal"

--- a/tests/test_claude_code_exit.py
+++ b/tests/test_claude_code_exit.py
@@ -1,91 +1,25 @@
-from typing import Any
-
 import pytest
-from inspect_swe._claude_code.claude_code import (
-    _claude_code_stop_reason,
-    _is_claude_code_refusal_exit,
-    _update_terminal_stop_reason,
-)
-
-
-def _resolve_terminal_stop_reason(events: list[dict[str, Any]]) -> str | None:
-    terminal_stop_reason: str | None = None
-    saw_result_event = False
-    for raw in events:
-        terminal_stop_reason, saw_result_event = _update_terminal_stop_reason(
-            raw, terminal_stop_reason, saw_result_event
-        )
-    return terminal_stop_reason
-
-
-def _assistant(stop_reason: str | None) -> dict[str, Any]:
-    return {"type": "assistant", "message": {"stop_reason": stop_reason}}
-
-
-@pytest.mark.parametrize(
-    ("events", "expected"),
-    [
-        # refusal assistant message followed by a result event that omits
-        # stop_reason (the real Claude Code shape) must not be clobbered
-        (
-            [_assistant("refusal"), {"type": "result", "subtype": "success"}],
-            "refusal",
-        ),
-        # partial stream: refusal assistant message, no result event
-        ([_assistant("refusal")], "refusal"),
-        # result event with an explicit stop_reason is authoritative
-        (
-            [_assistant("end_turn"), {"type": "result", "stop_reason": "refusal"}],
-            "refusal",
-        ),
-        # assistant events after a result event do not override it
-        (
-            [{"type": "result", "stop_reason": "stop"}, _assistant("refusal")],
-            "stop",
-        ),
-        # ordinary completion stays non-refusal
-        (
-            [_assistant("end_turn"), {"type": "result", "subtype": "success"}],
-            "end_turn",
-        ),
-    ],
-)
-def test_resolve_terminal_stop_reason(
-    events: list[dict[str, Any]], expected: str | None
-) -> None:
-    assert _resolve_terminal_stop_reason(events) == expected
-
-
-@pytest.mark.parametrize(
-    ("raw", "expected"),
-    [
-        (
-            {
-                "type": "assistant",
-                "message": {"role": "assistant", "stop_reason": "refusal"},
-            },
-            "refusal",
-        ),
-        ({"type": "result", "stop_reason": "refusal"}, "refusal"),
-        ({"type": "assistant", "message": "bad"}, None),
-        ({"type": "system", "stop_reason": "refusal"}, None),
-    ],
-)
-def test_claude_code_stop_reason(raw: dict[str, Any], expected: str | None) -> None:
-    assert _claude_code_stop_reason(raw) == expected
+from inspect_ai.event._model import ModelEvent
+from inspect_ai.model import GenerateConfig, ModelOutput
+from inspect_swe._claude_code._events.live_consumer import LiveConsumer
+from inspect_swe._claude_code.claude_code import _is_claude_code_refusal_exit
 
 
 @pytest.mark.parametrize(
     ("exit_code", "stderr_data", "stop_reason", "expected"),
     [
-        (1, "", "refusal", True),
+        # Anthropic refusal -> Inspect maps it to content_filter
+        (1, "", "content_filter", True),
         (1, "", "stop", False),
+        (1, "", "tool_calls", False),
         (1, "", None, False),
-        (1, "boom", "refusal", False),
-        (2, "", "refusal", False),
+        # genuine scaffold crash (stderr present) is not a refusal
+        (1, "boom", "content_filter", False),
+        # non-1 exit codes are never refusals
+        (2, "", "content_filter", False),
     ],
 )
-def test_claude_code_refusal_exit(
+def test_is_claude_code_refusal_exit(
     exit_code: int,
     stderr_data: str,
     stop_reason: str | None,
@@ -99,3 +33,37 @@ def test_claude_code_refusal_exit(
         )
         is expected
     )
+
+
+def _model_event(output: ModelOutput) -> ModelEvent:
+    return ModelEvent(
+        model="m",
+        input=[],
+        tools=[],
+        tool_choice="none",
+        config=GenerateConfig(),
+        output=output,
+    )
+
+
+def test_last_stop_reason_tracks_latest_completed_event() -> None:
+    consumer = LiveConsumer()
+    assert consumer.last_stop_reason is None
+
+    consumer.on_complete(_model_event(ModelOutput.from_content("m", "hi")))
+    assert consumer.last_stop_reason == "stop"
+
+    consumer.on_complete(
+        _model_event(ModelOutput.from_content("m", "", stop_reason="content_filter"))
+    )
+    assert consumer.last_stop_reason == "content_filter"
+
+
+def test_reset_clears_last_stop_reason() -> None:
+    consumer = LiveConsumer()
+    consumer.on_complete(
+        _model_event(ModelOutput.from_content("m", "", stop_reason="content_filter"))
+    )
+    assert consumer.last_stop_reason == "content_filter"
+    consumer.reset()
+    assert consumer.last_stop_reason is None

--- a/tests/test_claude_code_exit.py
+++ b/tests/test_claude_code_exit.py
@@ -4,7 +4,56 @@ import pytest
 from inspect_swe._claude_code.claude_code import (
     _claude_code_stop_reason,
     _is_claude_code_refusal_exit,
+    _update_terminal_stop_reason,
 )
+
+
+def _resolve_terminal_stop_reason(events: list[dict[str, Any]]) -> str | None:
+    terminal_stop_reason: str | None = None
+    saw_result_event = False
+    for raw in events:
+        terminal_stop_reason, saw_result_event = _update_terminal_stop_reason(
+            raw, terminal_stop_reason, saw_result_event
+        )
+    return terminal_stop_reason
+
+
+def _assistant(stop_reason: str | None) -> dict[str, Any]:
+    return {"type": "assistant", "message": {"stop_reason": stop_reason}}
+
+
+@pytest.mark.parametrize(
+    ("events", "expected"),
+    [
+        # refusal assistant message followed by a result event that omits
+        # stop_reason (the real Claude Code shape) must not be clobbered
+        (
+            [_assistant("refusal"), {"type": "result", "subtype": "success"}],
+            "refusal",
+        ),
+        # partial stream: refusal assistant message, no result event
+        ([_assistant("refusal")], "refusal"),
+        # result event with an explicit stop_reason is authoritative
+        (
+            [_assistant("end_turn"), {"type": "result", "stop_reason": "refusal"}],
+            "refusal",
+        ),
+        # assistant events after a result event do not override it
+        (
+            [{"type": "result", "stop_reason": "stop"}, _assistant("refusal")],
+            "stop",
+        ),
+        # ordinary completion stays non-refusal
+        (
+            [_assistant("end_turn"), {"type": "result", "subtype": "success"}],
+            "end_turn",
+        ),
+    ],
+)
+def test_resolve_terminal_stop_reason(
+    events: list[dict[str, Any]], expected: str | None
+) -> None:
+    assert _resolve_terminal_stop_reason(events) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_claude_code_exit.py
+++ b/tests/test_claude_code_exit.py
@@ -1,0 +1,52 @@
+from typing import Any
+
+import pytest
+from inspect_swe._claude_code.claude_code import (
+    _claude_code_stop_reason,
+    _is_claude_code_refusal_exit,
+)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (
+            {
+                "type": "assistant",
+                "message": {"role": "assistant", "stop_reason": "refusal"},
+            },
+            "refusal",
+        ),
+        ({"type": "result", "stop_reason": "refusal"}, "refusal"),
+        ({"type": "assistant", "message": "bad"}, None),
+        ({"type": "system", "stop_reason": "refusal"}, None),
+    ],
+)
+def test_claude_code_stop_reason(raw: dict[str, Any], expected: str | None) -> None:
+    assert _claude_code_stop_reason(raw) == expected
+
+
+@pytest.mark.parametrize(
+    ("exit_code", "stderr_data", "stop_reason", "expected"),
+    [
+        (1, "", "refusal", True),
+        (1, "", "stop", False),
+        (1, "", None, False),
+        (1, "boom", "refusal", False),
+        (2, "", "refusal", False),
+    ],
+)
+def test_claude_code_refusal_exit(
+    exit_code: int,
+    stderr_data: str,
+    stop_reason: str | None,
+    expected: bool,
+) -> None:
+    assert (
+        _is_claude_code_refusal_exit(
+            exit_code=exit_code,
+            stderr_data=stderr_data,
+            stop_reason=stop_reason,
+        )
+        is expected
+    )


### PR DESCRIPTION
When the `claude_code` solver runs into a refusal, we'd `raise RuntimeError` which would halt the eval. "Native" solvers in Inspect instead treat refusal as failure and continue on to scoring the sample and to run other samples. With these changes, the `claude_code` solver will now mimic the behavior of other solvers.