### PR TITLE
fix(claude_code): tolerate current install.sh DOWNLOAD_BASE_URL syntax

### DIFF
--- a/src/inspect_swe/_claude_code/agentbinary.py
+++ b/src/inspect_swe/_claude_code/agentbinary.py
@@ -44,12 +44,12 @@ async def _claude_code_download_base_url() -> str:
     INSTALL_SCRIPT_URL = "https://claude.ai/install.sh"
     script_content = await download_text_file(INSTALL_SCRIPT_URL)
     for pattern in [
-        r'DOWNLOAD_BASE_URL="(https://[^"]+)"',
-        r'GCS_BUCKET="(https://[^"]+)"',
+        r"""(?:^|\n)\s*(?:export\s+)?DOWNLOAD_BASE_URL\s*=\s*(["'])(https://[^"'\s]+)\1""",
+        r"""(?:^|\n)\s*(?:export\s+)?GCS_BUCKET\s*=\s*(["'])(https://[^"'\s]+)\1""",
     ]:
         match = re.search(pattern, script_content)
         if match is not None:
-            return match.group(1)
+            return match.group(2)
     raise RuntimeError("Unable to determine download base URL for claude code.")
 
 

--- a/tests/test_claude_code_agentbinary.py
+++ b/tests/test_claude_code_agentbinary.py
@@ -1,0 +1,44 @@
+from unittest.mock import AsyncMock
+
+import pytest
+from inspect_swe._claude_code import agentbinary
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("assignment", "expected_url"),
+    [
+        (
+            "export DOWNLOAD_BASE_URL='https://downloads.claude.ai/claude-code-releases'",
+            "https://downloads.claude.ai/claude-code-releases",
+        ),
+        (
+            'GCS_BUCKET="https://storage.googleapis.com/legacy-claude-code"',
+            "https://storage.googleapis.com/legacy-claude-code",
+        ),
+    ],
+)
+async def test_download_base_url_supports_current_and_legacy_install_scripts(
+    monkeypatch: pytest.MonkeyPatch, assignment: str, expected_url: str
+) -> None:
+    # Given
+    manifest = (
+        '{"version":"2.1.205","platforms":{"linux-x64":'
+        '{"checksum":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",'
+        '"size":1}}}'
+    )
+    monkeypatch.setattr(
+        agentbinary,
+        "download_text_file",
+        AsyncMock(side_effect=[f"#!/bin/bash\n{assignment}\n", "2.1.205", manifest]),
+    )
+
+    # When
+    resolved = await agentbinary.claude_code_binary_source().resolve_version(
+        "stable", "linux-x64"
+    )
+
+    # Then
+    assert resolved.version == "2.1.205"
+    assert resolved.expected_checksum == "a" * 64
+    assert resolved.download_url == f"{expected_url}/2.1.205/linux-x64/claude"


### PR DESCRIPTION
## What
Accept the current `install.sh` `DOWNLOAD_BASE_URL` syntax (exported/single-quoted) when acquiring the Claude Code binary, while retaining legacy `GCS_BUCKET` support.

## Why
The upstream installer changed its variable syntax, which broke binary acquisition.

## Notes
Test covers both the old and new forms.
