### PR TITLE
fix: update ACP client for agent-client-protocol 0.11.0 compatibility (#76)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-## Unreleased
-
-- ACP: Compatibility with `agent-client-protocol` 0.11.0 — match the revised `Client` interface signatures and implement the new elicitation methods (rejected as an unsupported capability, like fs/terminal). Requires `agent-client-protocol>=0.11.0`.
-
 ## 0.2.65 (05 July 2026)
 
 - Codex CLI and Claude Code: Support checkpointing and resuming runs via `checkpointer()`, restoring session/attempt state across resumes.


### PR DESCRIPTION
Catch-up release credit for **#76** (ACP 0.11.0 compatibility — revised `Client` interface signatures, new elicitation methods, requires `agent-client-protocol>=0.11.0`), which merged after the `0.2.65` tag but with a non-conventional squash title, so Release Please can't surface it.

- This PR's title is the conventional-commit credit — on merge, RP opens a **`0.2.66`** release PR (patch-pre-major, bare tag) with it in the notes.
- The diff removes the stale hand-maintained `## Unreleased` section that recorded it (Release Please owns the changelog now — same cleanup scout got in #516).

Code change is docs-only; the actual fix already lives on `main` via #76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)