### PR TITLE
feat(claude_code): control static MCP allowlisting

### DIFF
--- a/src/inspect_swe/_claude_code/claude_code.py
+++ b/src/inspect_swe/_claude_code/claude_code.py
@@ -2,7 +2,7 @@ import shlex
 import uuid
 from pathlib import Path
 from textwrap import dedent
-from typing import Any, Literal, Sequence
+from typing import Any, Literal, Mapping, Sequence, cast
 
 from inspect_ai.agent import (
     Agent,
@@ -28,6 +28,7 @@ from inspect_ai.util import (
 )
 from pydantic import Field
 from pydantic_core import to_json
+from typing_extensions import TypedDict, Unpack
 
 from inspect_swe._claude_code._events.live_consumer import LiveConsumer
 from inspect_swe._claude_code._events.stream import (
@@ -47,6 +48,55 @@ from .._util.sandbox import resolve_agent_cwd
 from .._util.trace import trace
 from .agentbinary import claude_code_binary_source
 from .model import resolve_claude_code_models
+
+ClaudeCodePermissionMode = Literal[
+    "acceptEdits", "auto", "bypassPermissions", "default", "dontAsk", "plan"
+]
+
+
+class ClaudeCodeDeprecatedArgs(TypedDict, total=False):
+    auto_mode: bool
+
+
+def resolve_claude_code_deprecated_args(
+    deprecated_args: Mapping[str, Any],
+    permission_mode: str | None,
+) -> ClaudeCodePermissionMode | None:
+    unexpected_args = set(deprecated_args) - {"auto_mode"}
+    if unexpected_args:
+        unexpected = ", ".join(sorted(unexpected_args))
+        raise TypeError(f"Unexpected keyword argument(s): {unexpected}")
+
+    auto_mode = deprecated_args.get("auto_mode")
+    if auto_mode:
+        if permission_mode is not None and permission_mode != "auto":
+            raise ValueError(
+                "auto_mode=True conflicts with permission_mode; use permission_mode='auto'."
+            )
+        return "auto"
+    return resolve_claude_code_permission_mode(permission_mode)
+
+
+def resolve_claude_code_permission_mode(
+    permission_mode: str | None,
+) -> ClaudeCodePermissionMode | None:
+    match permission_mode:
+        case None:
+            return None
+        case (
+            "acceptEdits"
+            | "auto"
+            | "bypassPermissions"
+            | "default"
+            | "dontAsk"
+            | "plan"
+        ):
+            return permission_mode
+        case _:
+            raise ValueError(
+                "permission_mode must be one of 'acceptEdits', 'auto', "
+                "'bypassPermissions', 'default', 'dontAsk', or 'plan'."
+            )
 
 
 @agent
@@ -71,7 +121,7 @@ def claude_code(
     haiku_model: str | None = None,
     subagent_model: str | None = None,
     filter: GenerateFilter | None = None,
-    auto_mode: bool = False,
+    permission_mode: ClaudeCodePermissionMode | None = None,
     retry_refusals: int | None = 3,
     retry_uncaught_errors: int | None = 3,
     cwd: str | None = None,
@@ -80,6 +130,8 @@ def claude_code(
     sandbox: str | None = None,
     version: Literal["auto", "sandbox", "stable", "latest"] | str = "auto",
     debug: bool | None = None,
+    allowlist_mcp_tools: bool = True,
+    **deprecated_args: Unpack[ClaudeCodeDeprecatedArgs],
 ) -> Agent:
     """Claude Code agent.
 
@@ -121,7 +173,15 @@ def claude_code(
         haiku_model: The model to use for haiku, or [background functionality](https://code.claude.com/docs/en/costs#background-token-usage). Defaults to `model`.
         subagent_model: The model to use for [subagents](https://code.claude.com/docs/en/sub-agents). Defaults to `model`.
         filter: Filter for intercepting bridged model requests.
-        auto_mode: Use `auto` permission mode rather than `--dangerously-skip-permissions`. Note that this can result in rejected tool calls so only enable if your evaluation can tolerate this.
+        permission_mode: Claude Code `--permission-mode`. The complete CLI set is
+            `"acceptEdits"`, `"auto"`, `"bypassPermissions"`, `"default"`,
+            `"dontAsk"`, and `"plan"`. `"bypassPermissions"` is near-equivalent
+            to the default `--dangerously-skip-permissions` path, and `"dontAsk"`
+            is also now reachable. `--allowed-tools` is consulted in every mode
+            except `"bypassPermissions"`. In unattended runs, tools excluded from
+            `--allowed-tools` cannot be prompted for and are denied; `"auto"` is
+            the only mode where otherwise-unapproved calls are adjudicated by
+            Claude Code's first-party classifier rather than denied unconditionally.
         retry_refusals: Should refusals be retried? Defaults to retrying up to 3 times.
         retry_uncaught_errors: Should uncaught errors (unexpected crashes of Claude Code) be retried. Defaults to retrying up to 3 times.
         cwd: Working directory to run claude code within.
@@ -135,6 +195,15 @@ def claude_code(
             - "latest": Download and use the very latest version of claude code.
             - "x.x.x": Download and use a specific version of claude code.
         debug: Add `--debug` cli flag and trace all debug output.
+        allowlist_mcp_tools: Whether to add static caller-provided MCP tools to
+            `--allowed-tools` (default `True`). It matters in every permission
+            mode except `"bypassPermissions"`: in unattended runs, excluded
+            static tools are denied without prompting. Set `False` with
+            `permission_mode="auto"` when Claude Code's first-party classifier
+            should adjudicate those tools. Bridged Inspect tools remain allowlisted
+            because an evaluation may depend on them being callable.
+        **deprecated_args: Supports the deprecated `auto_mode` argument. Set
+            `auto_mode=True` maps to `permission_mode="auto"`.
     """
     # resolve centaur
     if centaur is True:
@@ -145,6 +214,10 @@ def claude_code(
 
     # resolve attempts
     attempts = AgentAttempts(attempts) if isinstance(attempts, int) else attempts
+
+    effective_permission_mode = resolve_claude_code_deprecated_args(
+        cast(dict[str, Any], deprecated_args), permission_mode
+    )
 
     # allocate session_id once per agent instance so that all calls to execute()
     # for the same sample share the same session. this enables --resume <id> to
@@ -211,11 +284,9 @@ def claude_code(
                 claude_code_binary_source(), version, user, sandbox_env(sandbox)
             )
 
-            # base options — auto_mode uses --permission-mode auto (monitor active);
-            # otherwise --dangerously-skip-permissions (no permission gating).
             permission_flag = (
-                ["--permission-mode", "auto"]
-                if auto_mode
+                ["--permission-mode", effective_permission_mode]
+                if effective_permission_mode is not None
                 else ["--dangerously-skip-permissions"]
             )
             cmd = [
@@ -230,15 +301,20 @@ def claude_code(
                 if debug:
                     cmd.append("--debug")
 
-            # mcp servers (combine static configs with bridged tools)
             cmd_allowed_tools: list[str] = []
-            all_mcp_servers = list(mcp_servers or []) + bridge.mcp_server_configs
+            static_mcp_servers = list(mcp_servers or [])
+            bridged_mcp_servers = bridge.mcp_server_configs
+            all_mcp_servers = static_mcp_servers + bridged_mcp_servers
             if all_mcp_servers:
-                mcp_server_args, mcp_allowed_tools = resolve_mcp_servers(
-                    all_mcp_servers
-                )
+                mcp_server_args, _ = resolve_mcp_servers(all_mcp_servers)
                 cmd.extend(mcp_server_args)
-                cmd_allowed_tools.extend(mcp_allowed_tools)
+                cmd_allowed_tools.extend(
+                    resolve_allowed_mcp_tools(
+                        static_mcp_servers,
+                        bridged_mcp_servers,
+                        allowlist_mcp_tools,
+                    )
+                )
 
             # add allowed and disallowed tools
             if len(cmd_allowed_tools) > 0:
@@ -503,21 +579,10 @@ def resolve_mcp_servers(
 ) -> tuple[list[str], list[str]]:
     # build servers and allowed tools
     mcp_servers_json: dict[str, dict[str, Any]] = {}
-    allowed_tools: list[str] = []
     for mcp_server in mcp_servers:
         mcp_servers_json[mcp_server.name] = mcp_server.model_dump(
             exclude={"name", "tools"}, exclude_none=True
         )
-        if mcp_server.tools == "all":
-            allowed_tools.append(f"mcp__{mcp_server.name}_*")
-        elif isinstance(mcp_server.tools, list):
-            allowed_tools.extend(
-                [f"mcp__{mcp_server.name}__{tool}" for tool in mcp_server.tools]
-            )
-        else:
-            raise ValueError(
-                f"Unexpected value for mcp server tools: {mcp_server.tools}"
-            )
 
     # map to cli args
     mcp_config_cmds: list[str] = []
@@ -527,7 +592,39 @@ def resolve_mcp_servers(
             to_json({"mcpServers": mcp_servers_json}, exclude_none=True).decode()
         )
 
-    return mcp_config_cmds, allowed_tools
+    return mcp_config_cmds, resolve_mcp_server_allowed_tools(mcp_servers)
+
+
+def resolve_allowed_mcp_tools(
+    static_mcp_servers: Sequence[MCPServerConfig],
+    bridged_mcp_servers: Sequence[MCPServerConfig],
+    allowlist_mcp_tools: bool,
+) -> list[str]:
+    static_allowed_tools = (
+        resolve_mcp_server_allowed_tools(static_mcp_servers)
+        if allowlist_mcp_tools
+        else []
+    )
+    bridged_allowed_tools = resolve_mcp_server_allowed_tools(bridged_mcp_servers)
+    return [*static_allowed_tools, *bridged_allowed_tools]
+
+
+def resolve_mcp_server_allowed_tools(
+    mcp_servers: Sequence[MCPServerConfig],
+) -> list[str]:
+    allowed_tools: list[str] = []
+    for mcp_server in mcp_servers:
+        if mcp_server.tools == "all":
+            allowed_tools.append(f"mcp__{mcp_server.name}__*")
+        elif isinstance(mcp_server.tools, list):
+            allowed_tools.extend(
+                [f"mcp__{mcp_server.name}__{tool}" for tool in mcp_server.tools]
+            )
+        else:
+            raise ValueError(
+                f"Unexpected value for mcp server tools: {mcp_server.tools}"
+            )
+    return allowed_tools
 
 
 async def run_claude_code_centaur(

--- a/tests/test_claude_code_mcp_allowed_tools.py
+++ b/tests/test_claude_code_mcp_allowed_tools.py
@@ -1,0 +1,87 @@
+"""Regression tests for Claude Code MCP allowed-tool spellings.
+
+Claude Code recognizes wildcard rules only after the literal
+``mcp__<server>__`` prefix, so ``mcp__<server>__*`` uses a double underscore
+before the glob. The older, more portable spelling ``mcp__<server>`` also
+allows every tool from a server, which matters when ``version="auto"`` or
+``"sandbox"`` selects an older installed Claude Code version.
+"""
+
+import pytest
+from inspect_ai.tool import MCPServerConfig
+from inspect_swe._claude_code.claude_code import (
+    claude_code,
+    resolve_allowed_mcp_tools,
+    resolve_claude_code_deprecated_args,
+    resolve_mcp_servers,
+)
+
+
+def test_default_registers_and_allowlists_explicit_mcp_tools() -> None:
+    server = MCPServerConfig(
+        type="http", name="taiga-mcp", tools=["list_files", "read_file"]
+    )
+
+    mcp_config_cmds, allowed_tools = resolve_mcp_servers([server])
+
+    assert mcp_config_cmds[0] == "--mcp-config"
+    assert allowed_tools == [
+        "mcp__taiga-mcp__list_files",
+        "mcp__taiga-mcp__read_file",
+    ]
+
+
+def test_disabling_static_mcp_allowlist_keeps_servers_registered() -> None:
+    server = MCPServerConfig(
+        type="http", name="taiga-mcp", tools=["list_files", "read_file"]
+    )
+
+    mcp_config_cmds, _ = resolve_mcp_servers([server])
+    allowed_tools = resolve_allowed_mcp_tools([server], [], allowlist_mcp_tools=False)
+
+    assert mcp_config_cmds[0] == "--mcp-config"
+    assert allowed_tools == []
+
+
+def test_disabling_static_mcp_allowlist_preserves_bridged_allowlist() -> None:
+    static_server = MCPServerConfig(type="http", name="caller-tools", tools=["lookup"])
+    bridged_server = MCPServerConfig(
+        type="http", name="inspect-tools", tools=["submit"]
+    )
+
+    allowed_tools = resolve_allowed_mcp_tools(
+        [static_server], [bridged_server], allowlist_mcp_tools=False
+    )
+
+    assert allowed_tools == ["mcp__inspect-tools__submit"]
+
+
+def test_all_tools_wildcard_uses_double_underscore_before_glob() -> None:
+    server = MCPServerConfig(type="http", name="taiga-mcp", tools="all")
+
+    mcp_config_cmds, allowed_tools = resolve_mcp_servers([server])
+
+    assert mcp_config_cmds[0] == "--mcp-config"
+    assert allowed_tools == ["mcp__taiga-mcp__*"]
+
+
+def test_deprecated_auto_mode_resolves_to_auto_permission_mode() -> None:
+    assert resolve_claude_code_deprecated_args({"auto_mode": True}, None) == "auto"
+
+
+def test_truthy_deprecated_auto_mode_resolves_to_auto_permission_mode() -> None:
+    assert resolve_claude_code_deprecated_args({"auto_mode": 1}, None) == "auto"
+
+
+def test_claude_code_accepts_deprecated_auto_mode() -> None:
+    claude_code(auto_mode=True)
+
+
+def test_deprecated_auto_mode_rejects_conflicting_permission_mode() -> None:
+    with pytest.raises(ValueError, match="auto_mode"):
+        resolve_claude_code_deprecated_args({"auto_mode": True}, "acceptEdits")
+
+
+def test_invalid_permission_mode_raises_construction_error() -> None:
+    with pytest.raises(ValueError, match="permission_mode"):
+        resolve_claude_code_deprecated_args({}, "unrestricted")


### PR DESCRIPTION
## Summary
- Add `allowlist_mcp_tools` for static caller-provided MCP servers.
- Preserve the released `auto_mode` API through the established deprecated-argument shim while exposing the complete typed Claude Code permission-mode set.
- Correct the MCP wildcard syntax to `mcp__<name>__*` and cover the default `tools="all"` path.
- Keep Inspect-bridged MCP tools pre-approved when static MCP tools are sent to Claude Code's classifier.

## Behavior
`allowlist_mcp_tools=False` applies only to static `mcp_servers`. Bridged tools remain allowlisted because evaluation-owned submit and scoring tools can be required for the task to complete. In `permission_mode="auto"`, static MCP calls that are not pre-approved are adjudicated by Claude Code's first-party classifier.

Existing `tools="all"` static MCP servers were previously emitted as `mcp__<name>_*`, which Claude Code does not recognize as an MCP wildcard. They are now emitted as `mcp__<name>__*`, so existing `auto_mode=True` and `permission_mode="auto"` callers that rely on the default `allowlist_mcp_tools=True` now pre-approve every tool from those servers instead of sending each call to the classifier.

## Coordination
This PR is Claude Code only. #88 independently owns Codex CLI sandbox and approval-policy controls. Both branches are based on upstream `main` and do not depend on each other.

## Release notes

feat(claude_code): add `permission_mode` option (deprecates `auto_mode`)

fix(claude_code): correct "all" tools MCP allowlist wildcard to `mcp__<name>__*`