### PR TITLE
feat(kimi): add `kimi_code()` agent with Inspect bridging, MCP, skills, and Centaur support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@
 - Claude Code: Handle Anthropic refusals gracefully — a content-filter refusal now scores the sample as incorrect and continues the eval (matching native Inspect solvers) instead of raising an error that aborts the run.
 - Gemini CLI (ACP): Register bridged tools and MCP servers with the CLI (write `settings.json` and pass `--allowed-mcp-server-names`) so host-side tools are available to the agent.
 - All agents: When no `cwd` is specified and the sandbox's default working directory is `/` (i.e. the image has no `WORKDIR`), run the agent in the user's home directory instead of the container root.
-- Kimi Code: Add `kimi_code()` agent for Moonshot AI's [Kimi Code](https://github.com/MoonshotAI/kimi-code) CLI, running headless in a sandbox with Inspect model bridging and native MCP. Supports binary download (`version` "auto"/"sandbox"/"latest"/"x.x.x"), skills, bridged tools, centaur mode, and multiple attempts.
 
 ## 0.2.63 (10 June 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Claude Code: Handle Anthropic refusals gracefully — a content-filter refusal now scores the sample as incorrect and continues the eval (matching native Inspect solvers) instead of raising an error that aborts the run.
 - Gemini CLI (ACP): Register bridged tools and MCP servers with the CLI (write `settings.json` and pass `--allowed-mcp-server-names`) so host-side tools are available to the agent.
 - All agents: When no `cwd` is specified and the sandbox's default working directory is `/` (i.e. the image has no `WORKDIR`), run the agent in the user's home directory instead of the container root.
+- Kimi Code: Add `kimi_code()` agent for Moonshot AI's [Kimi Code](https://github.com/MoonshotAI/kimi-code) CLI, running headless in a sandbox with Inspect model bridging and native MCP. Supports binary download (`version` "auto"/"sandbox"/"latest"/"x.x.x"), skills, bridged tools, centaur mode, and multiple attempts.
 
 ## 0.2.63 (10 June 2026)
 

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -15,5 +15,6 @@ inspect-docs:
         - href: claude_code.qmd
         - href: codex_cli.qmd
         - href: gemini_cli.qmd
+        - href: kimi_code.qmd
         - href: opencode.qmd
         - href: mini_swe_agent.qmd

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -5,7 +5,7 @@ subtitle: Software Engineering Agents for Inspect AI
 
 ## Overview
 
-The `inspect_swe` package makes software engineering agents like [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview), [Codex CLI](https://github.com/openai/codex), [Gemini CLI](https://github.com/google-gemini/gemini-cli), [OpenCode](https://github.com/anomalyco/opencode), and [Mini SWE Agent](https://github.com/SWE-agent/mini-swe-agent).  available as standard Inspect agents. For example, here we use the `claude_code()` agent as the solver in an Inspect task:
+The `inspect_swe` package makes software engineering agents like [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview), [Codex CLI](https://github.com/openai/codex), [Gemini CLI](https://github.com/google-gemini/gemini-cli), [Kimi Code](https://github.com/MoonshotAI/kimi-code), [OpenCode](https://github.com/anomalyco/opencode), and [Mini SWE Agent](https://github.com/SWE-agent/mini-swe-agent) available as standard Inspect agents. For example, here we use the `claude_code()` agent as the solver in an Inspect task:
 
 ``` python
 from inspect_ai import Task, task
@@ -43,6 +43,7 @@ Then, try out one or more of the available agents:
 | [`claude_code()`](claude_code.qmd) | Anthropic's agentic coding tool [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) |
 | [`codex_cli()`](codex_cli.qmd) | OpenAI's terminal-based coding agent [Codex CLI](https://github.com/openai/codex) |
 | [`gemini_cli()`](gemini_cli.qmd) | Google's open-source AI agent [Gemini CLI](https://github.com/google-gemini/gemini-cli) |
+| [`kimi_code()`](kimi_code.qmd) | Moonshot AI's terminal-based coding agent [Kimi Code](https://github.com/MoonshotAI/kimi-code) |
 | [`opencode()`](opencode.qmd) | Provider-independent terminal-based coding agent. |
 | [`mini_swe_agent()`](mini_swe_agent.qmd) | SWE-agent's minimal 100-line agent. |
 

--- a/docs/kimi_code.qmd
+++ b/docs/kimi_code.qmd
@@ -22,6 +22,7 @@ The following options are supported for customizing the behavior of the agent:
 | `centaur` | Run in [Centaur Mode](#centaur-mode), which makes {{< meta agent_name >}} available to an Inspect `human_cli()` agent rather than running it unattended. |
 | `attempts` | Allow the agent to have multiple scored attempts at solving the task. |
 | `model` | Model name to use for agent (defaults to main model for task). |
+| `max_context_size` | Context window to configure for Kimi. Defaults to the bridged model's context length from Inspect model metadata; required when that metadata is unavailable. |
 | `filter` | Filter for intercepting bridged model requests. |
 | `retry_refusals` | Should refusals be retried? (pass number of times to retry) |
 | `disallowed_tools` | Tool names to deny via {{< meta agent_name >}} permission rules. |

--- a/docs/kimi_code.qmd
+++ b/docs/kimi_code.qmd
@@ -43,7 +43,13 @@ For example, here we specify a custom system prompt:
 
 {{< include _snippets/agent_bridged_tools.md >}}
 
+## Tool Repetition Reminders
+
+The {{< meta agent_name >}} CLI appends escalating `<system-reminder>` notes to tool results when it detects the same tool call repeated several times in a row. Since re-polling an identical read-only command is often legitimate in long-running tasks (e.g. waiting for a build to finish), the `kimi_code()` agent strips the first two escalation tiers of these reminders before the bridged model sees them (so they also don't appear in the transcript). The final tier — which instructs the model to write its final response, and precedes {{< meta agent_name >}} force-stopping the turn at 12 repetitions — is passed through unchanged so the model can wrap up gracefully.
+
 ## Installation
+
+{{< meta agent_name >}} publishes glibc-only Linux binaries, and the agent runs them via `bash`, so sandbox images must provide glibc and bash (e.g. Debian/Ubuntu based images). musl-based images such as Alpine are not supported and fail at binary resolution time.
 
 By default, the agent will download the current latest version of {{< meta agent_name >}} and copy it to the sandbox. You can override this behaviour using the `version` option:
 

--- a/docs/kimi_code.qmd
+++ b/docs/kimi_code.qmd
@@ -1,0 +1,63 @@
+---
+title: Kimi Code
+agent: kimi_code
+agent_provider: "Moonshot AI"
+agent_name: "Kimi Code"
+agent_url: "https://github.com/MoonshotAI/kimi-code"
+agent_disallowed_tool: "WebFetch"
+---
+
+{{< include _snippets/agent_intro.md >}}
+
+## Options
+
+The following options are supported for customizing the behavior of the agent:
+
+| Option | Description |
+|------------------------------------|------------------------------------|
+| `system_prompt` | Additional system prompt to append to default system prompt. |
+| `skills` | Additional [skills](https://inspect.aisi.org.uk/tools-standard.html#sec-skill) to make available to the agent. |
+| `mcp_servers` | MCP servers (see [MCP Servers](#mcp-servers) below for details). |
+| `bridged_tools` | Host-side Inspect tools to expose via MCP (see [Bridged Tools](#bridged-tools) below for details). |
+| `centaur` | Run in [Centaur Mode](#centaur-mode), which makes {{< meta agent_name >}} available to an Inspect `human_cli()` agent rather than running it unattended. |
+| `attempts` | Allow the agent to have multiple scored attempts at solving the task. |
+| `model` | Model name to use for agent (defaults to main model for task). |
+| `filter` | Filter for intercepting bridged model requests. |
+| `retry_refusals` | Should refusals be retried? (pass number of times to retry) |
+| `disallowed_tools` | Tool names to deny via {{< meta agent_name >}} permission rules. |
+| `cwd` | Working directory for {{< meta agent_name >}} session. |
+| `env` | Environment variables to set for {{< meta agent_name >}}. |
+| `version` | Version of {{< meta agent_name >}} to use (see [Installation](#installation) below for details) |
+
+: {tbl-colwidths=\[25,75\]}
+
+For example, here we specify a custom system prompt:
+
+```python
+{{< meta agent >}}(
+    system_prompt="You are an ace system researcher."
+)
+```
+
+{{< include _snippets/agent_mcp_servers.md >}}
+
+{{< include _snippets/agent_bridged_tools.md >}}
+
+## Installation
+
+By default, the agent will download the current latest version of {{< meta agent_name >}} and copy it to the sandbox. You can override this behaviour using the `version` option:
+
+| Option | Description |
+|------------------------------------|------------------------------------|
+| `"auto"` | Use any available version of {{< meta agent_name >}} in the sandbox, otherwise download the latest version. |
+| `"sandbox"` | Use the version of {{< meta agent_name >}} in the sandbox (raises `RuntimeError` if not available in the sandbox) |
+| `"latest"` | Download and use the very latest version. |
+| `"x.x.x"` | Download and use a specific version number. |
+
+: {tbl-colwidths=\[25,75\]}
+
+{{< include _snippets/agent_installation.md >}}
+
+{{< include _snippets/agent_centaur.md >}}
+
+{{< include _snippets/agent_troubleshooting.md >}}

--- a/examples/bridged_tools/task.py
+++ b/examples/bridged_tools/task.py
@@ -5,7 +5,7 @@ from inspect_ai.agent import BridgedToolsSpec
 from inspect_ai.dataset import Sample
 from inspect_ai.tool import Tool, tool
 from inspect_ai.util import SandboxEnvironmentType
-from inspect_swe import claude_code, codex_cli, gemini_cli, opencode
+from inspect_swe import claude_code, codex_cli, gemini_cli, kimi_code, opencode
 
 
 @tool
@@ -29,7 +29,7 @@ def secret_lookup() -> Tool:
 @task
 def bridged_tools_test(
     agent: Literal[
-        "claude_code", "codex_cli", "gemini_cli", "opencode"
+        "claude_code", "codex_cli", "gemini_cli", "kimi_code", "opencode"
     ] = "claude_code",
     sandbox: SandboxEnvironmentType | None = "docker",
 ) -> Task:
@@ -50,6 +50,8 @@ def bridged_tools_test(
             solver = gemini_cli(
                 system_prompt=system_prompt, bridged_tools=bridged_tools
             )
+        case "kimi_code":
+            solver = kimi_code(system_prompt=system_prompt, bridged_tools=bridged_tools)
         case "opencode":
             solver = opencode(system_prompt=system_prompt, bridged_tools=bridged_tools)
 

--- a/examples/system_explorer/task.py
+++ b/examples/system_explorer/task.py
@@ -4,13 +4,25 @@ from inspect_ai import Task, task
 from inspect_ai.dataset import json_dataset
 from inspect_ai.scorer import model_graded_qa
 from inspect_ai.util import SandboxEnvironmentType
-from inspect_swe import claude_code, codex_cli, gemini_cli, mini_swe_agent, opencode
+from inspect_swe import (
+    claude_code,
+    codex_cli,
+    gemini_cli,
+    kimi_code,
+    mini_swe_agent,
+    opencode,
+)
 
 
 @task
 def system_explorer(
     agent: Literal[
-        "claude_code", "codex_cli", "gemini_cli", "mini_swe_agent", "opencode"
+        "claude_code",
+        "codex_cli",
+        "gemini_cli",
+        "kimi_code",
+        "mini_swe_agent",
+        "opencode",
     ] = "claude_code",
     sandbox: SandboxEnvironmentType | None = "docker",
 ) -> Task:
@@ -21,6 +33,8 @@ def system_explorer(
             solver = codex_cli()
         case "gemini_cli":
             solver = gemini_cli()
+        case "kimi_code":
+            solver = kimi_code()
         case "mini_swe_agent":
             solver = mini_swe_agent()
         case "opencode":

--- a/src/inspect_swe/__init__.py
+++ b/src/inspect_swe/__init__.py
@@ -1,6 +1,7 @@
 from ._claude_code.claude_code import claude_code
 from ._codex_cli.codex_cli import codex_cli
 from ._gemini_cli.gemini_cli import gemini_cli
+from ._kimi_code.kimi_code import kimi_code
 from ._mini_swe_agent.mini_swe_agent import mini_swe_agent
 from ._opencode.opencode import opencode
 from ._tools.download import AgentBinary, cached_agent_binaries, download_agent_binary
@@ -26,6 +27,7 @@ __all__ = [
     "claude_code",
     "codex_cli",
     "gemini_cli",
+    "kimi_code",
     "mini_swe_agent",
     "opencode",
     "interactive_claude_code",

--- a/src/inspect_swe/_kimi_code/__init__.py
+++ b/src/inspect_swe/_kimi_code/__init__.py
@@ -1,0 +1,3 @@
+from .kimi_code import kimi_code
+
+__all__ = ["kimi_code"]

--- a/src/inspect_swe/_kimi_code/agentbinary.py
+++ b/src/inspect_swe/_kimi_code/agentbinary.py
@@ -1,0 +1,76 @@
+import json
+from pathlib import Path
+from typing import Any
+
+from typing_extensions import Literal
+
+from .._util.agentbinary import AgentBinarySource, AgentBinaryVersion
+from .._util.appdirs import package_cache_dir
+from .._util.download import download_text_file
+from .._util.sandbox import SandboxPlatform
+
+# Kimi Code publishes raw per-platform binaries plus a version pointer and a
+# per-version manifest of filenames and sha256 checksums.
+KIMI_DIST_URL = "https://code.kimi.com/kimi-code/binaries"
+KIMI_LATEST_URL = "https://code.kimi.com/kimi-code/latest.json"
+
+
+def kimi_code_binary_source() -> AgentBinarySource:
+    cached_binary_dir = package_cache_dir("kimi-code-downloads")
+
+    async def resolve_version(
+        version: Literal["stable", "latest"] | str, platform: SandboxPlatform
+    ) -> AgentBinaryVersion:
+        if version in ["stable", "latest"]:
+            version = await _fetch_latest_version()
+
+        manifest = await _fetch_manifest(version)
+        platforms = manifest["platforms"]
+        kimi_platform = _platform_to_kimi_platform(platform)
+        if kimi_platform not in platforms:
+            raise RuntimeError(
+                f"No Kimi Code binary for platform {platform} in version {version}"
+            )
+        entry = platforms[kimi_platform]
+        download_url = f"{KIMI_DIST_URL}/{version}/{entry['filename']}"
+        return AgentBinaryVersion(version, entry["checksum"], download_url)
+
+    def cached_binary_path(version: str, platform: SandboxPlatform) -> Path:
+        return cached_binary_dir / f"kimi-code-{version}-{platform}"
+
+    def list_cached_binaries() -> list[Path]:
+        return list(cached_binary_dir.glob("kimi-code-*"))
+
+    return AgentBinarySource(
+        agent="kimi code",
+        binary="kimi",
+        resolve_version=resolve_version,
+        cached_binary_path=cached_binary_path,
+        list_cached_binaries=list_cached_binaries,
+        post_download=None,
+        post_install=None,
+    )
+
+
+def _platform_to_kimi_platform(platform: SandboxPlatform) -> str:
+    # Kimi ships glibc linux builds keyed by arch only (no musl variants), so
+    # collapse musl platforms onto the plain linux key.
+    platform_map = {
+        "linux-x64": "linux-x64",
+        "linux-x64-musl": "linux-x64",
+        "linux-arm64": "linux-arm64",
+        "linux-arm64-musl": "linux-arm64",
+    }
+    if platform not in platform_map:
+        raise ValueError(f"Unsupported platform: {platform}")
+    return platform_map[platform]
+
+
+async def _fetch_latest_version() -> str:
+    latest = json.loads(await download_text_file(KIMI_LATEST_URL))
+    return str(latest["version"])
+
+
+async def _fetch_manifest(version: str) -> dict[str, Any]:
+    manifest_url = f"{KIMI_DIST_URL}/{version}/manifest.json"
+    return dict(json.loads(await download_text_file(manifest_url)))

--- a/src/inspect_swe/_kimi_code/agentbinary.py
+++ b/src/inspect_swe/_kimi_code/agentbinary.py
@@ -53,17 +53,16 @@ def kimi_code_binary_source() -> AgentBinarySource:
 
 
 def _platform_to_kimi_platform(platform: SandboxPlatform) -> str:
-    # Kimi ships glibc linux builds keyed by arch only (no musl variants), so
-    # collapse musl platforms onto the plain linux key.
-    platform_map = {
-        "linux-x64": "linux-x64",
-        "linux-x64-musl": "linux-x64",
-        "linux-arm64": "linux-arm64",
-        "linux-arm64-musl": "linux-arm64",
-    }
-    if platform not in platform_map:
-        raise ValueError(f"Unsupported platform: {platform}")
-    return platform_map[platform]
+    # Kimi publishes glibc-only linux builds (no musl variants), so there is no
+    # binary to fall back to on musl images (e.g. Alpine) — the glibc build
+    # would download fine and then fail at exec with a cryptic "required file
+    # not found". Raise at resolution time instead.
+    if platform.endswith("-musl"):
+        raise RuntimeError(
+            f"Kimi Code publishes glibc-only linux builds; no musl binary is "
+            f"available for {platform}."
+        )
+    return platform
 
 
 async def _fetch_latest_version() -> str:

--- a/src/inspect_swe/_kimi_code/kimi_code.py
+++ b/src/inspect_swe/_kimi_code/kimi_code.py
@@ -15,6 +15,7 @@ from inspect_ai.agent import (
     agent_with,
     sandbox_agent_bridge,
 )
+from inspect_ai.agent._bridge.util import resolve_inspect_model
 from inspect_ai.model import (
     ChatMessage,
     ChatMessageAssistant,
@@ -26,7 +27,6 @@ from inspect_ai.model import (
     GenerateFilter,
     Model,
     ModelOutput,
-    get_model,
     get_model_info,
 )
 from inspect_ai.model._model import GenerateInput
@@ -171,7 +171,10 @@ def kimi_code(
     if centaur is True:
         centaur = CentaurOptions()
 
-    # resolve model
+    # resolve the name Kimi sends and the bridge fallback independently: the
+    # bridge matches aliases against the raw requested name before stripping
+    # the inspect/ prefix from its fallback.
+    requested_model = model or "inspect"
     bridge_model = f"inspect/{model}" if model is not None else "inspect"
 
     # resolve skills / attempts
@@ -182,8 +185,9 @@ def kimi_code(
     filter_is_legacy = filter is not None and _is_legacy_str_filter(filter)
 
     async def execute(state: AgentState) -> AgentState:
+        resolved_model = _resolve_model(model=model, model_aliases=model_aliases)
         resolved_max_context_size = _resolve_max_context_size(
-            model=model, max_context_size=max_context_size
+            model=resolved_model, max_context_size=max_context_size
         )
 
         # determine port (use new port for each execution of agent on sample)
@@ -262,6 +266,7 @@ def kimi_code(
                     extra_skill_dirs=[skills_dir]
                     if resolved_skills is not None
                     else [],
+                    model=requested_model,
                     max_context_size=resolved_max_context_size,
                 ),
             )
@@ -458,24 +463,29 @@ def _mcp_json(mcp_servers: Sequence[MCPServerConfig]) -> str:
     return json.dumps({"mcpServers": servers}, indent=2)
 
 
-def _resolve_max_context_size(
-    *, model: str | None, max_context_size: int | None
-) -> int:
+def _resolve_model(
+    *, model: str | None, model_aliases: dict[str, str | Model] | None
+) -> Model:
+    requested_model = model or "inspect"
+    bridge_model = f"inspect/{model}" if model is not None else "inspect"
+    return resolve_inspect_model(requested_model, model_aliases, bridge_model)
+
+
+def _resolve_max_context_size(*, model: Model, max_context_size: int | None) -> int:
     if max_context_size is not None:
         if max_context_size <= 0:
             raise ValueError("max_context_size must be a positive integer")
         return max_context_size
 
-    resolved_model = get_model(model)
-    model_info = get_model_info(resolved_model)
+    model_info = get_model_info(model)
     if model_info is None or model_info.context_length is None:
         raise ValueError(
             f"Context length metadata is unavailable for model "
-            f"{resolved_model.name!r}; pass max_context_size explicitly."
+            f"{model.name!r}; pass max_context_size explicitly."
         )
     if model_info.context_length <= 0:
         raise ValueError(
-            f"Context length metadata for model {resolved_model.name!r} must be "
+            f"Context length metadata for model {model.name!r} must be "
             "positive; pass max_context_size explicitly."
         )
     return model_info.context_length
@@ -487,6 +497,7 @@ def _config_toml(
     mcp_servers: Sequence[MCPServerConfig],
     disallowed_tools: Sequence[str],
     extra_skill_dirs: Sequence[str],
+    model: str,
     max_context_size: int,
 ) -> str:
     lines = ['default_model = "bridge"', "telemetry = false"]
@@ -502,7 +513,7 @@ def _config_toml(
         "",
         "[models.bridge]",
         'provider = "bridge"',
-        'model = "inspect"',
+        f"model = {_format_value(model)}",
         f"max_context_size = {max_context_size}",
     ]
     # -p (prompt) mode auto-approves regular tool calls under the auto policy;

--- a/src/inspect_swe/_kimi_code/kimi_code.py
+++ b/src/inspect_swe/_kimi_code/kimi_code.py
@@ -1,3 +1,4 @@
+import inspect
 import json
 import re
 import shlex
@@ -30,6 +31,7 @@ from inspect_ai.model._model import GenerateInput
 from inspect_ai.scorer import score
 from inspect_ai.tool import (
     MCPServerConfig,
+    MCPServerConfigHTTP,
     MCPServerConfigStdio,
     Skill,
     ToolChoice,
@@ -48,25 +50,52 @@ from inspect_swe._util.trace import trace
 
 from .._util.agentbinary import ensure_agent_binary_installed
 from .._util.sandbox import resolve_agent_cwd
+from .._util.toml import _format_value
 from .agentbinary import kimi_code_binary_source
 
-# GenerateFilter is a union of Model-first and str-first callables; the bridge
-# dispatches Model-first filters (as used here), so we call through this form.
+# GenerateFilter is a union of Model-first and (deprecated) str-first callables;
+# the bridge dispatches on the user filter's first-parameter annotation. Our
+# combined_filter wrapper hides the user filter from that dispatch, so we
+# replicate it: Model-first filters get the Model, str-first get model.name.
 _ModelFilter = Callable[
     [Model, list[ChatMessage], list[ToolInfo], "ToolChoice | None", GenerateConfig],
     Awaitable["ModelOutput | GenerateInput | None"],
 ]
+_StrFilter = Callable[
+    [str, list[ChatMessage], list[ToolInfo], "ToolChoice | None", GenerateConfig],
+    Awaitable["ModelOutput | GenerateInput | None"],
+]
+
+
+def _is_legacy_str_filter(fn: GenerateFilter) -> bool:
+    first = next(iter(inspect.signature(fn).parameters.values()), None)
+    return first is not None and first.annotation is str
+
 
 KIMI_MAX_CONTEXT_SIZE = 262144
 
-# Kimi Code's CLI injects a <system-reminder> nagging the model not to repeat an
-# identical tool call. Re-polling the same read tool with the same arguments is
-# legitimate (a build hasn't finished, a status is still pending), so the nag is
-# a harness artifact rather than part of the task; strip it before the bridged
-# model sees it.
-_REPEAT_REMINDER_MARKER = "Repeated tool call detected"
+# Kimi Code's CLI appends escalating <system-reminder> nags to tool results when
+# it detects an identical tool call repeated N times in a row (tool-dedup: tier 1
+# at streak >= 3, tier 2 at >= 5, tier 3 "respond now" at >= 8, forced turn stop
+# at >= 12). Re-polling the same read tool with the same arguments is legitimate
+# (a build hasn't finished, a status is still pending), so tiers 1-2 are harness
+# artifacts rather than part of the task; strip them before the bridged model
+# sees them. Tier 3 is deliberately NOT stripped: kimi force-stops the turn at
+# streak 12 regardless of what the model saw, so hiding the "write your final
+# response now" instruction would only turn a graceful wrap-up into an abrupt
+# cutoff. Markers cover both wordings (rewritten in kimi-code 0.23.4, PR #1518).
+_REPEAT_REMINDER_MARKERS = (
+    # kimi-code >= 0.23.4
+    "The same tool call has been repeated",
+    "The same tool call has now been issued",
+    # kimi-code < 0.23.4
+    "You are repeating the exact same tool call",
+    "Repeated tool call detected",
+)
 _REPEAT_REMINDER_RE = re.compile(
-    r"<system-reminder>(?:(?!</system-reminder>).)*?Repeated tool call detected.*?</system-reminder>",
+    r"<system-reminder>(?:(?!</system-reminder>).)*?(?:"
+    + "|".join(re.escape(marker) for marker in _REPEAT_REMINDER_MARKERS)
+    + r").*?</system-reminder>",
     re.DOTALL,
 )
 
@@ -148,6 +177,7 @@ def kimi_code(
     attempts = AgentAttempts(attempts) if isinstance(attempts, int) else attempts
 
     resolved_disallowed = list(disallowed_tools or [])
+    filter_is_legacy = filter is not None and _is_legacy_str_filter(filter)
 
     async def execute(state: AgentState) -> AgentState:
         # determine port (use new port for each execution of agent on sample)
@@ -162,11 +192,19 @@ def kimi_code(
             tool_choice: ToolChoice | None,
             config: GenerateConfig,
         ) -> ModelOutput | GenerateInput | None:
+            # in place (not via GenerateInput) so the rewritten ids persist in
+            # both the recorded ModelEvent input and bridge.state.messages
+            _dedupe_tool_call_ids(messages)
             cleaned, changed = _strip_repeat_reminders(messages)
             if filter is not None:
-                result = await cast(_ModelFilter, filter)(
-                    model, cleaned, tools, tool_choice, config
-                )
+                if filter_is_legacy:
+                    result = await cast(_StrFilter, filter)(
+                        model.name, cleaned, tools, tool_choice, config
+                    )
+                else:
+                    result = await cast(_ModelFilter, filter)(
+                        model, cleaned, tools, tool_choice, config
+                    )
                 if result is not None:
                     return result
             if changed:
@@ -237,7 +275,11 @@ def kimi_code(
             if system_messages:
                 prompt = "\n\n".join(system_messages) + "\n\n" + prompt
 
-            cmd = [kimi_binary, "--output-format", "text"]
+            cmd = [kimi_binary]
+            # kimi rejects --output-format outside -p (prompt) mode, so keep the
+            # centaur alias (interactive) free of it
+            if centaur is False:
+                cmd.extend(["--output-format", "text"])
 
             agent_env = {
                 "KIMI_CODE_HOME": kimi_home,
@@ -310,20 +352,23 @@ def kimi_code(
                     debug_output.insert(0, "Kimi Code Debug Output:")
                     trace("\n".join(debug_output))
 
-        _dedupe_tool_call_ids(bridge.state.messages)
         return bridge.state
 
     return agent_with(execute, name=name, description=description)
 
 
+def _contains_repeat_reminder(text: str) -> bool:
+    return any(marker in text for marker in _REPEAT_REMINDER_MARKERS)
+
+
 def _strip_repeat_reminders(
     messages: list[ChatMessage],
 ) -> tuple[list[ChatMessage], bool]:
-    if not any(_REPEAT_REMINDER_MARKER in m.text for m in messages):
+    if not any(_contains_repeat_reminder(m.text) for m in messages):
         return messages, False
     cleaned: list[ChatMessage] = []
     for message in messages:
-        if _REPEAT_REMINDER_MARKER not in message.text:
+        if not _contains_repeat_reminder(message.text):
             cleaned.append(message)
             continue
         if isinstance(message.content, str):
@@ -348,23 +393,29 @@ def _strip_repeat_reminders(
     return cleaned, True
 
 
+_DEDUPE_SUFFIX_RE = re.compile(r"__u\d+$")
+
+
 def _dedupe_tool_call_ids(messages: list[ChatMessage]) -> None:
     # Kimi Code assigns tool_call_ids of the form `functions_<tool>_<n>` whose
-    # counter resets, so the same id (e.g. `functions_Bash_0`) recurs across a
-    # session. The bridge records those ids verbatim, so a transcript viewer that
-    # threads assistant-call<->tool-result on tool_call_id alone collapses every
-    # reuse of an id into one node — the linear chain renders as a spurious tree.
-    # Rewrite ids in place to be globally unique while preserving pairing: the
-    # k-th tool result for an original id maps (FIFO) to the k-th assistant call
-    # bearing that id. Generation is already complete, so the model never sees
-    # these ids.
+    # counter resets, so the same id (e.g. `functions_Bash_0`) recurs within a
+    # session — and, in a long enough session, within a single request, which a
+    # provider can reject or mispair. Transcript viewers that thread
+    # assistant-call<->tool-result on tool_call_id alone also collapse every
+    # reuse of an id into one node, rendering the linear chain as a spurious
+    # tree. Rewrite ids in place to be unique within the request while
+    # preserving pairing: the k-th tool result for an original id maps (FIFO)
+    # to the k-th assistant call bearing that id. Kimi resends the full history
+    # each request, so the rewrite is deterministic across requests; stripping
+    # any prior `__u<n>` suffix keeps it idempotent across bridge retries.
     pending: dict[str, list[str]] = {}
     counter = 0
     for message in messages:
         if isinstance(message, ChatMessageAssistant) and message.tool_calls:
             for tool_call in message.tool_calls:
                 original = tool_call.id
-                unique_id = f"{original}__{counter}"
+                base = _DEDUPE_SUFFIX_RE.sub("", original)
+                unique_id = f"{base}__u{counter}"
                 counter += 1
                 tool_call.id = unique_id
                 pending.setdefault(original, []).append(unique_id)
@@ -375,18 +426,31 @@ def _dedupe_tool_call_ids(messages: list[ChatMessage]) -> None:
 
 
 def _mcp_json(mcp_servers: Sequence[MCPServerConfig]) -> str:
+    # kimi's mcp.json accepts stdio, http, and sse servers, discriminated by a
+    # `transport` field that maps directly from the inspect config types.
     servers: dict[str, dict[str, object]] = {}
     for server in mcp_servers:
-        if not isinstance(server, MCPServerConfigStdio):
+        entry: dict[str, object]
+        if isinstance(server, MCPServerConfigStdio):
+            entry = {
+                "transport": "stdio",
+                "command": server.command,
+                "args": list(server.args),
+            }
+            if server.env:
+                entry["env"] = dict(server.env)
+            if server.cwd is not None:
+                entry["cwd"] = str(server.cwd)
+        elif isinstance(server, MCPServerConfigHTTP):
+            entry = {"transport": server.type, "url": server.url}
+            if server.headers:
+                entry["headers"] = dict(server.headers)
+        else:
             raise ValueError(
-                f"kimi_code only supports stdio MCP servers, got {type(server).__name__}"
+                f"Unsupported MCP server config type: {type(server).__name__}"
             )
-        entry: dict[str, object] = {
-            "command": server.command,
-            "args": list(server.args),
-        }
-        if server.env:
-            entry["env"] = dict(server.env)
+        if server.tools != "all":
+            entry["enabledTools"] = list(server.tools)
         servers[server.name] = entry
     return json.dumps({"mcpServers": servers}, indent=2)
 
@@ -401,7 +465,7 @@ def _config_toml(
 ) -> str:
     lines = ['default_model = "bridge"']
     if extra_skill_dirs:
-        dirs = ", ".join(f'"{d}"' for d in extra_skill_dirs)
+        dirs = ", ".join(_format_value(d) for d in extra_skill_dirs)
         lines.append(f"extra_skill_dirs = [{dirs}]")
     if skip_afk_prompt_injection:
         lines += ["", "[system]", "skip_afk_prompt_injection = true"]
@@ -426,14 +490,14 @@ def _config_toml(
             "",
             "[[permission.rules]]",
             'decision = "allow"',
-            f'pattern = "mcp__{server.name}__*"',
+            f"pattern = {_format_value(f'mcp__{server.name}__*')}",
         ]
     for tool in disallowed_tools:
         lines += [
             "",
             "[[permission.rules]]",
             'decision = "deny"',
-            f'pattern = "{tool}"',
+            f"pattern = {_format_value(tool)}",
         ]
     return "\n".join(lines) + "\n"
 

--- a/src/inspect_swe/_kimi_code/kimi_code.py
+++ b/src/inspect_swe/_kimi_code/kimi_code.py
@@ -1,0 +1,454 @@
+import json
+import re
+import shlex
+from pathlib import Path
+from textwrap import dedent
+from typing import Awaitable, Callable, Literal, Sequence, cast
+
+from inspect_ai.agent import (
+    Agent,
+    AgentAttempts,
+    AgentState,
+    BridgedToolsSpec,
+    agent,
+    agent_with,
+    sandbox_agent_bridge,
+)
+from inspect_ai.model import (
+    ChatMessage,
+    ChatMessageAssistant,
+    ChatMessageSystem,
+    ChatMessageTool,
+    ChatMessageUser,
+    ContentText,
+    GenerateConfig,
+    GenerateFilter,
+    Model,
+    ModelOutput,
+)
+from inspect_ai.model._model import GenerateInput
+from inspect_ai.scorer import score
+from inspect_ai.tool import (
+    MCPServerConfig,
+    MCPServerConfigStdio,
+    Skill,
+    ToolChoice,
+    ToolInfo,
+    install_skills,
+    read_skills,
+)
+from inspect_ai.util import sandbox as sandbox_env
+from inspect_ai.util import store
+from inspect_ai.util._sandbox import ExecRemoteAwaitableOptions
+
+from inspect_swe._util._async import is_callable_coroutine
+from inspect_swe._util.centaur import CentaurOptions, run_centaur
+from inspect_swe._util.messages import build_user_prompt
+from inspect_swe._util.trace import trace
+
+from .._util.agentbinary import ensure_agent_binary_installed
+from .._util.sandbox import resolve_agent_cwd
+from .agentbinary import kimi_code_binary_source
+
+# GenerateFilter is a union of Model-first and str-first callables; the bridge
+# dispatches Model-first filters (as used here), so we call through this form.
+_ModelFilter = Callable[
+    [Model, list[ChatMessage], list[ToolInfo], "ToolChoice | None", GenerateConfig],
+    Awaitable["ModelOutput | GenerateInput | None"],
+]
+
+KIMI_MAX_CONTEXT_SIZE = 262144
+
+# Kimi Code's CLI injects a <system-reminder> nagging the model not to repeat an
+# identical tool call. Re-polling the same read tool with the same arguments is
+# legitimate (a build hasn't finished, a status is still pending), so the nag is
+# a harness artifact rather than part of the task; strip it before the bridged
+# model sees it.
+_REPEAT_REMINDER_MARKER = "Repeated tool call detected"
+_REPEAT_REMINDER_RE = re.compile(
+    r"<system-reminder>(?:(?!</system-reminder>).)*?Repeated tool call detected.*?</system-reminder>",
+    re.DOTALL,
+)
+
+
+@agent
+def kimi_code(
+    name: str = "Kimi Code",
+    description: str = dedent("""
+        MoonshotAI Kimi Code terminal coding agent — reads and edits code, runs
+        shell commands, searches files, and iterates based on feedback.
+    """),
+    system_prompt: str | None = None,
+    skills: Sequence[str | Path | Skill] | None = None,
+    mcp_servers: Sequence[MCPServerConfig] | None = None,
+    bridged_tools: Sequence[BridgedToolsSpec] | None = None,
+    centaur: bool | CentaurOptions = False,
+    attempts: int | AgentAttempts = 1,
+    model: str | None = None,
+    model_aliases: dict[str, str | Model] | None = None,
+    filter: GenerateFilter | None = None,
+    retry_refusals: int | None = None,
+    disallowed_tools: Sequence[str] | None = None,
+    cwd: str | None = None,
+    env: dict[str, str] | None = None,
+    user: str | None = None,
+    sandbox: str | None = None,
+    version: Literal["auto", "sandbox", "stable", "latest"] | str = "auto",
+    debug: bool = False,
+) -> Agent:
+    """Kimi Code agent.
+
+    Agent that uses [Kimi Code](https://github.com/MoonshotAI/kimi-code)
+    running in a sandbox with Inspect model bridging.
+
+    Kimi's model calls are routed through a generated `config.toml` whose
+    `openai`-protocol provider points at the Inspect bridge, so the returned
+    transcript is the bridge's record of those calls (Kimi CLI stdout is not
+    parsed). MCP servers are wired natively via `mcp.json`.
+
+    Use the `attempts` option to enable additional submissions if the initial
+    submission(s) are incorrect (by default, no additional attempts are permitted).
+
+    Args:
+        name: Agent name (used in multi-agent systems with `as_tool()` and `handoff()`)
+        description: Agent description
+        system_prompt: Additional system prompt to append
+        skills: Additional [skills](https://inspect.aisi.org.uk/tools-standard.html#sec-skill) to make available to the agent.
+        mcp_servers: MCP servers to make available to the agent
+        bridged_tools: Host-side Inspect tools to expose to the agent via MCP
+        centaur: Run in 'centaur' mode, which makes Kimi Code available to an Inspect `human_cli()` agent rather than running it unattended.
+        attempts: Configure agent to make multiple attempts
+        model: Model name to use for inspect bridge (defaults to main model for task)
+        model_aliases: Optional mapping of model names to Model instances or model name strings.
+        filter: Filter for intercepting bridged model requests
+        retry_refusals: Should refusals be retried? (pass number of times to retry)
+        disallowed_tools: Tool names to deny via Kimi permission rules
+        cwd: Working directory to run kimi within
+        env: Environment variables to set for kimi
+        user: User to execute kimi with
+        sandbox: Optional sandbox environment name
+        version: Version of kimi to use. One of:
+            - "auto": Use any available version in sandbox, otherwise download latest
+            - "sandbox": Use sandbox version (raises RuntimeError if not available)
+            - "stable"/"latest": Download and use the latest version
+            - "x.x.x": Download and use a specific version
+        debug: Trace all debug output.
+    """
+    # resolve centaur
+    if centaur is True:
+        centaur = CentaurOptions()
+
+    # resolve model
+    bridge_model = f"inspect/{model}" if model is not None else "inspect"
+
+    # resolve skills / attempts
+    resolved_skills = read_skills(skills) if skills is not None else None
+    attempts = AgentAttempts(attempts) if isinstance(attempts, int) else attempts
+
+    resolved_disallowed = list(disallowed_tools or [])
+
+    async def execute(state: AgentState) -> AgentState:
+        # determine port (use new port for each execution of agent on sample)
+        MODEL_PORT = "kimi_code_model_port"
+        port = store().get(MODEL_PORT, 3100) + 1
+        store().set(MODEL_PORT, port)
+
+        async def combined_filter(
+            model: Model,
+            messages: list[ChatMessage],
+            tools: list[ToolInfo],
+            tool_choice: ToolChoice | None,
+            config: GenerateConfig,
+        ) -> ModelOutput | GenerateInput | None:
+            cleaned, changed = _strip_repeat_reminders(messages)
+            if filter is not None:
+                result = await cast(_ModelFilter, filter)(
+                    model, cleaned, tools, tool_choice, config
+                )
+                if result is not None:
+                    return result
+            if changed:
+                return GenerateInput(
+                    input=cleaned, tools=tools, tool_choice=tool_choice, config=config
+                )
+            return None
+
+        async with sandbox_agent_bridge(
+            state,
+            model=bridge_model,
+            model_aliases=model_aliases,
+            filter=combined_filter,
+            sandbox=sandbox,
+            retry_refusals=retry_refusals,
+            port=port,
+            bridged_tools=bridged_tools,
+        ) as bridge:
+            # resolve sandbox
+            sbox = sandbox_env(sandbox)
+            agent_cwd = await resolve_agent_cwd(sbox, user, cwd)
+
+            # install kimi in sandbox
+            kimi_binary = await ensure_agent_binary_installed(
+                kimi_code_binary_source(), version, user, sbox
+            )
+
+            # combine static mcp configs with bridged tools' mcp servers
+            all_mcp_servers = list(mcp_servers or []) + list(bridge.mcp_server_configs)
+
+            # detect sandbox home directory
+            home_result = await sbox.exec(["sh", "-c", "echo $HOME"], user=user)
+            sandbox_home = home_result.stdout.strip() or "/root"
+            kimi_home = f"{sandbox_home}/.kimi-code"
+            await sbox.exec(["mkdir", "-p", kimi_home], user=user)
+
+            # install skills (kimi discovers them via extra_skill_dirs)
+            skills_dir = f"{kimi_home}/skills"
+            if resolved_skills is not None:
+                await install_skills(resolved_skills, sbox, user, skills_dir)
+
+            # write config.toml (route the bridge provider) and mcp.json
+            await sbox.write_file(
+                f"{kimi_home}/config.toml",
+                _config_toml(
+                    port=bridge.port,
+                    mcp_servers=all_mcp_servers,
+                    disallowed_tools=resolved_disallowed,
+                    extra_skill_dirs=[skills_dir]
+                    if resolved_skills is not None
+                    else [],
+                ),
+            )
+            if all_mcp_servers:
+                await sbox.write_file(
+                    f"{kimi_home}/mcp.json", _mcp_json(all_mcp_servers)
+                )
+
+            # build the prompt (kimi -p takes a single message and has no
+            # separate system-prompt flag, so we prepend system messages)
+            system_messages = [
+                m.text for m in state.messages if isinstance(m, ChatMessageSystem)
+            ]
+            if system_prompt is not None:
+                system_messages.append(system_prompt)
+            prompt, has_assistant_response = build_user_prompt(state.messages)
+            if system_messages:
+                prompt = "\n\n".join(system_messages) + "\n\n" + prompt
+
+            cmd = [kimi_binary, "--output-format", "text"]
+
+            agent_env = {
+                "KIMI_CODE_HOME": kimi_home,
+                "HOME": sandbox_home,
+            } | (env or {})
+
+            if centaur:
+                await _run_kimi_code_centaur(
+                    options=centaur,
+                    kimi_cmd=cmd,
+                    agent_env=agent_env,
+                    state=state,
+                )
+            else:
+                debug_output: list[str] = []
+                agent_prompt = prompt
+                attempt_count = 0
+
+                while True:
+                    agent_cmd = cmd.copy()
+
+                    # continue previous conversation between attempts (or when
+                    # the inbound state already carries an assistant turn)
+                    if has_assistant_response or attempt_count > 0:
+                        agent_cmd.append("--continue")
+                    agent_cmd += ["-p", agent_prompt]
+
+                    result = await sbox.exec_remote(
+                        cmd=["bash", "-c", 'exec 0</dev/null; "$@"', "bash"]
+                        + agent_cmd,
+                        options=ExecRemoteAwaitableOptions(
+                            cwd=agent_cwd,
+                            env=agent_env,
+                            user=user,
+                            concurrency=False,
+                        ),
+                        stream=False,
+                    )
+
+                    if debug:
+                        debug_output.append(result.stdout)
+                        debug_output.append(result.stderr)
+
+                    if not result.success:
+                        raise RuntimeError(
+                            f"Error executing kimi code agent {result.returncode}:\n"
+                            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+                        )
+
+                    attempt_count += 1
+                    if attempt_count >= attempts.attempts:
+                        break
+
+                    answer_scores = await score(bridge.state)
+                    if attempts.score_value(answer_scores[0].value) == 1.0:
+                        break
+
+                    if callable(attempts.incorrect_message):
+                        if not is_callable_coroutine(attempts.incorrect_message):
+                            raise ValueError(
+                                "The incorrect_message function must be async."
+                            )
+                        agent_prompt = await attempts.incorrect_message(
+                            bridge.state, answer_scores
+                        )
+                    else:
+                        agent_prompt = attempts.incorrect_message
+
+                if debug:
+                    debug_output.insert(0, "Kimi Code Debug Output:")
+                    trace("\n".join(debug_output))
+
+        _dedupe_tool_call_ids(bridge.state.messages)
+        return bridge.state
+
+    return agent_with(execute, name=name, description=description)
+
+
+def _strip_repeat_reminders(
+    messages: list[ChatMessage],
+) -> tuple[list[ChatMessage], bool]:
+    if not any(_REPEAT_REMINDER_MARKER in m.text for m in messages):
+        return messages, False
+    cleaned: list[ChatMessage] = []
+    for message in messages:
+        if _REPEAT_REMINDER_MARKER not in message.text:
+            cleaned.append(message)
+            continue
+        if isinstance(message.content, str):
+            new_text = _REPEAT_REMINDER_RE.sub("", message.content).strip()
+            # Dropping a tool/assistant message would orphan a tool-call pairing;
+            # only user/system messages are safe to drop when they become empty.
+            if not new_text and isinstance(
+                message, (ChatMessageUser, ChatMessageSystem)
+            ):
+                continue
+            cleaned.append(message.model_copy(update={"content": new_text}))
+        else:
+            new_content = [
+                item.model_copy(
+                    update={"text": _REPEAT_REMINDER_RE.sub("", item.text).strip()}
+                )
+                if isinstance(item, ContentText)
+                else item
+                for item in message.content
+            ]
+            cleaned.append(message.model_copy(update={"content": new_content}))
+    return cleaned, True
+
+
+def _dedupe_tool_call_ids(messages: list[ChatMessage]) -> None:
+    # Kimi Code assigns tool_call_ids of the form `functions_<tool>_<n>` whose
+    # counter resets, so the same id (e.g. `functions_Bash_0`) recurs across a
+    # session. The bridge records those ids verbatim, so a transcript viewer that
+    # threads assistant-call<->tool-result on tool_call_id alone collapses every
+    # reuse of an id into one node — the linear chain renders as a spurious tree.
+    # Rewrite ids in place to be globally unique while preserving pairing: the
+    # k-th tool result for an original id maps (FIFO) to the k-th assistant call
+    # bearing that id. Generation is already complete, so the model never sees
+    # these ids.
+    pending: dict[str, list[str]] = {}
+    counter = 0
+    for message in messages:
+        if isinstance(message, ChatMessageAssistant) and message.tool_calls:
+            for tool_call in message.tool_calls:
+                original = tool_call.id
+                unique_id = f"{original}__{counter}"
+                counter += 1
+                tool_call.id = unique_id
+                pending.setdefault(original, []).append(unique_id)
+        elif isinstance(message, ChatMessageTool) and message.tool_call_id is not None:
+            queue = pending.get(message.tool_call_id)
+            if queue:
+                message.tool_call_id = queue.pop(0)
+
+
+def _mcp_json(mcp_servers: Sequence[MCPServerConfig]) -> str:
+    servers: dict[str, dict[str, object]] = {}
+    for server in mcp_servers:
+        if not isinstance(server, MCPServerConfigStdio):
+            raise ValueError(
+                f"kimi_code only supports stdio MCP servers, got {type(server).__name__}"
+            )
+        entry: dict[str, object] = {
+            "command": server.command,
+            "args": list(server.args),
+        }
+        if server.env:
+            entry["env"] = dict(server.env)
+        servers[server.name] = entry
+    return json.dumps({"mcpServers": servers}, indent=2)
+
+
+def _config_toml(
+    *,
+    port: int,
+    mcp_servers: Sequence[MCPServerConfig],
+    disallowed_tools: Sequence[str],
+    extra_skill_dirs: Sequence[str],
+) -> str:
+    lines = ['default_model = "bridge"']
+    if extra_skill_dirs:
+        dirs = ", ".join(f'"{d}"' for d in extra_skill_dirs)
+        lines.append(f"extra_skill_dirs = [{dirs}]")
+    lines += [
+        "",
+        "[providers.bridge]",
+        'type = "openai"',
+        f'base_url = "http://localhost:{port}/v1"',
+        'api_key = "sk-none"',
+        "",
+        "[models.bridge]",
+        'provider = "bridge"',
+        'model = "inspect"',
+        f"max_context_size = {KIMI_MAX_CONTEXT_SIZE}",
+    ]
+    # -p (prompt) mode auto-approves regular tool calls under the auto policy;
+    # make MCP tools explicitly allowed and honor disallowed_tools as static
+    # deny rules (deny wins). MCP tools are named mcp__<server>__<tool>; rules
+    # match MCP/custom tools by name.
+    for server in mcp_servers:
+        lines += [
+            "",
+            "[[permission.rules]]",
+            'decision = "allow"',
+            f'pattern = "mcp__{server.name}__*"',
+        ]
+    for tool in disallowed_tools:
+        lines += [
+            "",
+            "[[permission.rules]]",
+            'decision = "deny"',
+            f'pattern = "{tool}"',
+        ]
+    return "\n".join(lines) + "\n"
+
+
+async def _run_kimi_code_centaur(
+    options: CentaurOptions,
+    kimi_cmd: list[str],
+    agent_env: dict[str, str],
+    state: AgentState,
+) -> None:
+    instructions = (
+        "Kimi Code:\n\n"
+        " - You may also use Kimi Code via the 'kimi' command.\n"
+        " - Use 'kimi --continue' if you need to resume a previous kimi session."
+    )
+    # only export vars needed for the kimi alias, not HOME which would break
+    # human_cli.
+    centaur_env = {k: v for k, v in agent_env.items() if k != "HOME"}
+    agent_env_vars = [f'export {k}="{v}"' for k, v in centaur_env.items()]
+    alias_cmd = shlex.join(kimi_cmd)
+    alias_cmd = "alias kimi='" + alias_cmd.replace("'", "'\\''") + "'"
+    bashrc = "\n".join(agent_env_vars + ["", alias_cmd])
+
+    await run_centaur(options, instructions, bashrc, state)

--- a/src/inspect_swe/_kimi_code/kimi_code.py
+++ b/src/inspect_swe/_kimi_code/kimi_code.py
@@ -26,6 +26,8 @@ from inspect_ai.model import (
     GenerateFilter,
     Model,
     ModelOutput,
+    get_model,
+    get_model_info,
 )
 from inspect_ai.model._model import GenerateInput
 from inspect_ai.scorer import score
@@ -72,8 +74,6 @@ def _is_legacy_str_filter(fn: GenerateFilter) -> bool:
     return first is not None and first.annotation is str
 
 
-KIMI_MAX_CONTEXT_SIZE = 262144
-
 # Kimi Code's CLI appends escalating <system-reminder> nags to tool results when
 # it detects an identical tool call repeated N times in a row (tool-dedup: tier 1
 # at streak >= 3, tier 2 at >= 5, tier 3 "respond now" at >= 8, forced turn stop
@@ -114,11 +114,11 @@ def kimi_code(
     centaur: bool | CentaurOptions = False,
     attempts: int | AgentAttempts = 1,
     model: str | None = None,
+    max_context_size: int | None = None,
     model_aliases: dict[str, str | Model] | None = None,
     filter: GenerateFilter | None = None,
     retry_refusals: int | None = None,
     disallowed_tools: Sequence[str] | None = None,
-    skip_afk_prompt_injection: bool = False,
     cwd: str | None = None,
     env: dict[str, str] | None = None,
     user: str | None = None,
@@ -149,11 +149,13 @@ def kimi_code(
         centaur: Run in 'centaur' mode, which makes Kimi Code available to an Inspect `human_cli()` agent rather than running it unattended.
         attempts: Configure agent to make multiple attempts
         model: Model name to use for inspect bridge (defaults to main model for task)
+        max_context_size: Context window to configure for Kimi. Defaults to the
+            bridged model's context length from Inspect model metadata; required
+            when that metadata is unavailable.
         model_aliases: Optional mapping of model names to Model instances or model name strings.
         filter: Filter for intercepting bridged model requests
         retry_refusals: Should refusals be retried? (pass number of times to retry)
         disallowed_tools: Tool names to deny via Kimi permission rules
-        skip_afk_prompt_injection: Suppress Kimi Code's AFK-mode system reminder.
         cwd: Working directory to run kimi within
         env: Environment variables to set for kimi
         user: User to execute kimi with
@@ -180,6 +182,10 @@ def kimi_code(
     filter_is_legacy = filter is not None and _is_legacy_str_filter(filter)
 
     async def execute(state: AgentState) -> AgentState:
+        resolved_max_context_size = _resolve_max_context_size(
+            model=model, max_context_size=max_context_size
+        )
+
         # determine port (use new port for each execution of agent on sample)
         MODEL_PORT = "kimi_code_model_port"
         port = store().get(MODEL_PORT, 3100) + 1
@@ -256,13 +262,10 @@ def kimi_code(
                     extra_skill_dirs=[skills_dir]
                     if resolved_skills is not None
                     else [],
-                    skip_afk_prompt_injection=skip_afk_prompt_injection,
+                    max_context_size=resolved_max_context_size,
                 ),
             )
-            if all_mcp_servers:
-                await sbox.write_file(
-                    f"{kimi_home}/mcp.json", _mcp_json(all_mcp_servers)
-                )
+            await sbox.write_file(f"{kimi_home}/mcp.json", _mcp_json(all_mcp_servers))
 
             # build the prompt (kimi -p takes a single message and has no
             # separate system-prompt flag, so we prepend system messages)
@@ -455,20 +458,41 @@ def _mcp_json(mcp_servers: Sequence[MCPServerConfig]) -> str:
     return json.dumps({"mcpServers": servers}, indent=2)
 
 
+def _resolve_max_context_size(
+    *, model: str | None, max_context_size: int | None
+) -> int:
+    if max_context_size is not None:
+        if max_context_size <= 0:
+            raise ValueError("max_context_size must be a positive integer")
+        return max_context_size
+
+    resolved_model = get_model(model)
+    model_info = get_model_info(resolved_model)
+    if model_info is None or model_info.context_length is None:
+        raise ValueError(
+            f"Context length metadata is unavailable for model "
+            f"{resolved_model.name!r}; pass max_context_size explicitly."
+        )
+    if model_info.context_length <= 0:
+        raise ValueError(
+            f"Context length metadata for model {resolved_model.name!r} must be "
+            "positive; pass max_context_size explicitly."
+        )
+    return model_info.context_length
+
+
 def _config_toml(
     *,
     port: int,
     mcp_servers: Sequence[MCPServerConfig],
     disallowed_tools: Sequence[str],
     extra_skill_dirs: Sequence[str],
-    skip_afk_prompt_injection: bool = False,
+    max_context_size: int,
 ) -> str:
-    lines = ['default_model = "bridge"']
+    lines = ['default_model = "bridge"', "telemetry = false"]
     if extra_skill_dirs:
         dirs = ", ".join(_format_value(d) for d in extra_skill_dirs)
         lines.append(f"extra_skill_dirs = [{dirs}]")
-    if skip_afk_prompt_injection:
-        lines += ["", "[system]", "skip_afk_prompt_injection = true"]
     lines += [
         "",
         "[providers.bridge]",
@@ -479,7 +503,7 @@ def _config_toml(
         "[models.bridge]",
         'provider = "bridge"',
         'model = "inspect"',
-        f"max_context_size = {KIMI_MAX_CONTEXT_SIZE}",
+        f"max_context_size = {max_context_size}",
     ]
     # -p (prompt) mode auto-approves regular tool calls under the auto policy;
     # make MCP tools explicitly allowed and honor disallowed_tools as static

--- a/src/inspect_swe/_kimi_code/kimi_code.py
+++ b/src/inspect_swe/_kimi_code/kimi_code.py
@@ -398,7 +398,10 @@ def _strip_repeat_reminders(
                 for item in message.content
             ]
             cleaned.append(message.model_copy(update={"content": new_content}))
-    return cleaned, True
+    # AgentBridge tracks the original input list after generation, so update it
+    # in place to keep reminders out of both model input and returned state.
+    messages[:] = cleaned
+    return messages, True
 
 
 _DEDUPE_SUFFIX_RE = re.compile(r"__u\d+$")

--- a/src/inspect_swe/_kimi_code/kimi_code.py
+++ b/src/inspect_swe/_kimi_code/kimi_code.py
@@ -25,11 +25,11 @@ from inspect_ai.model import (
     ContentText,
     GenerateConfig,
     GenerateFilter,
+    GenerateInput,
     Model,
     ModelOutput,
     get_model_info,
 )
-from inspect_ai.model._model import GenerateInput
 from inspect_ai.scorer import score
 from inspect_ai.tool import (
     MCPServerConfig,

--- a/src/inspect_swe/_kimi_code/kimi_code.py
+++ b/src/inspect_swe/_kimi_code/kimi_code.py
@@ -89,6 +89,7 @@ def kimi_code(
     filter: GenerateFilter | None = None,
     retry_refusals: int | None = None,
     disallowed_tools: Sequence[str] | None = None,
+    skip_afk_prompt_injection: bool = False,
     cwd: str | None = None,
     env: dict[str, str] | None = None,
     user: str | None = None,
@@ -123,6 +124,7 @@ def kimi_code(
         filter: Filter for intercepting bridged model requests
         retry_refusals: Should refusals be retried? (pass number of times to retry)
         disallowed_tools: Tool names to deny via Kimi permission rules
+        skip_afk_prompt_injection: Suppress Kimi Code's AFK-mode system reminder.
         cwd: Working directory to run kimi within
         env: Environment variables to set for kimi
         user: User to execute kimi with
@@ -216,6 +218,7 @@ def kimi_code(
                     extra_skill_dirs=[skills_dir]
                     if resolved_skills is not None
                     else [],
+                    skip_afk_prompt_injection=skip_afk_prompt_injection,
                 ),
             )
             if all_mcp_servers:
@@ -394,11 +397,14 @@ def _config_toml(
     mcp_servers: Sequence[MCPServerConfig],
     disallowed_tools: Sequence[str],
     extra_skill_dirs: Sequence[str],
+    skip_afk_prompt_injection: bool = False,
 ) -> str:
     lines = ['default_model = "bridge"']
     if extra_skill_dirs:
         dirs = ", ".join(f'"{d}"' for d in extra_skill_dirs)
         lines.append(f"extra_skill_dirs = [{dirs}]")
+    if skip_afk_prompt_injection:
+        lines += ["", "[system]", "skip_afk_prompt_injection = true"]
     lines += [
         "",
         "[providers.bridge]",

--- a/src/inspect_swe/_registry.py
+++ b/src/inspect_swe/_registry.py
@@ -3,7 +3,15 @@
 from ._claude_code.claude_code import claude_code
 from ._codex_cli.codex_cli import codex_cli
 from ._gemini_cli.gemini_cli import gemini_cli
+from ._kimi_code.kimi_code import kimi_code
 from ._mini_swe_agent.mini_swe_agent import mini_swe_agent
 from ._opencode.opencode import opencode
 
-__all__ = ["codex_cli", "claude_code", "gemini_cli", "mini_swe_agent", "opencode"]
+__all__ = [
+    "codex_cli",
+    "claude_code",
+    "gemini_cli",
+    "kimi_code",
+    "mini_swe_agent",
+    "opencode",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -164,7 +164,12 @@ def get_available_sandboxes() -> List[Literal["docker", "k8s"]]:
 def run_example(
     example: str,
     agent: Literal[
-        "claude_code", "codex_cli", "gemini_cli", "mini_swe_agent", "opencode"
+        "claude_code",
+        "codex_cli",
+        "gemini_cli",
+        "kimi_code",
+        "mini_swe_agent",
+        "opencode",
     ],
     model: str,
     sandbox: str | None = None,

--- a/tests/test_bridged_tools.py
+++ b/tests/test_bridged_tools.py
@@ -35,6 +35,14 @@ def test_gemini_cli_bridged_tools() -> None:
 
 @skip_if_no_anthropic
 @skip_if_no_docker
+def test_kimi_code_bridged_tools() -> None:
+    check_bridged_tools(
+        "kimi_code", "anthropic/claude-sonnet-4-0", "mcp__secrets__secret_lookup"
+    )
+
+
+@skip_if_no_anthropic
+@skip_if_no_docker
 def test_opencode_bridged_tools() -> None:
     check_bridged_tools(
         "opencode", "anthropic/claude-sonnet-4-0", "secrets_secret_lookup"
@@ -42,7 +50,7 @@ def test_opencode_bridged_tools() -> None:
 
 
 def check_bridged_tools(
-    agent: Literal["claude_code", "codex_cli", "gemini_cli", "opencode"],
+    agent: Literal["claude_code", "codex_cli", "gemini_cli", "kimi_code", "opencode"],
     model: str,
     expected_tool_name: str,
 ) -> None:

--- a/tests/test_kimi_setup.py
+++ b/tests/test_kimi_setup.py
@@ -96,6 +96,17 @@ def test_config_toml_routes_bridge_and_wires_rules() -> None:
     assert 'decision = "allow"' in toml
     assert 'pattern = "WebFetch"' in toml
     assert 'decision = "deny"' in toml
+    assert "skip_afk_prompt_injection" not in toml
+
+    toml = _config_toml(
+        port=3123,
+        mcp_servers=[],
+        disallowed_tools=[],
+        extra_skill_dirs=[],
+        skip_afk_prompt_injection=True,
+    )
+    assert "[system]" in toml
+    assert "skip_afk_prompt_injection = true" in toml
 
 
 def test_mcp_json_shape_and_rejects_non_stdio() -> None:

--- a/tests/test_kimi_setup.py
+++ b/tests/test_kimi_setup.py
@@ -332,6 +332,7 @@ def test_strip_repeat_reminders_removes_nag_and_keeps_pairing() -> None:
         ]
         cleaned, changed = _strip_repeat_reminders(messages)
         assert changed is True
+        assert cleaned is messages
         assert all("<system-reminder>" not in m.text for m in cleaned)
         # tool/user messages preserved (pairing intact), user text retained
         assert len(cleaned) == 3

--- a/tests/test_kimi_setup.py
+++ b/tests/test_kimi_setup.py
@@ -2,7 +2,7 @@
 
 import json
 import re
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import anyio
 import pytest
@@ -13,6 +13,7 @@ from inspect_ai.model import (
     ChatMessageUser,
     GenerateConfig,
     Model,
+    ModelInfo,
     ModelOutput,
 )
 from inspect_ai.tool import (
@@ -28,6 +29,7 @@ from inspect_swe._kimi_code.kimi_code import (
     _dedupe_tool_call_ids,
     _is_legacy_str_filter,
     _mcp_json,
+    _resolve_max_context_size,
     _strip_repeat_reminders,
 )
 
@@ -97,6 +99,7 @@ def test_config_toml_routes_bridge_and_wires_rules() -> None:
         mcp_servers=[MCPServerConfigStdio(name="engine", command="serve", args=[])],
         disallowed_tools=["WebFetch"],
         extra_skill_dirs=["/root/.kimi-code/skills"],
+        max_context_size=131072,
     )
     assert 'base_url = "http://localhost:3123/v1"' in toml
     assert 'default_model = "bridge"' in toml
@@ -105,7 +108,8 @@ def test_config_toml_routes_bridge_and_wires_rules() -> None:
     assert 'decision = "allow"' in toml
     assert 'pattern = "WebFetch"' in toml
     assert 'decision = "deny"' in toml
-    assert "skip_afk_prompt_injection" not in toml
+    assert toml.startswith('default_model = "bridge"\ntelemetry = false\n')
+    assert "max_context_size = 131072" in toml
 
     # user-supplied strings are escaped rather than breaking the TOML
     toml = _config_toml(
@@ -113,18 +117,72 @@ def test_config_toml_routes_bridge_and_wires_rules() -> None:
         mcp_servers=[],
         disallowed_tools=['Web"Fetch\\x'],
         extra_skill_dirs=[],
+        max_context_size=8192,
     )
     assert 'pattern = "Web\\"Fetch\\\\x"' in toml
 
-    toml = _config_toml(
-        port=3123,
-        mcp_servers=[],
-        disallowed_tools=[],
-        extra_skill_dirs=[],
-        skip_afk_prompt_injection=True,
-    )
-    assert "[system]" in toml
-    assert "skip_afk_prompt_injection = true" in toml
+
+def test_resolve_max_context_size_uses_explicit_override() -> None:
+    with patch("inspect_swe._kimi_code.kimi_code.get_model") as mock_get_model:
+        assert (
+            _resolve_max_context_size(model="unknown/model", max_context_size=4096)
+            == 4096
+        )
+    mock_get_model.assert_not_called()
+
+
+def test_resolve_max_context_size_uses_model_metadata() -> None:
+    resolved_model = Mock(spec=Model)
+    resolved_model.name = "provider/model"
+    with (
+        patch(
+            "inspect_swe._kimi_code.kimi_code.get_model",
+            return_value=resolved_model,
+        ) as mock_get_model,
+        patch(
+            "inspect_swe._kimi_code.kimi_code.get_model_info",
+            return_value=ModelInfo(context_length=32768),
+        ) as mock_get_model_info,
+    ):
+        assert _resolve_max_context_size(model=None, max_context_size=None) == 32768
+    mock_get_model.assert_called_once_with(None)
+    mock_get_model_info.assert_called_once_with(resolved_model)
+
+
+@pytest.mark.parametrize(
+    "model_info", [None, ModelInfo(context_length=None), ModelInfo(context_length=0)]
+)
+def test_resolve_max_context_size_requires_metadata_or_override(
+    model_info: ModelInfo | None,
+) -> None:
+    resolved_model = Mock(spec=Model)
+    resolved_model.name = "provider/unknown"
+    with (
+        patch(
+            "inspect_swe._kimi_code.kimi_code.get_model",
+            return_value=resolved_model,
+        ),
+        patch(
+            "inspect_swe._kimi_code.kimi_code.get_model_info",
+            return_value=model_info,
+        ),
+        pytest.raises(ValueError, match="pass max_context_size explicitly"),
+    ):
+        _resolve_max_context_size(model="provider/unknown", max_context_size=None)
+
+
+@pytest.mark.parametrize("max_context_size", [0, -1])
+def test_resolve_max_context_size_rejects_invalid_override(
+    max_context_size: int,
+) -> None:
+    with pytest.raises(ValueError, match="must be a positive integer"):
+        _resolve_max_context_size(
+            model="provider/model", max_context_size=max_context_size
+        )
+
+
+def test_mcp_json_empty_shape() -> None:
+    assert json.loads(_mcp_json([])) == {"mcpServers": {}}
 
 
 def test_mcp_json_stdio_shape() -> None:

--- a/tests/test_kimi_setup.py
+++ b/tests/test_kimi_setup.py
@@ -1,0 +1,193 @@
+"""Unit tests for the Kimi Code agent binary source and config helpers."""
+
+import json
+import re
+from unittest.mock import AsyncMock, patch
+
+import anyio
+import pytest
+from inspect_ai.model import (
+    ChatMessage,
+    ChatMessageAssistant,
+    ChatMessageTool,
+    ChatMessageUser,
+)
+from inspect_ai.tool import MCPServerConfigHTTP, MCPServerConfigStdio, ToolCall
+from inspect_swe._kimi_code import agentbinary
+from inspect_swe._kimi_code.kimi_code import (
+    _config_toml,
+    _dedupe_tool_call_ids,
+    _mcp_json,
+    _strip_repeat_reminders,
+)
+
+from tests.conftest import skip_if_github_action
+
+_LATEST_JSON = json.dumps({"schemaVersion": 1, "version": "0.21.1"})
+_MANIFEST_JSON = json.dumps(
+    {
+        "version": "0.21.1",
+        "platforms": {
+            "linux-x64": {"filename": "kimi-code-linux-x64", "checksum": "aa" * 32},
+            "linux-arm64": {"filename": "kimi-code-linux-arm64", "checksum": "bb" * 32},
+        },
+    }
+)
+
+
+def test_resolve_version_latest_fetches_pointer_then_manifest() -> None:
+    source = agentbinary.kimi_code_binary_source()
+    with patch.object(
+        agentbinary,
+        "download_text_file",
+        AsyncMock(side_effect=[_LATEST_JSON, _MANIFEST_JSON]),
+    ) as mock_download:
+        resolved = anyio.run(source.resolve_version, "latest", "linux-x64")
+    assert resolved.version == "0.21.1"
+    assert resolved.expected_checksum == "aa" * 32
+    assert resolved.download_url == (
+        "https://code.kimi.com/kimi-code/binaries/0.21.1/kimi-code-linux-x64"
+    )
+    assert mock_download.await_count == 2
+
+
+def test_resolve_version_specific_skips_pointer() -> None:
+    source = agentbinary.kimi_code_binary_source()
+    with patch.object(
+        agentbinary, "download_text_file", AsyncMock(return_value=_MANIFEST_JSON)
+    ) as mock_download:
+        resolved = anyio.run(source.resolve_version, "0.21.1", "linux-arm64")
+    assert resolved.version == "0.21.1"
+    assert resolved.expected_checksum == "bb" * 32
+    assert resolved.download_url.endswith("/0.21.1/kimi-code-linux-arm64")
+    mock_download.assert_awaited_once()
+
+
+def test_platform_musl_collapses_to_glibc_key() -> None:
+    assert agentbinary._platform_to_kimi_platform("linux-x64-musl") == "linux-x64"
+    assert agentbinary._platform_to_kimi_platform("linux-arm64-musl") == "linux-arm64"
+
+
+def test_resolve_version_unknown_platform_raises() -> None:
+    source = agentbinary.kimi_code_binary_source()
+    with patch.object(
+        agentbinary, "download_text_file", AsyncMock(return_value=_MANIFEST_JSON)
+    ):
+        # manifest omits win32; requesting a linux platform absent from a manifest
+        manifest_no_linux = json.dumps({"version": "0.21.1", "platforms": {}})
+        with patch.object(
+            agentbinary, "download_text_file", AsyncMock(return_value=manifest_no_linux)
+        ):
+            with pytest.raises(RuntimeError, match="No Kimi Code binary"):
+                anyio.run(source.resolve_version, "0.21.1", "linux-x64")
+
+
+def test_config_toml_routes_bridge_and_wires_rules() -> None:
+    toml = _config_toml(
+        port=3123,
+        mcp_servers=[MCPServerConfigStdio(name="engine", command="serve", args=[])],
+        disallowed_tools=["WebFetch"],
+        extra_skill_dirs=["/root/.kimi-code/skills"],
+    )
+    assert 'base_url = "http://localhost:3123/v1"' in toml
+    assert 'default_model = "bridge"' in toml
+    assert 'extra_skill_dirs = ["/root/.kimi-code/skills"]' in toml
+    assert 'pattern = "mcp__engine__*"' in toml
+    assert 'decision = "allow"' in toml
+    assert 'pattern = "WebFetch"' in toml
+    assert 'decision = "deny"' in toml
+
+
+def test_mcp_json_shape_and_rejects_non_stdio() -> None:
+    parsed = json.loads(
+        _mcp_json(
+            [MCPServerConfigStdio(name="engine", command="serve", args=["--flag"])]
+        )
+    )
+    assert parsed == {
+        "mcpServers": {"engine": {"command": "serve", "args": ["--flag"]}}
+    }
+    with pytest.raises(ValueError, match="only supports stdio"):
+        _mcp_json([MCPServerConfigHTTP(name="remote", type="http", url="http://x")])
+
+
+def test_strip_repeat_reminders_removes_nag_and_keeps_pairing() -> None:
+    reminder = (
+        "<system-reminder>Repeated tool call detected: do not repeat.</system-reminder>"
+    )
+    messages: list[ChatMessage] = [
+        ChatMessageUser(content=f"check status\n\n{reminder}"),
+        ChatMessageAssistant(
+            content="polling",
+            tool_calls=[ToolCall(id="functions_Bash_0", function="Bash", arguments={})],
+        ),
+        ChatMessageTool(content=f"pending {reminder}", tool_call_id="functions_Bash_0"),
+    ]
+    cleaned, changed = _strip_repeat_reminders(messages)
+    assert changed is True
+    assert all("Repeated tool call detected" not in m.text for m in cleaned)
+    # tool/user messages preserved (pairing intact), user text retained
+    assert len(cleaned) == 3
+    assert cleaned[0].text == "check status"
+
+
+def test_strip_repeat_reminders_noop_when_absent() -> None:
+    messages: list[ChatMessage] = [ChatMessageUser(content="hello")]
+    cleaned, changed = _strip_repeat_reminders(messages)
+    assert changed is False
+    assert cleaned is messages
+
+
+def test_dedupe_tool_call_ids_makes_ids_unique_preserving_pairing() -> None:
+    messages: list[ChatMessage] = [
+        ChatMessageAssistant(
+            content="",
+            tool_calls=[ToolCall(id="functions_Bash_0", function="Bash", arguments={})],
+        ),
+        ChatMessageTool(content="a", tool_call_id="functions_Bash_0"),
+        ChatMessageAssistant(
+            content="",
+            tool_calls=[ToolCall(id="functions_Bash_0", function="Bash", arguments={})],
+        ),
+        ChatMessageTool(content="b", tool_call_id="functions_Bash_0"),
+    ]
+    _dedupe_tool_call_ids(messages)
+    call_ids = [
+        tc.id
+        for m in messages
+        if isinstance(m, ChatMessageAssistant) and m.tool_calls
+        for tc in m.tool_calls
+    ]
+    result_ids = [m.tool_call_id for m in messages if isinstance(m, ChatMessageTool)]
+    assert len(set(call_ids)) == 2
+    # each tool result still threads to its originating call (FIFO)
+    assert result_ids == call_ids
+
+
+@skip_if_github_action
+def test_live_distribution_manifest_shape() -> None:
+    """Drift check: Kimi's version pointer + manifest still expose linux binaries.
+
+    The binary source depends on ``latest.json`` carrying ``version`` and each
+    ``binaries/<version>/manifest.json`` carrying per-platform ``filename`` and
+    64-hex ``checksum``. This fetches the live endpoints and fails if that shape
+    changes. Skips when offline; github-action-gated so an upstream hiccup can't
+    block unrelated CI.
+    """
+    from inspect_swe._util.download import download_text_file
+
+    try:
+        version = anyio.run(agentbinary._fetch_latest_version)
+        manifest = anyio.run(agentbinary._fetch_manifest, version)
+    except Exception as ex:
+        pytest.skip(f"live Kimi distribution unavailable: {ex}")
+
+    platforms = manifest["platforms"]
+    for key in ("linux-x64", "linux-arm64"):
+        assert key in platforms, f"manifest missing platform {key}"
+        entry = platforms[key]
+        assert entry["filename"], "manifest entry missing filename"
+        assert re.fullmatch(r"[0-9a-f]{64}", entry["checksum"]), (
+            f"manifest checksum for {key} is not sha256 hex: {entry['checksum']!r}"
+        )
+    assert callable(download_text_file)

--- a/tests/test_kimi_setup.py
+++ b/tests/test_kimi_setup.py
@@ -2,6 +2,7 @@
 
 import json
 import re
+from importlib import import_module
 from unittest.mock import AsyncMock, Mock, patch
 
 import anyio
@@ -30,6 +31,7 @@ from inspect_swe._kimi_code.kimi_code import (
     _is_legacy_str_filter,
     _mcp_json,
     _resolve_max_context_size,
+    _resolve_model,
     _strip_repeat_reminders,
 )
 
@@ -45,6 +47,7 @@ _MANIFEST_JSON = json.dumps(
         },
     }
 )
+_KIMI_CODE_MODULE = import_module("inspect_swe._kimi_code.kimi_code")
 
 
 def test_resolve_version_latest_fetches_pointer_then_manifest() -> None:
@@ -99,6 +102,7 @@ def test_config_toml_routes_bridge_and_wires_rules() -> None:
         mcp_servers=[MCPServerConfigStdio(name="engine", command="serve", args=[])],
         disallowed_tools=["WebFetch"],
         extra_skill_dirs=["/root/.kimi-code/skills"],
+        model="openai/gpt-5",
         max_context_size=131072,
     )
     assert 'base_url = "http://localhost:3123/v1"' in toml
@@ -109,6 +113,7 @@ def test_config_toml_routes_bridge_and_wires_rules() -> None:
     assert 'pattern = "WebFetch"' in toml
     assert 'decision = "deny"' in toml
     assert toml.startswith('default_model = "bridge"\ntelemetry = false\n')
+    assert 'model = "openai/gpt-5"' in toml
     assert "max_context_size = 131072" in toml
 
     # user-supplied strings are escaped rather than breaking the TOML
@@ -117,35 +122,84 @@ def test_config_toml_routes_bridge_and_wires_rules() -> None:
         mcp_servers=[],
         disallowed_tools=['Web"Fetch\\x'],
         extra_skill_dirs=[],
+        model='alias"name',
         max_context_size=8192,
     )
     assert 'pattern = "Web\\"Fetch\\\\x"' in toml
+    assert 'model = "alias\\"name"' in toml
+
+
+@pytest.mark.parametrize(
+    ("model", "requested_model", "bridge_model"),
+    [
+        (None, "inspect", "inspect"),
+        ("openai/gpt-5", "openai/gpt-5", "inspect/openai/gpt-5"),
+    ],
+)
+def test_resolve_model_matches_bridge_resolution(
+    model: str | None, requested_model: str, bridge_model: str
+) -> None:
+    resolved_model = Mock(spec=Model)
+    with patch.object(
+        _KIMI_CODE_MODULE,
+        "resolve_inspect_model",
+        return_value=resolved_model,
+    ) as mock_resolve:
+        assert _resolve_model(model=model, model_aliases=None) is resolved_model
+    mock_resolve.assert_called_once_with(requested_model, None, bridge_model)
+
+
+def test_explicit_alias_drives_context_size() -> None:
+    aliased_model = Mock(spec=Model)
+    aliases: dict[str, str | Model] = {"fast": aliased_model}
+    with patch.object(
+        _KIMI_CODE_MODULE,
+        "get_model_info",
+        return_value=ModelInfo(context_length=65536),
+    ) as mock_get_model_info:
+        resolved_model = _resolve_model(model="fast", model_aliases=aliases)
+        assert resolved_model is aliased_model
+        assert (
+            _resolve_max_context_size(model=resolved_model, max_context_size=None)
+            == 65536
+        )
+    mock_get_model_info.assert_called_once_with(aliased_model)
+
+
+def test_resolve_model_does_not_hide_resolution_errors() -> None:
+    with (
+        patch.object(
+            _KIMI_CODE_MODULE,
+            "resolve_inspect_model",
+            side_effect=ValueError("unknown model"),
+        ),
+        pytest.raises(ValueError, match="unknown model"),
+    ):
+        _resolve_model(model="missing/model", model_aliases=None)
 
 
 def test_resolve_max_context_size_uses_explicit_override() -> None:
-    with patch("inspect_swe._kimi_code.kimi_code.get_model") as mock_get_model:
+    resolved_model = Mock(spec=Model)
+    with patch.object(_KIMI_CODE_MODULE, "get_model_info") as mock_get_model_info:
         assert (
-            _resolve_max_context_size(model="unknown/model", max_context_size=4096)
+            _resolve_max_context_size(model=resolved_model, max_context_size=4096)
             == 4096
         )
-    mock_get_model.assert_not_called()
+    mock_get_model_info.assert_not_called()
 
 
 def test_resolve_max_context_size_uses_model_metadata() -> None:
     resolved_model = Mock(spec=Model)
     resolved_model.name = "provider/model"
-    with (
-        patch(
-            "inspect_swe._kimi_code.kimi_code.get_model",
-            return_value=resolved_model,
-        ) as mock_get_model,
-        patch(
-            "inspect_swe._kimi_code.kimi_code.get_model_info",
-            return_value=ModelInfo(context_length=32768),
-        ) as mock_get_model_info,
-    ):
-        assert _resolve_max_context_size(model=None, max_context_size=None) == 32768
-    mock_get_model.assert_called_once_with(None)
+    with patch.object(
+        _KIMI_CODE_MODULE,
+        "get_model_info",
+        return_value=ModelInfo(context_length=32768),
+    ) as mock_get_model_info:
+        assert (
+            _resolve_max_context_size(model=resolved_model, max_context_size=None)
+            == 32768
+        )
     mock_get_model_info.assert_called_once_with(resolved_model)
 
 
@@ -158,26 +212,24 @@ def test_resolve_max_context_size_requires_metadata_or_override(
     resolved_model = Mock(spec=Model)
     resolved_model.name = "provider/unknown"
     with (
-        patch(
-            "inspect_swe._kimi_code.kimi_code.get_model",
-            return_value=resolved_model,
-        ),
-        patch(
-            "inspect_swe._kimi_code.kimi_code.get_model_info",
+        patch.object(
+            _KIMI_CODE_MODULE,
+            "get_model_info",
             return_value=model_info,
         ),
         pytest.raises(ValueError, match="pass max_context_size explicitly"),
     ):
-        _resolve_max_context_size(model="provider/unknown", max_context_size=None)
+        _resolve_max_context_size(model=resolved_model, max_context_size=None)
 
 
 @pytest.mark.parametrize("max_context_size", [0, -1])
 def test_resolve_max_context_size_rejects_invalid_override(
     max_context_size: int,
 ) -> None:
+    resolved_model = Mock(spec=Model)
     with pytest.raises(ValueError, match="must be a positive integer"):
         _resolve_max_context_size(
-            model="provider/model", max_context_size=max_context_size
+            model=resolved_model, max_context_size=max_context_size
         )
 
 

--- a/tests/test_kimi_setup.py
+++ b/tests/test_kimi_setup.py
@@ -11,12 +11,22 @@ from inspect_ai.model import (
     ChatMessageAssistant,
     ChatMessageTool,
     ChatMessageUser,
+    GenerateConfig,
+    Model,
+    ModelOutput,
 )
-from inspect_ai.tool import MCPServerConfigHTTP, MCPServerConfigStdio, ToolCall
+from inspect_ai.tool import (
+    MCPServerConfigHTTP,
+    MCPServerConfigStdio,
+    ToolCall,
+    ToolChoice,
+    ToolInfo,
+)
 from inspect_swe._kimi_code import agentbinary
 from inspect_swe._kimi_code.kimi_code import (
     _config_toml,
     _dedupe_tool_call_ids,
+    _is_legacy_str_filter,
     _mcp_json,
     _strip_repeat_reminders,
 )
@@ -63,23 +73,22 @@ def test_resolve_version_specific_skips_pointer() -> None:
     mock_download.assert_awaited_once()
 
 
-def test_platform_musl_collapses_to_glibc_key() -> None:
-    assert agentbinary._platform_to_kimi_platform("linux-x64-musl") == "linux-x64"
-    assert agentbinary._platform_to_kimi_platform("linux-arm64-musl") == "linux-arm64"
+def test_platform_musl_raises() -> None:
+    # kimi publishes glibc-only linux builds; musl must fail at resolution time
+    for platform in ("linux-x64-musl", "linux-arm64-musl"):
+        with pytest.raises(RuntimeError, match="glibc-only"):
+            agentbinary._platform_to_kimi_platform(platform)
 
 
 def test_resolve_version_unknown_platform_raises() -> None:
     source = agentbinary.kimi_code_binary_source()
+    # requesting a linux platform absent from a manifest
+    manifest_no_linux = json.dumps({"version": "0.21.1", "platforms": {}})
     with patch.object(
-        agentbinary, "download_text_file", AsyncMock(return_value=_MANIFEST_JSON)
+        agentbinary, "download_text_file", AsyncMock(return_value=manifest_no_linux)
     ):
-        # manifest omits win32; requesting a linux platform absent from a manifest
-        manifest_no_linux = json.dumps({"version": "0.21.1", "platforms": {}})
-        with patch.object(
-            agentbinary, "download_text_file", AsyncMock(return_value=manifest_no_linux)
-        ):
-            with pytest.raises(RuntimeError, match="No Kimi Code binary"):
-                anyio.run(source.resolve_version, "0.21.1", "linux-x64")
+        with pytest.raises(RuntimeError, match="No Kimi Code binary"):
+            anyio.run(source.resolve_version, "0.21.1", "linux-x64")
 
 
 def test_config_toml_routes_bridge_and_wires_rules() -> None:
@@ -98,6 +107,15 @@ def test_config_toml_routes_bridge_and_wires_rules() -> None:
     assert 'decision = "deny"' in toml
     assert "skip_afk_prompt_injection" not in toml
 
+    # user-supplied strings are escaped rather than breaking the TOML
+    toml = _config_toml(
+        port=3123,
+        mcp_servers=[],
+        disallowed_tools=['Web"Fetch\\x'],
+        extra_skill_dirs=[],
+    )
+    assert 'pattern = "Web\\"Fetch\\\\x"' in toml
+
     toml = _config_toml(
         port=3123,
         mcp_servers=[],
@@ -109,37 +127,117 @@ def test_config_toml_routes_bridge_and_wires_rules() -> None:
     assert "skip_afk_prompt_injection = true" in toml
 
 
-def test_mcp_json_shape_and_rejects_non_stdio() -> None:
+def test_mcp_json_stdio_shape() -> None:
     parsed = json.loads(
         _mcp_json(
-            [MCPServerConfigStdio(name="engine", command="serve", args=["--flag"])]
+            [
+                MCPServerConfigStdio(
+                    name="engine",
+                    command="serve",
+                    args=["--flag"],
+                    cwd="/srv/engine",
+                    tools=["query", "status"],
+                )
+            ]
         )
     )
     assert parsed == {
-        "mcpServers": {"engine": {"command": "serve", "args": ["--flag"]}}
+        "mcpServers": {
+            "engine": {
+                "transport": "stdio",
+                "command": "serve",
+                "args": ["--flag"],
+                "cwd": "/srv/engine",
+                "enabledTools": ["query", "status"],
+            }
+        }
     }
-    with pytest.raises(ValueError, match="only supports stdio"):
-        _mcp_json([MCPServerConfigHTTP(name="remote", type="http", url="http://x")])
+
+
+def test_mcp_json_http_shape() -> None:
+    # bridged tools arrive as MCPServerConfigHTTP (the bridge's own MCP
+    # endpoint); kimi supports remote servers natively via transport http/sse
+    parsed = json.loads(
+        _mcp_json(
+            [
+                MCPServerConfigHTTP(
+                    name="bridged",
+                    type="http",
+                    url="http://localhost:3101/mcp/bridged",
+                    headers={"Authorization": "Bearer tok"},
+                )
+            ]
+        )
+    )
+    assert parsed == {
+        "mcpServers": {
+            "bridged": {
+                "transport": "http",
+                "url": "http://localhost:3101/mcp/bridged",
+                "headers": {"Authorization": "Bearer tok"},
+            }
+        }
+    }
+
+
+# reminder wordings by kimi-code era (rewritten in 0.23.4) and escalation tier
+_REMINDERS_STRIPPED = [
+    # >= 0.23.4, tiers 1-2
+    "<system-reminder>\nThe same tool call has been repeated several times in a "
+    "row. Before your next call, write one sentence stating what new information "
+    "you expect it to produce.\n</system-reminder>",
+    "<system-reminder>\nThe same tool call has now been issued 5 times in a row. "
+    "Choose exactly one of the following and state your choice before acting.\n"
+    "</system-reminder>",
+    # < 0.23.4, tiers 1-2
+    "<system-reminder>\nYou are repeating the exact same tool call with identical "
+    "parameters. Please carefully analyze the previous result.\n</system-reminder>",
+    "<system-reminder>\nYou have repeatedly called the same tool with identical "
+    "parameters many times.\nRepeated tool call detected:\n- tool: Bash\n"
+    "</system-reminder>",
+]
+# tier 3 precedes kimi's forced turn stop (streak >= 12) and must be preserved
+_REMINDERS_KEPT = [
+    "<system-reminder>\nWrite your final response now, without any further tool "
+    "calls.\n</system-reminder>",
+    "<system-reminder>\nYou are stuck in a dead end and have repeatedly made the "
+    "same function call without progress.\nStop all function calls immediately.\n"
+    "</system-reminder>",
+]
 
 
 def test_strip_repeat_reminders_removes_nag_and_keeps_pairing() -> None:
-    reminder = (
-        "<system-reminder>Repeated tool call detected: do not repeat.</system-reminder>"
-    )
-    messages: list[ChatMessage] = [
-        ChatMessageUser(content=f"check status\n\n{reminder}"),
-        ChatMessageAssistant(
-            content="polling",
-            tool_calls=[ToolCall(id="functions_Bash_0", function="Bash", arguments={})],
-        ),
-        ChatMessageTool(content=f"pending {reminder}", tool_call_id="functions_Bash_0"),
-    ]
-    cleaned, changed = _strip_repeat_reminders(messages)
-    assert changed is True
-    assert all("Repeated tool call detected" not in m.text for m in cleaned)
-    # tool/user messages preserved (pairing intact), user text retained
-    assert len(cleaned) == 3
-    assert cleaned[0].text == "check status"
+    for reminder in _REMINDERS_STRIPPED:
+        messages: list[ChatMessage] = [
+            ChatMessageUser(content=f"check status\n\n{reminder}"),
+            ChatMessageAssistant(
+                content="polling",
+                tool_calls=[
+                    ToolCall(id="functions_Bash_0", function="Bash", arguments={})
+                ],
+            ),
+            ChatMessageTool(
+                content=f"pending {reminder}", tool_call_id="functions_Bash_0"
+            ),
+        ]
+        cleaned, changed = _strip_repeat_reminders(messages)
+        assert changed is True
+        assert all("<system-reminder>" not in m.text for m in cleaned)
+        # tool/user messages preserved (pairing intact), user text retained
+        assert len(cleaned) == 3
+        assert cleaned[0].text == "check status"
+
+
+def test_strip_repeat_reminders_keeps_final_response_tier() -> None:
+    for reminder in _REMINDERS_KEPT:
+        messages: list[ChatMessage] = [
+            ChatMessageTool(
+                content=f"pending {reminder}", tool_call_id="functions_Bash_0"
+            ),
+        ]
+        cleaned, changed = _strip_repeat_reminders(messages)
+        assert changed is False
+        assert cleaned is messages
 
 
 def test_strip_repeat_reminders_noop_when_absent() -> None:
@@ -173,6 +271,41 @@ def test_dedupe_tool_call_ids_makes_ids_unique_preserving_pairing() -> None:
     assert len(set(call_ids)) == 2
     # each tool result still threads to its originating call (FIFO)
     assert result_ids == call_ids
+
+    # idempotent: a second pass (bridge retry) must not grow suffixes
+    _dedupe_tool_call_ids(messages)
+    assert [
+        tc.id
+        for m in messages
+        if isinstance(m, ChatMessageAssistant) and m.tool_calls
+        for tc in m.tool_calls
+    ] == call_ids
+    assert [
+        m.tool_call_id for m in messages if isinstance(m, ChatMessageTool)
+    ] == result_ids
+
+
+def test_is_legacy_str_filter_dispatch() -> None:
+    async def legacy(
+        model: str,
+        messages: list[ChatMessage],
+        tools: list[ToolInfo],
+        tool_choice: ToolChoice | None,
+        config: GenerateConfig,
+    ) -> ModelOutput | None:
+        return None
+
+    async def modern(
+        model: Model,
+        messages: list[ChatMessage],
+        tools: list[ToolInfo],
+        tool_choice: ToolChoice | None,
+        config: GenerateConfig,
+    ) -> ModelOutput | None:
+        return None
+
+    assert _is_legacy_str_filter(legacy) is True
+    assert _is_legacy_str_filter(modern) is False
 
 
 @skip_if_github_action


### PR DESCRIPTION
## Summary

Adds a `kimi_code()` agent for Moonshot AI's [Kimi Code](https://github.com/MoonshotAI/kimi-code) CLI, running headless in a sandbox with Inspect model bridging — the same shape as the existing `opencode()` / `claude_code()` agents. Closes #72.

Kimi's model calls are routed through a generated `~/.kimi-code/config.toml` whose `openai`-protocol provider points at the Inspect bridge, so the returned transcript is the bridge's record of those calls (Kimi CLI stdout is never parsed). MCP servers are wired natively via `~/.kimi-code/mcp.json`.

## What's included

**`_kimi_code/kimi_code.py`** — the agent. Writes `config.toml` (bridge provider + permission rules) and `mcp.json`, prepends system messages to the prompt (kimi `-p` has no separate system-prompt flag), runs `kimi --output-format text [--continue] -p <prompt>`, and returns `bridge.state`. Full parity with the other agents:
- `system_prompt`, `mcp_servers`, `bridged_tools`, `filter`, `model` / `model_aliases`, `retry_refusals`, `cwd` (via the shared `resolve_agent_cwd`), `env`, `user`, `sandbox`.
- `skills` — installed into `~/.kimi-code/skills` and surfaced through kimi's `extra_skill_dirs` config.
- `centaur` — exposes a `kimi` alias to an Inspect `human_cli()` agent.
- `attempts` — multiple scored attempts with `--continue` between them.
- `disallowed_tools` — denied via kimi's native `[[permission.rules]]` (deny wins).

**`_kimi_code/agentbinary.py`** — binary download via the shared `AgentBinarySource`, so `version` supports `auto` / `sandbox` / `latest` / `x.x.x`. Kimi publishes a `latest.json` version pointer and a per-version `binaries/<version>/manifest.json` carrying each platform's filename + sha256, which drives resolution and checksum verification.

**Two Kimi-specific fixups** (in `kimi_code.py`):
- `_dedupe_tool_call_ids` — kimi assigns tool_call_ids like `functions_Bash_0` whose counter resets, so ids recur across a session. The bridge records them verbatim, so a viewer that threads on tool_call_id collapses every reuse into one node (a linear chain renders as a spurious tree — same class as #33). Rewrites ids to be globally unique post-generation while preserving assistant↔tool pairing.
- Repeat-reminder strip — kimi's CLI injects a `<system-reminder>Repeated tool call detected…</system-reminder>` nag. Re-polling the same read tool is legitimate in long-horizon tasks, so this strips the nag before the bridged model sees it. Composed with any user-supplied `filter`. **This one is mildly opinionated** — happy to gate it behind an option or drop it if you'd prefer.

Also registered in `__init__.py` / `_registry.py`, `docs/kimi_code.qmd` (+ nav + index), and `CHANGELOG.md`.

## Tests

`tests/test_kimi_setup.py` — 10 tests: version resolution (latest pointer → manifest, and specific-version), platform mapping (incl. musl→glibc collapse) and unknown-platform error, `config.toml` / `mcp.json` generation, and both fixups (reminder strip preserving pairing, tool_call_id dedupe preserving FIFO pairing). Includes a network-gated live drift-check asserting kimi's `latest.json` + `manifest.json` still expose linux binaries with sha256 checksums.

Locally green: `ruff check`, `ruff format --check`, `mypy src tests`, `pytest tests/test_kimi_setup.py`.

**End-to-end smoke test** (docker sandbox, `python:3.12-bookworm`, `version="latest"`, bridged to `anthropic/claude-sonnet-4-5`): a one-sample task asking the agent to write `/root/answer.txt`. The agent downloaded the current binary (0.21.1), ran headless, used its native `Write` tool through the bridge, and the file-based scorer confirmed the contents — `accuracy 1.000`. Transcript threading and the tool_call_id dedupe both applied correctly.

## Notes / limitations

- The runtime path is adapted from an implementation that's been running in production RL rollouts. The full agent — including the new **upstream binary-download path** (`agentbinary.py`) — was exercised end-to-end via the smoke test above; it has not been run at scale or against a broad task suite.
- kimi ships glibc linux builds keyed by arch only (no musl variants), so musl sandbox platforms are collapsed onto the plain `linux-x64` / `linux-arm64` keys.

