### PR TITLE
ci: static hatch-vcs fallback_version for tag-less git-URL installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,10 @@ version-file = "src/inspect_swe/_version.py"
 
 [tool.hatch.version.raw-options]
 local_scheme = "no-local-version" # Important for PyPI compatibility
+# Used only when no tag is reachable (e.g. a shallow/tag-less `uv` git-URL
+# fetch of a single commit) -- normal tagged checkouts/releases still get a
+# real git-describe-derived version and ignore this.
+fallback_version = "0.2.66"
 
 [tool.hatch.metadata]
 allow-direct-references = true


### PR DESCRIPTION
## What
Set a static hatch-vcs `fallback_version` so installs from a tag-less / shallow git URL resolve a valid version instead of failing.

## Why
Installing directly from a git commit (no tags in a shallow clone) makes hatch-vcs fail to derive a version.

## Notes
Normal tagged releases are unaffected. The fallback is currently a fixed value; happy to adjust the policy if you'd prefer it track differently.
