### PR TITLE
feat: add antigravity_cli agent

### DIFF
--- a/src/inspect_swe/__init__.py
+++ b/src/inspect_swe/__init__.py
@@ -1,5 +1,6 @@
 from ._claude_code.claude_code import claude_code
 from ._codex_cli.codex_cli import codex_cli
+from ._antigravity_cli.antigravity_cli import antigravity_cli
 from ._gemini_cli.gemini_cli import gemini_cli
 from ._mini_swe_agent.mini_swe_agent import mini_swe_agent
 from ._opencode.opencode import opencode
@@ -25,6 +26,7 @@ __all__ = [
     "bridge_mcp_to_acp",
     "claude_code",
     "codex_cli",
+    "antigravity_cli",
     "gemini_cli",
     "mini_swe_agent",
     "opencode",

--- a/src/inspect_swe/_antigravity_cli/__init__.py
+++ b/src/inspect_swe/_antigravity_cli/__init__.py
@@ -1,0 +1,3 @@
+from .antigravity_cli import antigravity_cli
+
+__all__ = ["antigravity_cli"]

--- a/src/inspect_swe/_antigravity_cli/_addon.py
+++ b/src/inspect_swe/_antigravity_cli/_addon.py
@@ -1,0 +1,197 @@
+"""mitmproxy addon: route agy's Vertex :streamGenerateContent to the Inspect
+bridge model_proxy (dynamic port). Everything else passes through to Google.
+
+Uses ``requests`` (bundled with the mitmproxy standalone binary) run off the
+event loop via ``run_in_executor``, not ``httpx``: the standalone binary's
+embedded Python environment does not ship httpx (or anyio), only requests.
+"""
+
+import asyncio  # noqa: ANYIO_OK -- anyio is not present in mitmdump's embedded env
+import functools
+import json
+import os
+import re
+from typing import TypeAlias
+
+import requests
+from mitmproxy import http
+
+BRIDGE_PORT = int(os.environ.get("ANTIGRAVITY_BRIDGE_PORT", "13131"))
+_MODEL_RE = re.compile(r"models/([^/:]+)")
+
+# Vertex/Gemini's Schema proto uses SCREAMING_SNAKE_CASE type names for the
+# JSON Schema "type" keyword in tool declarations; the bridge's ToolParams
+# model expects lowercase JSON Schema type strings.
+_SCHEMA_TYPE_NAMES = frozenset(
+    {"STRING", "NUMBER", "INTEGER", "BOOLEAN", "ARRAY", "OBJECT", "NULL"}
+)
+
+JsonValue: TypeAlias = (
+    "dict[str, JsonValue] | list[JsonValue] | str | int | float | bool | None"
+)
+
+
+def _lowercase_schema_type(value: JsonValue) -> JsonValue:
+    if isinstance(value, str):
+        return value.lower() if value in _SCHEMA_TYPE_NAMES else value
+    if isinstance(value, list):
+        return [_lowercase_schema_type(item) for item in value]
+    return value
+
+
+def _lowercase_schema_types(value: JsonValue) -> JsonValue:
+    if isinstance(value, dict):
+        return {
+            key: _lowercase_schema_type(inner)
+            if key == "type"
+            else _lowercase_schema_types(inner)
+            for key, inner in value.items()
+        }
+    if isinstance(value, list):
+        return [_lowercase_schema_types(item) for item in value]
+    return value
+
+
+def _lowercase_tool_schema_types(body: dict[str, JsonValue]) -> dict[str, JsonValue]:
+    tools = body.get("tools")
+    if not isinstance(tools, list):
+        return body
+
+    normalized_tools: list[JsonValue] = []
+    for tool in tools:
+        if not isinstance(tool, dict):
+            normalized_tools.append(tool)
+            continue
+        declarations = tool.get("functionDeclarations")
+        if not isinstance(declarations, list):
+            normalized_tools.append(tool)
+            continue
+
+        normalized_declarations: list[JsonValue] = []
+        for declaration in declarations:
+            if not isinstance(declaration, dict):
+                normalized_declarations.append(declaration)
+                continue
+            normalized_declaration = declaration.copy()
+            for schema_key in ("parameters", "parametersJsonSchema"):
+                schema = declaration.get(schema_key)
+                if isinstance(schema, (dict, list)):
+                    normalized_declaration[schema_key] = _lowercase_schema_types(schema)
+            normalized_declarations.append(normalized_declaration)
+
+        normalized_tool = tool.copy()
+        normalized_tool["functionDeclarations"] = normalized_declarations
+        normalized_tools.append(normalized_tool)
+
+    if normalized_tools == tools:
+        return body
+    normalized_body = body.copy()
+    normalized_body["tools"] = normalized_tools
+    return normalized_body
+
+# The Antigravity CLI sends functionResponse parts (tool results) inside a
+# content item with role="model" instead of the standard role="user". The
+# Inspect bridge's messages_from_google_contents only recognizes
+# functionResponse parts when role=="user"; under role=="model" they are
+# silently dropped, producing a blank assistant turn immediately after every
+# tool call and stalling the agent. Relabel (or split out) those parts to
+# role="user" before forwarding to the bridge.
+def _relabel_function_response_contents(
+    contents: list[JsonValue],
+) -> list[JsonValue]:
+    normalized: list[JsonValue] = []
+    changed = False
+
+    for content in contents:
+        if not isinstance(content, dict) or content.get("role") != "model":
+            normalized.append(content)
+            continue
+
+        parts = content.get("parts")
+        if not isinstance(parts, list):
+            normalized.append(content)
+            continue
+
+        function_response_parts: list[JsonValue] = [
+            part
+            for part in parts
+            if isinstance(part, dict)
+            and ("functionResponse" in part or "function_response" in part)
+        ]
+        if not function_response_parts:
+            normalized.append(content)
+            continue
+
+        changed = True
+        remaining_parts: list[JsonValue] = [
+            part for part in parts if part not in function_response_parts
+        ]
+
+        if remaining_parts:
+            model_content = content.copy()
+            model_content["parts"] = remaining_parts
+            normalized.append(model_content)
+
+        user_content = content.copy()
+        user_content["role"] = "user"
+        user_content["parts"] = function_response_parts
+        normalized.append(user_content)
+
+    return normalized if changed else contents
+
+
+def _relabel_function_response_role(
+    body: dict[str, JsonValue],
+) -> dict[str, JsonValue]:
+    contents = body.get("contents")
+    if not isinstance(contents, list):
+        return body
+    normalized_contents = _relabel_function_response_contents(contents)
+    if normalized_contents is contents:
+        return body
+    normalized_body = body.copy()
+    normalized_body["contents"] = normalized_contents
+    return normalized_body
+
+def _normalized_forward_body(content: bytes) -> bytes:
+    try:
+        body: JsonValue = json.loads(content)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return content
+    if not isinstance(body, dict):
+        return content
+    normalized_body = _lowercase_tool_schema_types(body)
+    normalized_body = _relabel_function_response_role(normalized_body)
+    return content if normalized_body == body else json.dumps(normalized_body).encode()
+
+
+async def request(flow: http.HTTPFlow) -> None:
+    host, path = flow.request.pretty_host, flow.request.path
+    if "aiplatform" not in host or "generatecontent" not in path.lower():
+        return
+    match = _MODEL_RE.search(path)
+    model = match.group(1) if match else "inspect"
+    url = (
+        f"http://127.0.0.1:{BRIDGE_PORT}/v1beta/models/{model}:"
+        "streamGenerateContent?alt=sse"
+    )
+    loop = asyncio.get_running_loop()
+    response = await loop.run_in_executor(
+        None,
+        functools.partial(
+            requests.post,
+            url,
+            data=_normalized_forward_body(flow.request.content),
+            headers={"content-type": "application/json"},
+            timeout=600,
+        ),
+    )
+    flow.response = http.Response.make(
+        response.status_code,
+        response.content,
+        {
+            "content-type": response.headers.get(
+                "content-type", "text/event-stream; charset=utf-8"
+            )
+        },
+    )

--- a/src/inspect_swe/_antigravity_cli/agentbinary.py
+++ b/src/inspect_swe/_antigravity_cli/agentbinary.py
@@ -1,0 +1,92 @@
+import io
+import os
+import tarfile
+from pathlib import Path, PurePosixPath
+from typing import Final
+
+from inspect_ai.util import SandboxEnvironment, concurrency
+
+from .._util.sandbox import SANDBOX_INSTALL_DIR, bash_command
+
+DEFAULT_BINARY_SOURCE: Final = Path("/tmp/opencode/agy-bin/antigravity")
+DEFAULT_TOKEN_SOURCE: Final = Path.home() / ".gemini" / "antigravity-cli"
+EXCLUDED_TOKEN_DIRECTORIES: Final = frozenset(
+    {"log", "cache", "crashes", "conversations", "scratch"}
+)
+TOKEN_ARCHIVE_PATH: Final = "/tmp/antigravity-cli-home.tgz"
+
+
+def _include_token_member(member: tarfile.TarInfo) -> tarfile.TarInfo | None:
+    member_path = PurePosixPath(member.name)
+    if member.isdir() and member_path.name in EXCLUDED_TOKEN_DIRECTORIES:
+        return None
+    if any(part in EXCLUDED_TOKEN_DIRECTORIES for part in member_path.parts[:-1]):
+        return None
+    return member
+
+
+async def ensure_antigravity_cli_setup(
+    sandbox: SandboxEnvironment, *, binary_source: str | None, user: str | None
+) -> str:
+    """Install agy in the sandbox and return its absolute path."""
+    configured_source = binary_source
+    if configured_source is None:
+        configured_source = os.environ.get("ANTIGRAVITY_CLI_BINARY")
+    source = Path(configured_source) if configured_source is not None else DEFAULT_BINARY_SOURCE
+    if not source.is_file():
+        raise FileNotFoundError(f"Antigravity CLI binary source not found: {source}")
+
+    install_dir = f"{SANDBOX_INSTALL_DIR}/antigravity-cli"
+    agy_path = f"{install_dir}/agy"
+    result = await sandbox.exec(bash_command(f"test -x {agy_path}"), user=user)
+    if result.success:
+        return agy_path
+
+    async with concurrency("antigravity-cli-install", 1, visible=False):
+        await sandbox.write_file(agy_path, source.read_bytes())
+        # write_file() creates the binary owned by root, so the chmod must run as
+        # root (the owner); running it as the unprivileged agent user fails with
+        # EPERM. 0755 leaves it world-executable so the agent user can still exec it.
+        result = await sandbox.exec(bash_command(f"chmod 0755 {agy_path}"))
+        if not result.success:
+            raise RuntimeError(f"Unable to make Antigravity CLI executable: {result.stderr}")
+
+    return agy_path
+
+
+async def provision_antigravity_home(
+    sandbox: SandboxEnvironment,
+    *,
+    sandbox_home: str,
+    token_source: str | None,
+    user: str | None,
+) -> str:
+    """Copy the Antigravity CLI token home into the sandbox."""
+    configured_source = token_source
+    if configured_source is None:
+        configured_source = os.environ.get("ANTIGRAVITY_CLI_HOME")
+    source = Path(configured_source) if configured_source is not None else DEFAULT_TOKEN_SOURCE
+    if not source.is_dir():
+        raise FileNotFoundError(f"Antigravity CLI token source not found: {source}")
+
+    archive_buffer = io.BytesIO()
+    with tarfile.open(fileobj=archive_buffer, mode="w:gz", encoding="utf-8") as archive:
+        archive.add(
+            source,
+            arcname=source.name,
+            filter=_include_token_member,
+        )
+
+    gemini_home = f"{sandbox_home}/.gemini"
+    result = await sandbox.exec(bash_command(f"mkdir -p {gemini_home}"), user=user)
+    if not result.success:
+        raise RuntimeError(f"Unable to create Antigravity CLI home: {result.stderr}")
+    await sandbox.write_file(TOKEN_ARCHIVE_PATH, archive_buffer.getvalue())
+    result = await sandbox.exec(
+        bash_command(f"tar -xzf {TOKEN_ARCHIVE_PATH} -C {gemini_home}"),
+        user=user,
+    )
+    if not result.success:
+        raise RuntimeError(f"Unable to extract Antigravity CLI tokens: {result.stderr}")
+
+    return f"{gemini_home}/antigravity-cli"

--- a/src/inspect_swe/_antigravity_cli/antigravity_cli.py
+++ b/src/inspect_swe/_antigravity_cli/antigravity_cli.py
@@ -1,0 +1,241 @@
+import asyncio
+import json
+from pathlib import Path
+from textwrap import dedent
+from typing import Any, Sequence
+
+from inspect_ai.agent import (
+    Agent,
+    AgentAttempts,
+    AgentState,
+    BridgedToolsSpec,
+    agent,
+    agent_with,
+    sandbox_agent_bridge,
+)
+from inspect_ai.model import ChatMessageSystem, GenerateFilter, Model
+from inspect_ai.scorer import score
+from inspect_ai.tool import MCPServerConfig, Skill, install_skills, read_skills
+from inspect_ai.tool._mcp._config import MCPServerConfigHTTP
+from inspect_ai.util import sandbox as sandbox_env
+from inspect_ai.util import store
+from inspect_ai.util._sandbox import ExecRemoteAwaitableOptions
+
+from inspect_swe._util._async import is_callable_coroutine
+from inspect_swe._util.messages import build_user_prompt
+from inspect_swe._util.sandbox import detect_sandbox_platform
+from inspect_swe._util.trace import trace
+
+from .agentbinary import ensure_antigravity_cli_setup, provision_antigravity_home
+from .interceptor import ensure_mitmproxy, start_interceptor
+
+
+@agent
+def antigravity_cli(
+    name: str = "Antigravity CLI",
+    description: str = dedent("""
+       Autonomous coding agent capable of writing, testing, debugging,
+       and iterating on code across multiple languages.
+    """),
+    system_prompt: str | None = None,
+    skills: Sequence[str | Path | Skill] | None = None,
+    mcp_servers: Sequence[MCPServerConfig] | None = None,
+    bridged_tools: Sequence[BridgedToolsSpec] | None = None,
+    attempts: int | AgentAttempts = 1,
+    model: str | None = None,
+    model_aliases: dict[str, str | Model] | None = None,
+    filter: GenerateFilter | None = None,
+    retry_refusals: int | None = None,
+    binary_source: str | None = None,
+    token_source: str | None = None,
+    cwd: str | None = None,
+    env: dict[str, str] | None = None,
+    user: str | None = "root",
+    sandbox: str | None = None,
+    print_timeout: str = "876000h",
+) -> Agent:
+    """Create an Antigravity CLI agent using the Inspect model bridge."""
+    model = f"inspect/{model}" if model is not None else "inspect"
+    resolved_skills = read_skills(skills) if skills is not None else None
+    attempts = AgentAttempts(attempts) if isinstance(attempts, int) else attempts
+
+    async def execute(state: AgentState) -> AgentState:
+        bridge_port_key = "antigravity_bridge_port"
+        bridge_port = store().get(bridge_port_key, 3000) + 1
+        store().set(bridge_port_key, bridge_port)
+        intercept_port = bridge_port + 5000
+
+        async with sandbox_agent_bridge(
+            state,
+            model=model,
+            model_aliases=model_aliases,
+            filter=filter,
+            sandbox=sandbox,
+            retry_refusals=retry_refusals,
+            port=bridge_port,
+            bridged_tools=bridged_tools,
+        ) as bridge:
+            sbox = sandbox_env(sandbox)
+            platform = await detect_sandbox_platform(sbox)
+            home_result = await sbox.exec(["sh", "-c", "echo $HOME"], user=user)
+            sandbox_home = home_result.stdout.strip() or "/root"
+
+            if resolved_skills is not None:
+                await install_skills(
+                    resolved_skills, sbox, user, f"{sandbox_home}/.gemini/skills"
+                )
+
+            agy = await ensure_antigravity_cli_setup(
+                sbox, binary_source=binary_source, user=user
+            )
+            antigravity_home = await provision_antigravity_home(
+                sbox,
+                sandbox_home=sandbox_home,
+                token_source=token_source,
+                user=user,
+            )
+            await ensure_mitmproxy(sbox, platform, user)
+            proxy_proc, ca_cert_path, monitor_task = await start_interceptor(
+                sbox,
+                listen_port=intercept_port,
+                bridge_port=bridge.port,
+                confdir=f"{sandbox_home}/.mitmproxy-antigravity",
+                user=user,
+            )
+
+            try:
+                all_mcp_servers = list(mcp_servers or [])
+                await sbox.write_file(
+                    f"{antigravity_home}/mcp_config.json",
+                    resolve_mcp_servers_antigravity(all_mcp_servers),
+                )
+
+                system_messages = [
+                    message.text
+                    for message in state.messages
+                    if isinstance(message, ChatMessageSystem)
+                ]
+                if system_prompt is not None:
+                    system_messages.append(system_prompt)
+
+                prompt, _ = build_user_prompt(state.messages)
+                if system_messages:
+                    combined_system = "\n\n".join(system_messages)
+                    prompt = f"{combined_system}\n\n{prompt}"
+
+                agent_env = build_antigravity_agent_env(
+                    sandbox_home=sandbox_home,
+                    ca_cert_path=ca_cert_path,
+                    intercept_port=intercept_port,
+                    env=env,
+                )
+                debug_output: list[str] = []
+                agent_prompt = prompt
+                attempt_count = 0
+
+                while True:
+                    result = await sbox.exec_remote(
+                        cmd=[
+                            "bash",
+                            "-c",
+                            'exec 0</dev/null; "$@"',
+                            "bash",
+                            agy,
+                            "-p",
+                            agent_prompt,
+                            "--dangerously-skip-permissions",
+                            # agy's -p print mode self-terminates the ENTIRE run
+                            # after --print-timeout (agy default 5m0s) — a total
+                            # wall-clock cap on the whole trajectory, not a per-call
+                            # timeout, and unique to agy (other inspect_swe CLIs have
+                            # no such cap). agent-c trajectories routinely run 200+
+                            # tool calls / 30m+, so any fixed cap eventually kills a
+                            # legit run mid-trajectory. --print-timeout=0 is NOT
+                            # "disabled" (tested: it times out immediately), so this
+                            # defaults absurdly high (~100y) to never bind — Inspect's
+                            # --time-limit/--working-limit govern duration instead.
+                            f"--print-timeout={print_timeout}",
+                        ],
+                        options=ExecRemoteAwaitableOptions(
+                            cwd=cwd,
+                            env=agent_env,
+                            concurrency=False,
+                        ),
+                        stream=False,
+                    )
+                    debug_output.append(result.stdout)
+                    debug_output.append(result.stderr)
+
+                    if not result.success:
+                        # Surface agy's real failure — its stderr and exit code.
+                        # agy dumps its entire thinking transcript to stdout even
+                        # on failure, which buries the actual error; keep it out of
+                        # the exception and put the full output in the trace instead.
+                        debug_output.insert(0, "Antigravity CLI Debug Output (failed):")
+                        trace("\n".join(debug_output))
+                        detail = result.stderr.strip() or (
+                            "no stderr (agy may have hit --print-timeout); "
+                            "full output in trace"
+                        )
+                        raise RuntimeError(
+                            f"Antigravity CLI exited {result.returncode}: {detail}"
+                        )
+
+                    attempt_count += 1
+                    if attempt_count >= attempts.attempts:
+                        break
+
+                    answer_scores = await score(bridge.state)
+                    if attempts.score_value(answer_scores[0].value) == 1.0:
+                        break
+
+                    if callable(attempts.incorrect_message):
+                        if not is_callable_coroutine(attempts.incorrect_message):
+                            raise ValueError(
+                                "The incorrect_message function must be async."
+                            )
+                        agent_prompt = await attempts.incorrect_message(
+                            bridge.state, answer_scores
+                        )
+                    else:
+                        agent_prompt = attempts.incorrect_message
+
+                debug_output.insert(0, "Antigravity CLI Debug Output:")
+                trace("\n".join(debug_output))
+            finally:
+                monitor_task.cancel()
+                await asyncio.shield(proxy_proc.kill())
+
+        return bridge.state
+
+    return agent_with(execute, name=name, description=description)
+
+
+def build_antigravity_agent_env(
+    *,
+    sandbox_home: str,
+    ca_cert_path: str,
+    intercept_port: int,
+    env: dict[str, str] | None,
+) -> dict[str, str]:
+    """Build the Antigravity CLI environment for proxy-mediated model calls."""
+    return {
+        "HTTPS_PROXY": f"http://127.0.0.1:{intercept_port}",
+        "HTTP_PROXY": f"http://127.0.0.1:{intercept_port}",
+        "SSL_CERT_FILE": ca_cert_path,
+        "HOME": sandbox_home,
+        "PATH": "/usr/local/bin:/usr/bin:/bin",
+    } | (env or {})
+
+
+def resolve_mcp_servers_antigravity(mcp_servers: Sequence[MCPServerConfig]) -> str:
+    """Build Antigravity CLI MCP configuration from Inspect server configs."""
+    mcp_servers_config: dict[str, Any] = {}
+    for server in mcp_servers:
+        config = server.model_dump(exclude={"name", "tools", "type"}, exclude_none=True)
+        if isinstance(server, MCPServerConfigHTTP) and "url" in config:
+            config["serverUrl"] = config.pop("url")
+        if "cwd" in config and not isinstance(config["cwd"], str):
+            config["cwd"] = str(config["cwd"])
+        mcp_servers_config[server.name] = config
+    return json.dumps({"mcpServers": mcp_servers_config}, indent=2)

--- a/src/inspect_swe/_antigravity_cli/interceptor.py
+++ b/src/inspect_swe/_antigravity_cli/interceptor.py
@@ -1,0 +1,196 @@
+"""mitmproxy provisioning and launch support for the Antigravity CLI."""
+
+import asyncio  # noqa: ANYIO_OK -- pre-existing; see _monitor_interceptor's create_task
+import os
+from dataclasses import dataclass
+from logging import getLogger
+from pathlib import Path
+from typing import Final
+
+import anyio
+from inspect_ai.util import SandboxEnvironment, concurrency
+from inspect_ai.util._sandbox.exec_remote import (
+    ExecCompleted,
+    ExecRemoteProcess,
+    ExecRemoteStreamingOptions,
+    ExecStderr,
+)
+
+from .._util.download import download_file
+from .._util.sandbox import SANDBOX_INSTALL_DIR, SandboxPlatform, bash_command
+
+logger = getLogger(__name__)
+
+MITMPROXY_VERSION: Final = "11.1.3"
+MITMPROXY_INSTALL_DIR: Final = f"{SANDBOX_INSTALL_DIR}/mitmproxy"
+MITMDUMP_PATH: Final = f"{MITMPROXY_INSTALL_DIR}/mitmdump"
+MITMPROXY_ARCHIVE_PATH: Final = f"{SANDBOX_INSTALL_DIR}/mitmproxy.tar.gz"
+ADDON_PATH: Final = f"{MITMPROXY_INSTALL_DIR}/antigravity_addon.py"
+DEFAULT_MITMPROXY_TARBALL_URL: Final = (
+    "https://downloads.mitmproxy.org/11.1.3/"
+    "mitmproxy-11.1.3-linux-x86_64.tar.gz"
+)
+
+
+@dataclass(slots=True, eq=False)  # noqa: MUTABLE_OK -- frozen=True breaks __traceback__
+class MitmproxyStartupTimeoutError(RuntimeError):
+    """contextlib's @asynccontextmanager sets __traceback__ on caught
+    exceptions via a plain attribute assignment; combined with slots=True,
+    frozen's generated __setattr__ raises ``TypeError: super(type, obj): obj
+    must be an instance or subtype of type`` when re-raised through an async
+    context manager (e.g. sandbox_agent_bridge). ``eq=False`` keeps identity-
+    based ``__hash__`` (inspect_ai's exception-group flattening hashes
+    exceptions); dataclass sets ``__hash__ = None`` for eq=True, frozen=False.
+    Exceptions are mutated by the runtime (traceback/context/cause)
+    regardless of dataclass frozen semantics, so this class stays mutable.
+    """
+
+    detail: str
+
+    detail: str
+
+    def __str__(self) -> str:
+        return self.detail
+
+
+def _mitmproxy_tarball_url(platform: SandboxPlatform) -> str:
+    """Resolve the standalone mitmproxy archive URL for a sandbox platform."""
+    configured_url = os.environ.get("ANTIGRAVITY_MITMPROXY_TARBALL_URL")
+    if configured_url is not None:
+        return configured_url
+
+    architecture = {
+        "linux-x64": "linux-x86_64",
+        "linux-x64-musl": "linux-x86_64",
+        "linux-arm64": "linux-aarch64",
+        "linux-arm64-musl": "linux-aarch64",
+    }[platform]
+    if architecture == "linux-x86_64":
+        return DEFAULT_MITMPROXY_TARBALL_URL
+    return (
+        f"https://downloads.mitmproxy.org/{MITMPROXY_VERSION}/"
+        f"mitmproxy-{MITMPROXY_VERSION}-{architecture}.tar.gz"
+    )
+
+
+async def ensure_mitmproxy(
+    sandbox: SandboxEnvironment, platform: SandboxPlatform, user: str | None
+) -> str:
+    """Install mitmdump in the sandbox and return its absolute path."""
+    result = await sandbox.exec(bash_command(f"test -x {MITMDUMP_PATH}"), user=user)
+    if result.success:
+        return MITMDUMP_PATH
+
+    async with concurrency("mitmproxy-install", 1, visible=False):
+        archive_data = await download_file(_mitmproxy_tarball_url(platform))
+        await sandbox.exec(
+            bash_command(f"mkdir -p {MITMPROXY_INSTALL_DIR}"), user="root"
+        )
+        await sandbox.write_file(MITMPROXY_ARCHIVE_PATH, archive_data)
+        result = await sandbox.exec(
+            bash_command(
+                f"tar -xzf {MITMPROXY_ARCHIVE_PATH} -C {MITMPROXY_INSTALL_DIR} && rm -f {MITMPROXY_ARCHIVE_PATH}"
+            ),
+            user="root",
+        )
+        if not result.success:
+            raise RuntimeError(f"Unable to extract mitmproxy: {result.stderr}")
+
+    result = await sandbox.exec(bash_command(f"test -x {MITMDUMP_PATH}"), user=user)
+    if not result.success:
+        raise RuntimeError(f"mitmdump binary not found at {MITMDUMP_PATH}")
+    return MITMDUMP_PATH
+
+
+async def start_interceptor(
+    sandbox: SandboxEnvironment,
+    *,
+    listen_port: int,
+    bridge_port: int,
+    confdir: str,
+    user: str | None,
+) -> tuple[ExecRemoteProcess, str, asyncio.Task[None]]:
+    """Start mitmdump and return its process, CA certificate, and monitor task."""
+    addon_data = Path(__file__).with_name("_addon.py").read_bytes()
+    await sandbox.write_file(ADDON_PATH, addon_data)
+    process = await sandbox.exec_remote(
+        cmd=[
+            MITMDUMP_PATH,
+            "--listen-host",
+            "127.0.0.1",
+            "--listen-port",
+            str(listen_port),
+            "--set",
+            f"confdir={confdir}",
+            "-s",
+            ADDON_PATH,
+            "-q",
+        ],
+        options=ExecRemoteStreamingOptions(
+            concurrency=False,
+            env={"ANTIGRAVITY_BRIDGE_PORT": str(bridge_port)},
+        ),
+    )
+    monitor_task = asyncio.create_task(_monitor_interceptor(process))
+
+    ca_cert_path = f"{confdir}/mitmproxy-ca-cert.pem"
+    for _ in range(30):
+        result = await sandbox.exec(bash_command(f"test -f {ca_cert_path}"), user=user)
+        if result.success:
+            break
+        await anyio.sleep(0.5)
+    else:
+        await process.kill()
+        raise MitmproxyStartupTimeoutError(
+            detail=f"mitmproxy CA certificate was not created at {ca_cert_path}"
+        )
+
+    await _wait_for_listening_port(sandbox, process, listen_port, user)
+    return process, ca_cert_path, monitor_task
+
+
+async def _wait_for_listening_port(
+    sandbox: SandboxEnvironment,
+    process: ExecRemoteProcess,
+    port: int,
+    user: str | None,
+) -> None:
+    """Poll until mitmdump's listen socket accepts connections.
+
+    The CA certificate file materializes as mitmdump starts, but the actual
+    listen socket may not be accepting connections yet -- agy's very first
+    outbound call (silent-auth / token refresh) can otherwise race a
+    not-yet-ready listener and fail with a hard ``connection refused``.
+    """
+    probe = bash_command(f"echo -n '' > /dev/tcp/127.0.0.1/{port}")
+    for _ in range(30):
+        result = await sandbox.exec(probe, user=user)
+        if result.success:
+            return
+        await anyio.sleep(0.5)
+
+    await process.kill()
+    raise MitmproxyStartupTimeoutError(
+        detail=f"mitmproxy did not start accepting connections on port {port}"
+    )
+
+
+async def _monitor_interceptor(process: ExecRemoteProcess) -> None:
+    stderr: list[str] = []
+    async for event in process:
+        if isinstance(event, ExecStderr):
+            stderr.append(event.data)
+            logger.debug("mitmdump stderr: %s", event.data.rstrip())
+        if isinstance(event, ExecCompleted):
+            if not event.success:
+                raise RuntimeError(
+                    f"mitmdump process exited unexpectedly with failure: {''.join(stderr)}."
+                )
+            if stderr:
+                logger.warning(
+                    "mitmdump stderr output on clean exit:\n%s", "".join(stderr).rstrip()
+                )
+            return
+    raise RuntimeError(
+        f"mitmdump process stream ended unexpectedly: {''.join(stderr)}."
+    )

--- a/src/inspect_swe/_antigravity_cli/interceptor.py
+++ b/src/inspect_swe/_antigravity_cli/interceptor.py
@@ -113,19 +113,31 @@ async def start_interceptor(
     """Start mitmdump and return its process, CA certificate, and monitor task."""
     addon_data = Path(__file__).with_name("_addon.py").read_bytes()
     await sandbox.write_file(ADDON_PATH, addon_data)
+    cmd = [
+        MITMDUMP_PATH,
+        "--listen-host",
+        "127.0.0.1",
+        "--listen-port",
+        str(listen_port),
+        "--set",
+        f"confdir={confdir}",
+        "-s",
+        ADDON_PATH,
+        "-q",
+    ]
+    # When the sandbox exposes an upstream egress-allowlist proxy (set by the
+    # compose egress profile as SANDBOX_EGRESS_PROXY), chain mitmdump's
+    # pass-through traffic (agy's OAuth / cloudcode bootstrap calls) through it.
+    # Inference is still short-circuited to the local Inspect bridge by the addon
+    # and never egresses; in an isolated sandbox this proxy is the ONLY route out.
+    egress = await sandbox.exec(
+        bash_command('printf %s "${SANDBOX_EGRESS_PROXY:-}"'), user=user
+    )
+    upstream = egress.stdout.strip() if egress.success else ""
+    if upstream:
+        cmd += ["--mode", f"upstream:{upstream}"]
     process = await sandbox.exec_remote(
-        cmd=[
-            MITMDUMP_PATH,
-            "--listen-host",
-            "127.0.0.1",
-            "--listen-port",
-            str(listen_port),
-            "--set",
-            f"confdir={confdir}",
-            "-s",
-            ADDON_PATH,
-            "-q",
-        ],
+        cmd=cmd,
         options=ExecRemoteStreamingOptions(
             concurrency=False,
             env={"ANTIGRAVITY_BRIDGE_PORT": str(bridge_port)},

--- a/src/inspect_swe/_registry.py
+++ b/src/inspect_swe/_registry.py
@@ -2,8 +2,9 @@
 
 from ._claude_code.claude_code import claude_code
 from ._codex_cli.codex_cli import codex_cli
+from ._antigravity_cli.antigravity_cli import antigravity_cli
 from ._gemini_cli.gemini_cli import gemini_cli
 from ._mini_swe_agent.mini_swe_agent import mini_swe_agent
 from ._opencode.opencode import opencode
 
-__all__ = ["codex_cli", "claude_code", "gemini_cli", "mini_swe_agent", "opencode"]
+__all__ = ["codex_cli", "claude_code", "gemini_cli", "mini_swe_agent", "opencode", "antigravity_cli"]

--- a/tests/test_antigravity_cli.py
+++ b/tests/test_antigravity_cli.py
@@ -1,0 +1,720 @@
+from __future__ import annotations
+
+import importlib
+import io
+import json
+import tarfile
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+from typing import Mapping, Protocol
+
+import anyio
+import pytest
+from inspect_ai.agent import Agent, AgentState
+from inspect_ai.model import ChatMessageUser
+from inspect_ai.tool import MCPServerConfigStdio
+from inspect_ai.tool._mcp._config import MCPServerConfigHTTP
+
+from inspect_swe._antigravity_cli.agentbinary import (
+    ensure_antigravity_cli_setup,
+    provision_antigravity_home,
+)
+from inspect_swe._antigravity_cli.interceptor import (
+    MITMDUMP_PATH,
+    MITMPROXY_ARCHIVE_PATH,
+    MITMPROXY_INSTALL_DIR,
+    ensure_mitmproxy,
+)
+from inspect_swe._util.sandbox import SANDBOX_INSTALL_DIR
+
+
+@dataclass(frozen=True, slots=True)
+class ExecResult:
+    success: bool
+    stdout: str = ""
+    stderr: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class RecordedCommand:
+    command: tuple[str, ...]
+    user: str | None
+
+
+class RecordingSandbox:
+    def __init__(self) -> None:
+        self.commands: list[RecordedCommand] = []
+        self.executable_paths: set[str] = set()
+        self.writes: list[tuple[str, bytes]] = []
+
+    async def exec(self, cmd: list[str], user: str | None = None) -> ExecResult:
+        self.commands.append(RecordedCommand(command=tuple(cmd), user=user))
+        shell_command = cmd[-1]
+        if shell_command.startswith("test -x "):
+            path = shell_command.removeprefix("test -x ")
+            return ExecResult(success=path in self.executable_paths)
+        if shell_command.startswith("chmod 0755 "):
+            self.executable_paths.add(shell_command.removeprefix("chmod 0755 "))
+        return ExecResult(success=True)
+
+    async def write_file(self, path: str, contents: bytes) -> None:
+        self.writes.append((path, contents))
+
+
+def test_ensure_antigravity_cli_setup_writes_an_executable_once(
+    tmp_path: Path,
+) -> None:
+    async def provision() -> None:
+        binary_source = tmp_path / "antigravity"
+        binary_data = b"agy-binary"
+        binary_source.write_bytes(binary_data)
+        sandbox = RecordingSandbox()
+        agy_path = f"{SANDBOX_INSTALL_DIR}/antigravity-cli/agy"
+
+        result = await ensure_antigravity_cli_setup(
+            sandbox,
+            binary_source=str(binary_source),
+            user="root",
+        )
+
+        assert result == agy_path
+        assert sandbox.writes == [(agy_path, binary_data)]
+        assert RecordedCommand(
+            command=("bash", "-c", f"chmod 0755 {agy_path}"),
+            user="root",
+        ) in sandbox.commands
+
+        result = await ensure_antigravity_cli_setup(
+            sandbox,
+            binary_source=str(binary_source),
+            user="root",
+        )
+
+        assert result == agy_path
+        assert sandbox.writes == [(agy_path, binary_data)]
+
+    anyio.run(provision)
+
+
+def test_provision_antigravity_home_archives_only_runtime_tokens(tmp_path: Path) -> None:
+    async def provision() -> None:
+        token_source = tmp_path / "antigravity-cli"
+        token_source.mkdir()
+        (token_source / "antigravity-oauth-token").write_text(
+            "token", encoding="utf-8"
+        )
+        for excluded_directory in (
+            "log",
+            "cache",
+            "crashes",
+            "conversations",
+            "scratch",
+        ):
+            directory = token_source / excluded_directory
+            directory.mkdir()
+            (directory / "ignored.txt").write_text("ignored", encoding="utf-8")
+
+        sandbox = RecordingSandbox()
+        sandbox_home = "/root"
+
+        result = await provision_antigravity_home(
+            sandbox,
+            sandbox_home=sandbox_home,
+            token_source=str(token_source),
+            user="root",
+        )
+
+        archive_path, archive_data = sandbox.writes[0]
+        with tarfile.open(fileobj=io.BytesIO(archive_data), mode="r:gz") as archive:
+            archive_names = archive.getnames()
+
+        assert result == "/root/.gemini/antigravity-cli"
+        assert "antigravity-cli/antigravity-oauth-token" in archive_names
+        assert not any(
+            excluded_directory in Path(name).parts
+            for name in archive_names
+            for excluded_directory in (
+                "log",
+                "cache",
+                "crashes",
+                "conversations",
+                "scratch",
+            )
+        )
+        assert RecordedCommand(
+            command=("bash", "-c", "mkdir -p /root/.gemini"),
+            user="root",
+        ) in sandbox.commands
+        assert RecordedCommand(
+            command=(
+                "bash",
+                "-c",
+                f"tar -xzf {archive_path} -C /root/.gemini",
+            ),
+            user="root",
+        ) in sandbox.commands
+
+    anyio.run(provision)
+
+
+def test_ensure_mitmproxy_extracts_flat_archive_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class MitmproxySandbox(RecordingSandbox):
+        async def exec(self, cmd: list[str], user: str | None = None) -> ExecResult:
+            if cmd[-1].startswith("tar -xzf "):
+                self.executable_paths.add(MITMDUMP_PATH)
+            return await super().exec(cmd, user=user)
+
+    async def download_file(_: str) -> bytes:
+        return b"mitmproxy-archive"
+
+    async def provision() -> None:
+        monkeypatch.setattr(
+            "inspect_swe._antigravity_cli.interceptor.download_file", download_file
+        )
+        sandbox = MitmproxySandbox()
+
+        result = await ensure_mitmproxy(sandbox, "linux-x64", "root")
+
+        assert result == MITMDUMP_PATH
+        assert sandbox.writes == [(MITMPROXY_ARCHIVE_PATH, b"mitmproxy-archive")]
+        assert RecordedCommand(
+            command=(
+                "bash",
+                "-c",
+                f"tar -xzf {MITMPROXY_ARCHIVE_PATH} -C {MITMPROXY_INSTALL_DIR} && rm -f {MITMPROXY_ARCHIVE_PATH}",
+            ),
+            user="root",
+        ) in sandbox.commands
+        assert not any(
+            "--strip-components" in recorded.command[-1]
+            for recorded in sandbox.commands
+        )
+
+        result = await ensure_mitmproxy(sandbox, "linux-x64", "root")
+
+        assert result == MITMDUMP_PATH
+        assert len(sandbox.writes) == 1
+        assert sandbox.commands[-1] == RecordedCommand(
+            command=("bash", "-c", f"test -x {MITMDUMP_PATH}"), user="root"
+        )
+
+    anyio.run(provision)
+
+
+class _FlowResponse(Protocol):
+    status_code: int
+    content: bytes
+    headers: Mapping[str, str]
+
+
+def test_addon_rewrites_only_aiplatform(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeResponse:
+        status_code: int = 200
+        content: bytes = b"data: {}\n\n"
+        headers: dict[str, str] = {"content-type": "text/event-stream"}
+
+    class FakeResponse:
+        status_code: int = 200
+        content: bytes = b"data: {}\n\n"
+        headers: dict[str, str] = {"content-type": "text/event-stream"}
+
+    @dataclass(frozen=True, slots=True)
+    class FakeRequest:
+        pretty_host: str
+        path: str
+        content: bytes
+
+    @dataclass(slots=True)
+    class FakeFlow:
+        request: FakeRequest
+        response: _FlowResponse | None = None
+
+    posted: list[tuple[str, bytes, dict[str, str]]] = []
+
+    def fake_post(
+        url: str, *, data: bytes, headers: dict[str, str], timeout: int
+    ) -> FakeResponse:
+        posted.append((url, data, headers))
+        return FakeResponse()
+
+    async def exercise() -> None:
+        monkeypatch.setenv("ANTIGRAVITY_BRIDGE_PORT", "24680")
+        addon = importlib.reload(
+            importlib.import_module("inspect_swe._antigravity_cli._addon")
+        )
+        monkeypatch.setattr(addon.requests, "post", fake_post)
+
+        non_aiplatform = FakeFlow(
+            request=FakeRequest(
+                pretty_host="oauth2.googleapis.com",
+                path="/token",
+                content=b"{}",
+            )
+        )
+        await addon.request(non_aiplatform)
+
+        aiplatform = FakeFlow(
+            request=FakeRequest(
+                pretty_host="us-central1-aiplatform.googleapis.com",
+                path=(
+                    "/v1/projects/project/locations/us-central1/publishers/google/"
+                    "models/gemini-2.5-flash:streamGenerateContent?alt=sse"
+                ),
+                content=b'{"contents": []}',
+            )
+        )
+        await addon.request(aiplatform)
+
+        assert non_aiplatform.response is None
+        assert posted == [
+            (
+                "http://127.0.0.1:24680/v1beta/models/"
+                "gemini-2.5-flash:streamGenerateContent?alt=sse",
+                b'{"contents": []}',
+                {"content-type": "application/json"},
+            )
+        ]
+        assert aiplatform.response is not None
+        assert aiplatform.response.status_code == 200
+        assert aiplatform.response.content == b"data: {}\n\n"
+        assert aiplatform.response.headers["content-type"] == "text/event-stream"
+
+    anyio.run(exercise)
+
+
+def test_addon_lowercases_vertex_schema_types_for_the_bridge(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeResponse:
+        status_code: int = 200
+        content: bytes = b"data: {}\n\n"
+        headers: dict[str, str] = {"content-type": "text/event-stream"}
+
+    @dataclass(frozen=True, slots=True)
+    class FakeRequest:
+        pretty_host: str
+        path: str
+        content: bytes
+
+    @dataclass(slots=True)  # noqa: MUTABLE_OK -- addon.request() mutates .response
+    class FakeFlow:
+        request: FakeRequest
+        response: _FlowResponse | None = None
+
+    posted: list[bytes] = []
+
+    def fake_post(
+        url: str, *, data: bytes, headers: dict[str, str], timeout: int
+    ) -> FakeResponse:
+        posted.append(data)
+        return FakeResponse()
+
+    async def exercise() -> None:
+        monkeypatch.setenv("ANTIGRAVITY_BRIDGE_PORT", "24680")
+        addon = importlib.reload(
+            importlib.import_module("inspect_swe._antigravity_cli._addon")
+        )
+        monkeypatch.setattr(addon.requests, "post", fake_post)
+
+        vertex_body = {
+            "contents": [{"type": "OBJECT"}],
+            "tools": [
+                {
+                    "functionDeclarations": [
+                        {
+                            "name": "browser",
+                            "parameters": {
+                                "type": "OBJECT",
+                                "properties": {
+                                    "action": {"type": "STRING"},
+                                    "count": {
+                                        "anyOf": [
+                                            {"type": "NUMBER"},
+                                            {"type": "INTEGER"},
+                                        ]
+                                    },
+                                    "options": {
+                                        "type": "ARRAY",
+                                        "items": {"type": ["STRING", "NULL"]},
+                                    },
+                                    "enabled": {"allOf": [{"type": "BOOLEAN"}]},
+                                    "target": {
+                                        "oneOf": [
+                                            {
+                                                "type": "OBJECT",
+                                                "properties": {"id": {"type": "STRING"}},
+                                            }
+                                        ]
+                                    },
+                                },
+                            },
+                        }
+                    ]
+                }
+            ],
+        }
+        aiplatform = FakeFlow(
+            request=FakeRequest(
+                pretty_host="us-central1-aiplatform.googleapis.com",
+                path=(
+                    "/v1/projects/project/locations/us-central1/publishers/google/"
+                    "models/gemini-2.5-flash:streamGenerateContent?alt=sse"
+                ),
+                content=json.dumps(vertex_body).encode(),
+            )
+        )
+
+        await addon.request(aiplatform)
+
+        forwarded = json.loads(posted[0])
+        schema = forwarded["tools"][0]["functionDeclarations"][0]["parameters"]
+        assert schema["type"] == "object"
+        assert schema["properties"]["action"]["type"] == "string"
+        assert schema["properties"]["count"]["anyOf"][0]["type"] == "number"
+        assert schema["properties"]["count"]["anyOf"][1]["type"] == "integer"
+        assert schema["properties"]["options"]["type"] == "array"
+        assert schema["properties"]["options"]["items"]["type"] == ["string", "null"]
+        assert schema["properties"]["enabled"]["allOf"][0]["type"] == "boolean"
+        target_schema = schema["properties"]["target"]["oneOf"][0]
+        assert target_schema["type"] == "object"
+        assert target_schema["properties"]["id"]["type"] == "string"
+        assert forwarded["contents"] == [{"type": "OBJECT"}]
+
+    anyio.run(exercise)
+
+
+def test_addon_relabels_model_role_function_response_to_user(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeResponse:
+        status_code: int = 200
+        content: bytes = b"data: {}\n\n"
+        headers: dict[str, str] = {"content-type": "text/event-stream"}
+
+    @dataclass(frozen=True, slots=True)
+    class FakeRequest:
+        pretty_host: str
+        path: str
+        content: bytes
+
+    @dataclass(slots=True)  # noqa: MUTABLE_OK -- addon.request() mutates .response
+    class FakeFlow:
+        request: FakeRequest
+        response: _FlowResponse | None = None
+
+    posted: list[bytes] = []
+
+    def fake_post(
+        url: str, *, data: bytes, headers: dict[str, str], timeout: int
+    ) -> FakeResponse:
+        posted.append(data)
+        return FakeResponse()
+
+    async def exercise() -> None:
+        monkeypatch.setenv("ANTIGRAVITY_BRIDGE_PORT", "24680")
+        addon = importlib.reload(
+            importlib.import_module("inspect_swe._antigravity_cli._addon")
+        )
+        monkeypatch.setattr(addon.requests, "post", fake_post)
+
+        # agy sends functionResponse under role="model" instead of the
+        # standard role="user" -- a pure tool-result content, plus one mixed
+        # with a functionCall alongside a functionResponse.
+        body = {
+            "contents": [
+                {"role": "user", "parts": [{"text": "list the schemas"}]},
+                {
+                    "role": "model",
+                    "parts": [
+                        {
+                            "functionCall": {
+                                "name": "call_mcp_tool",
+                                "args": {"tool": "postgres_schema"},
+                            }
+                        }
+                    ],
+                },
+                {
+                    "role": "model",
+                    "parts": [
+                        {
+                            "functionResponse": {
+                                "name": "call_mcp_tool",
+                                "response": {"output": "ok"},
+                            }
+                        }
+                    ],
+                },
+                {
+                    "role": "model",
+                    "parts": [
+                        {"text": "mixed turn"},
+                        {
+                            "functionResponse": {
+                                "name": "call_mcp_tool",
+                                "response": {"output": "mixed"},
+                            }
+                        },
+                    ],
+                },
+            ],
+        }
+        aiplatform = FakeFlow(
+            request=FakeRequest(
+                pretty_host="us-central1-aiplatform.googleapis.com",
+                path=(
+                    "/v1/projects/project/locations/us-central1/publishers/google/"
+                    "models/gemini-2.5-flash:streamGenerateContent?alt=sse"
+                ),
+                content=json.dumps(body).encode(),
+            )
+        )
+
+        await addon.request(aiplatform)
+
+        forwarded = json.loads(posted[0])
+        contents = forwarded["contents"]
+
+        assert contents[0] == {"role": "user", "parts": [{"text": "list the schemas"}]}
+        assert contents[1]["role"] == "model"
+        assert "functionCall" in contents[1]["parts"][0]
+
+        # pure functionResponse content: relabeled in place, not split
+        assert contents[2] == {
+            "role": "user",
+            "parts": [
+                {
+                    "functionResponse": {
+                        "name": "call_mcp_tool",
+                        "response": {"output": "ok"},
+                    }
+                }
+            ],
+        }
+
+        # mixed content: split into a model turn (remaining parts) followed
+        # by a user turn (the functionResponse)
+        assert contents[3] == {"role": "model", "parts": [{"text": "mixed turn"}]}
+        assert contents[4] == {
+            "role": "user",
+            "parts": [
+                {
+                    "functionResponse": {
+                        "name": "call_mcp_tool",
+                        "response": {"output": "mixed"},
+                    }
+                }
+            ],
+        }
+        assert len(contents) == 5
+
+    anyio.run(exercise)
+
+
+def _antigravity_module() -> ModuleType:
+    try:
+        return importlib.import_module("inspect_swe._antigravity_cli.antigravity_cli")
+    except ModuleNotFoundError:
+        pytest.fail("the Antigravity CLI agent module has not been implemented")
+
+
+def test_resolve_mcp_servers_stdio() -> None:
+    agent_module = _antigravity_module()
+    server = MCPServerConfigStdio(
+        name="taiga-mcp",
+        command="/opt/venv/bin/browser_injections",
+        args=["mcp"],
+    )
+
+    result = agent_module.resolve_mcp_servers_antigravity([server])
+
+    assert result == (
+        '{\n'
+        '  "mcpServers": {\n'
+        '    "taiga-mcp": {\n'
+        '      "command": "/opt/venv/bin/browser_injections",\n'
+        '      "args": [\n'
+        '        "mcp"\n'
+        '      ]\n'
+        '    }\n'
+        '  }\n'
+        '}'
+    )
+
+
+def test_resolve_mcp_servers_http_uses_server_url() -> None:
+    agent_module = _antigravity_module()
+    server = MCPServerConfigHTTP(
+        name="remote", type="http", url="https://mcp.example.test"
+    )
+
+    result = agent_module.resolve_mcp_servers_antigravity([server])
+
+    assert result == (
+        '{\n'
+        '  "mcpServers": {\n'
+        '    "remote": {\n'
+        '      "serverUrl": "https://mcp.example.test"\n'
+        '    }\n'
+        '  }\n'
+        '}'
+    )
+
+
+def test_agent_env_no_base_url_dynamic_ports(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def exercise() -> None:
+        agent_module = _antigravity_module()
+        captured: dict[str, int | str | bool] = {}
+
+        class FakeStore:
+            def get(self, _: str, default: int) -> int:
+                return default
+
+            def set(self, _: str, value: int) -> None:
+                captured["stored_bridge_port"] = value
+
+        class FakeBridge:
+            port = 24680
+
+            def __init__(self, state: AgentState) -> None:
+                self.state = state
+
+            async def __aenter__(self) -> FakeBridge:
+                return self
+
+            async def __aexit__(self, *_: object) -> None:
+                return None
+
+        class FakeProcess:
+            async def kill(self) -> None:
+                captured["proxy_killed"] = True
+
+        class FakeMonitor:
+            def cancel(self) -> None:
+                captured["monitor_cancelled"] = True
+
+        class AgentSandbox(RecordingSandbox):
+            async def exec_remote(
+                self, *, cmd: list[str], options: object, stream: bool
+            ) -> ExecResult:
+                captured["https_proxy"] = options.env["HTTPS_PROXY"]
+                captured["has_base_url"] = "GOOGLE_GEMINI_BASE_URL" in options.env
+                return ExecResult(success=True)
+
+        sandbox = AgentSandbox()
+
+        def fake_bridge(state: AgentState, **_: object) -> FakeBridge:
+            return FakeBridge(state)
+
+        async def fake_ensure_cli(*_: object, **__: object) -> str:
+            return "/usr/local/bin/agy"
+
+        async def fake_provision_home(*_: object, **__: object) -> str:
+            return "/root/.gemini/antigravity-cli"
+
+        async def fake_ensure_mitmproxy(*_: object, **__: object) -> str:
+            return "/usr/local/bin/mitmdump"
+
+        async def fake_detect_sandbox_platform(_: RecordingSandbox) -> str:
+            return "linux-x64"
+
+        async def fake_start_interceptor(
+            _: RecordingSandbox,
+            *,
+            listen_port: int,
+            bridge_port: int,
+            confdir: str,
+            user: str | None,
+        ) -> tuple[FakeProcess, str, FakeMonitor]:
+            captured["intercept_port"] = listen_port
+            captured["bridge_port"] = bridge_port
+            captured["confdir"] = confdir
+            captured["interceptor_user"] = user or ""
+            return FakeProcess(), "/root/mitmproxy-ca-cert.pem", FakeMonitor()
+
+        monkeypatch.setattr(agent_module, "store", lambda: FakeStore())
+        monkeypatch.setattr(agent_module, "sandbox_agent_bridge", fake_bridge)
+        monkeypatch.setattr(agent_module, "sandbox_env", lambda _: sandbox)
+        monkeypatch.setattr(
+            agent_module, "detect_sandbox_platform", fake_detect_sandbox_platform
+        )
+        monkeypatch.setattr(agent_module, "ensure_antigravity_cli_setup", fake_ensure_cli)
+        monkeypatch.setattr(agent_module, "provision_antigravity_home", fake_provision_home)
+        monkeypatch.setattr(agent_module, "ensure_mitmproxy", fake_ensure_mitmproxy)
+        monkeypatch.setattr(agent_module, "start_interceptor", fake_start_interceptor)
+        monkeypatch.setattr(agent_module, "trace", lambda _: None)
+
+        agent = agent_module.antigravity_cli()
+        await agent(AgentState(messages=[ChatMessageUser(content="Solve the task")]))
+
+        assert captured["stored_bridge_port"] == 3001
+        assert captured["intercept_port"] == 8001
+        assert captured["bridge_port"] == 24680
+        assert captured["https_proxy"] == "http://127.0.0.1:8001"
+        assert captured["has_base_url"] is False
+        assert captured["monitor_cancelled"] is True
+        assert captured["proxy_killed"] is True
+
+    anyio.run(exercise)
+
+
+def test_antigravity_cli_returns_an_agent() -> None:
+    agent_module = _antigravity_module()
+
+    result = agent_module.antigravity_cli()
+
+    assert isinstance(result, Agent)
+
+
+def test_start_interceptor_waits_for_listening_socket_before_returning() -> None:
+    async def exercise() -> None:
+        interceptor_module = importlib.import_module(
+            "inspect_swe._antigravity_cli.interceptor"
+        )
+
+        class FakeProcess:
+            def __aiter__(self) -> "FakeProcess":
+                return self
+
+            async def __anext__(self) -> object:
+                await anyio.sleep_forever()
+                raise StopAsyncIteration
+
+        class PortProbeSandbox(RecordingSandbox):
+            def __init__(self) -> None:
+                super().__init__()
+                self.port_probe_attempts = 0
+
+            async def exec_remote(
+                self, *, cmd: list[str], options: object
+            ) -> FakeProcess:
+                return FakeProcess()
+
+            async def exec(
+                self, cmd: list[str], user: str | None = None
+            ) -> ExecResult:
+                shell_command = cmd[-1]
+                if "/dev/tcp/" in shell_command:
+                    self.port_probe_attempts += 1
+                    return ExecResult(success=self.port_probe_attempts >= 3)
+                return await super().exec(cmd, user=user)
+
+        sandbox = PortProbeSandbox()
+
+        process, ca_cert_path, monitor_task = await interceptor_module.start_interceptor(
+            sandbox,
+            listen_port=8001,
+            bridge_port=3001,
+            confdir="/root/.mitmproxy-antigravity",
+            user="root",
+        )
+
+        assert isinstance(process, FakeProcess)
+        assert ca_cert_path == "/root/.mitmproxy-antigravity/mitmproxy-ca-cert.pem"
+        assert sandbox.port_probe_attempts == 3
+        monitor_task.cancel()
+
+    anyio.run(exercise)


### PR DESCRIPTION
## Summary

Adds an `antigravity_cli` agent that runs Google's Antigravity CLI (`agy`, the successor to Gemini CLI) headless inside an Inspect sandbox, with model calls routed through the sandbox agent bridge — mirroring the existing `gemini_cli` agent.

## How it works

Unlike `gemini_cli` (which honors `GOOGLE_GEMINI_BASE_URL`), `agy` has no base-URL/endpoint override, so this agent:

- Provisions `agy` and a mitmproxy into the sandbox at runtime.
- Sets `HTTPS_PROXY` and uses an in-sandbox mitmdump addon to route `agy`'s Vertex `:streamGenerateContent` calls to the bridge's Gemini-compatible endpoint; all other traffic passes through to Google.

Two request normalizations in the addon let `agy` interoperate with the bridge:

- **Tool-schema types:** Vertex emits the JSON-Schema `type` keyword in SCREAMING_SNAKE_CASE (`STRING`, `OBJECT`, …) in tool declarations; the addon lowercases these to the JSON-Schema strings the bridge expects.
- **functionResponse role:** `agy` places `functionResponse` parts (tool results) under `role="model"` rather than the conventional `role="user"`. The bridge maps tool results to tool messages only under `role="user"`, so without normalization `agy`'s own tool results are dropped from the next request and the agent stalls after a single tool call. The addon relabels (and, for mixed content, splits) those parts to `role="user"` so the tool-call loop proceeds.

## Tests

`tests/test_antigravity_cli.py` covers the addon transforms — including the `functionResponse` role normalization (pure and mixed-content cases) — and the agent wiring/registration.
