### PR TITLE
docs: add Changelog title so release-please inserts new sections at the top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# Changelog
+
 ## [0.2.66](https://github.com/meridianlabs-ai/inspect_swe/compare/0.2.65...0.2.66) (2026-07-14)
 
 


### PR DESCRIPTION
Permanent fix for the changelog mis-ordering quirk (new release sections landing *below* the previous one).

Root cause, verified in release-please's source: the changelog updater inserts the new section before the first version header **preceded by a newline** (`\n###? v?[0-9[]`). A version header on **line 1** never matches, so the insert lands after it. Repos whose changelogs start with `# Changelog` (flow/harbor/sandboxes/vscode) have always ordered correctly; this brings the legacy hand-written changelogs in line by adding the same title line.

One-line diff; `docs:` so it's hidden from notes and doesn't trigger a release. If a release PR is open, this merge regenerates it — with the new section correctly at the top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)