### PR TITLE
Update ACP client for agent-client-protocol 0.11.0 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- ACP: Compatibility with `agent-client-protocol` 0.11.0 — match the revised `Client` interface signatures and implement the new elicitation methods (rejected as an unsupported capability, like fs/terminal). Requires `agent-client-protocol>=0.11.0`.
+
 ## 0.2.65 (05 July 2026)
 
 - Codex CLI and Claude Code: Support checkpointing and resuming runs via `checkpointer()`, restoring session/attempt state across resumes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "sniffio",
     "anyio",
     "typing_extensions>=4.9.0",
-    "agent-client-protocol>=0.10.1",
+    "agent-client-protocol>=0.11.0",
 ]
 
 [project.urls]

--- a/src/inspect_swe/acp/client.py
+++ b/src/inspect_swe/acp/client.py
@@ -14,13 +14,17 @@ from acp.client.connection import ClientSideConnection
 from acp.interfaces import Client
 from acp.schema import (
     AgentMessageChunk,
+    AgentPlanContentUpdate,
+    AgentPlanRemovedUpdate,
     AgentPlanUpdate,
     AgentThoughtChunk,
     AllowedOutcome,
     AvailableCommandsUpdate,
     ConfigOptionUpdate,
+    CreateElicitationResponse,
     CreateTerminalResponse,
     CurrentModeUpdate,
+    ElicitationMode,
     EnvVariable,
     KillTerminalResponse,
     PermissionOption,
@@ -62,9 +66,9 @@ class DefaultClient(Client):
 
     async def request_permission(
         self,
-        options: list[PermissionOption],
         session_id: str,
         tool_call: ToolCallUpdate,
+        options: list[PermissionOption],
         **kwargs: Any,
     ) -> RequestPermissionResponse:
         for kind in ("allow_always", "allow_once"):
@@ -96,6 +100,8 @@ class DefaultClient(Client):
         | ToolCallStart
         | ToolCallProgress
         | AgentPlanUpdate
+        | AgentPlanContentUpdate
+        | AgentPlanRemovedUpdate
         | AvailableCommandsUpdate
         | CurrentModeUpdate
         | ConfigOptionUpdate
@@ -107,26 +113,26 @@ class DefaultClient(Client):
 
     async def read_text_file(
         self,
-        path: str,
         session_id: str,
-        limit: int | None = None,
+        path: str,
         line: int | None = None,
+        limit: int | None = None,
         **kwargs: Any,
     ) -> ReadTextFileResponse:
         raise _unsupported_capability_request("fs/read_text_file")
 
     async def write_text_file(
-        self, content: str, path: str, session_id: str, **kwargs: Any
+        self, session_id: str, path: str, content: str, **kwargs: Any
     ) -> WriteTextFileResponse | None:
         raise _unsupported_capability_request("fs/write_text_file")
 
     async def create_terminal(
         self,
-        command: str,
         session_id: str,
+        command: str,
         args: list[str] | None = None,
-        cwd: str | None = None,
         env: list[EnvVariable] | None = None,
+        cwd: str | None = None,
         output_byte_limit: int | None = None,
         **kwargs: Any,
     ) -> CreateTerminalResponse:
@@ -151,6 +157,14 @@ class DefaultClient(Client):
         self, session_id: str, terminal_id: str, **kwargs: Any
     ) -> KillTerminalResponse | None:
         raise _unsupported_capability_request("terminal/kill")
+
+    async def create_elicitation(
+        self, message: str, mode: ElicitationMode, **kwargs: Any
+    ) -> CreateElicitationResponse:
+        raise _unsupported_capability_request("elicitation/create")
+
+    async def complete_elicitation(self, elicitation_id: str, **kwargs: Any) -> None:
+        pass
 
     async def ext_method(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
         raise _unsupported_capability_request(method)

--- a/tests/test_claude_code_exit.py
+++ b/tests/test_claude_code_exit.py
@@ -1,6 +1,6 @@
 import pytest
 from inspect_ai.event._model import ModelEvent
-from inspect_ai.model import GenerateConfig, ModelOutput
+from inspect_ai.model import GenerateConfig, ModelOutput, StopReason
 from inspect_swe._claude_code._events.live_consumer import LiveConsumer
 from inspect_swe._claude_code.claude_code import _is_claude_code_refusal_exit
 
@@ -22,7 +22,7 @@ from inspect_swe._claude_code.claude_code import _is_claude_code_refusal_exit
 def test_is_claude_code_refusal_exit(
     exit_code: int,
     stderr_data: str,
-    stop_reason: str | None,
+    stop_reason: StopReason | None,
     expected: bool,
 ) -> None:
     assert (

--- a/uv.lock
+++ b/uv.lock
@@ -12,14 +12,14 @@ resolution-markers = [
 
 [[package]]
 name = "agent-client-protocol"
-version = "0.10.1"
+version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/88/a0/3b96cd8374725c69bc3dae9fcc2082f3f6cafec1be35d24d7af0f8c3265f/agent_client_protocol-0.10.1.tar.gz", hash = "sha256:355c65ca19f0568344aafc2c1552b7066a8fc491df23ab28e7e253c6c9a85a25", size = 81924, upload-time = "2026-05-24T18:46:44.444Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/93/396d02c91b387b2678f23081869ca47bd495fc6c78789022c683180cf5f1/agent_client_protocol-0.11.0.tar.gz", hash = "sha256:8920a3b27bdcc852fd7c73066f47ab53257dbfbe57b505e20a40c69f80a5391c", size = 87402, upload-time = "2026-07-05T17:07:56.803Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/18/d8c7ff337cf621ea79a84006a7252ff057bfb5767549bb102cc6649f4ec2/agent_client_protocol-0.10.1-py3-none-any.whl", hash = "sha256:a03d3198f4d772f2e0ec012c00ac1cce131b4710220a3dc9fae3c991d047c750", size = 65401, upload-time = "2026-05-24T18:46:43.202Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/48/a1367dded7765f5489f9840389949d5aeac53a73aeb1b4e6c0ab61e1617a/agent_client_protocol-0.11.0-py3-none-any.whl", hash = "sha256:2d8570cd4911f8af9fbab4808f7b05f09204a756f346c7409ecdcae3f37cdb2f", size = 68089, upload-time = "2026-07-05T17:07:55.518Z" },
 ]
 
 [[package]]
@@ -1339,7 +1339,7 @@ doc = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agent-client-protocol", specifier = ">=0.10.1" },
+    { name = "agent-client-protocol", specifier = ">=0.11.0" },
     { name = "anthropic", marker = "extra == 'dev'" },
     { name = "anyio" },
     { name = "griffe", marker = "extra == 'dev'", specifier = ">=2" },


### PR DESCRIPTION
## Summary
Updates the ACP client implementation to be compatible with `agent-client-protocol` 0.11.0, which includes revised `Client` interface signatures and new elicitation functionality.

## Key Changes
- **Updated method signatures** to match the revised `Client` interface:
  - `request_permission()`: Reordered parameters to `(session_id, tool_call, options, **kwargs)`
  - `read_text_file()`: Reordered parameters to `(session_id, path, line, limit, **kwargs)`
  - `write_text_file()`: Reordered parameters to `(session_id, path, content, **kwargs)`
  - `create_terminal()`: Reordered parameters to `(session_id, command, args, env, cwd, output_byte_limit, **kwargs)`

- **Added new schema imports** for elicitation support:
  - `AgentPlanContentUpdate` and `AgentPlanRemovedUpdate` for plan updates
  - `CreateElicitationResponse` and `ElicitationMode` for elicitation functionality

- **Implemented new elicitation methods**:
  - `create_elicitation()`: Raises unsupported capability error (consistent with fs/terminal handling)
  - `complete_elicitation()`: No-op implementation

- **Updated session_update type hints** to include the new plan update types (`AgentPlanContentUpdate`, `AgentPlanRemovedUpdate`)

- **Updated dependency requirement** to `agent-client-protocol>=0.11.0`

- **Fixed type annotation** in test file: Changed `stop_reason: str | None` to `stop_reason: StopReason | None` for proper type safety

## Implementation Details
The elicitation methods follow the same pattern as other unsupported capabilities (fs/terminal operations), raising `_unsupported_capability_request()` errors to indicate they are not implemented by this client.

https://claude.ai/code/session_014cUZQ5vFCUnXjGDfgFtPtk