### PR TITLE
fix(codex_cli): refresh bundled model catalog snapshot to track live latest

### DIFF
--- a/src/inspect_swe/_codex_cli/_bundled_catalog.py
+++ b/src/inspect_swe/_codex_cli/_bundled_catalog.py
@@ -8,9 +8,9 @@ trimmed snapshot of the fields the resolver reads
 (``slug``/``priority``/``apply_patch_tool_type``/``supports_search_tool``) is
 sufficient.
 
-Snapshot source: ``openai/codex`` ``codex-rs/models-manager/models.json`` (main,
-June 2026). Refresh when bumping the default Codex version; the live fetch keeps
-this exact when ``raw.githubusercontent.com`` is reachable.
+Snapshot source: ``openai/codex`` ``codex-rs/models-manager/models.json``
+(``rust-v0.145.0``, July 2026). Refresh when bumping the default Codex version;
+the live fetch keeps this exact when ``raw.githubusercontent.com`` is reachable.
 """
 
 from typing import Any
@@ -18,38 +18,50 @@ from typing import Any
 BUNDLED_CODEX_CATALOG: dict[str, Any] = {
     "models": [
         {
-            "slug": "gpt-5.5",
-            "priority": 0,
+            "slug": "gpt-5.6-sol",
+            "priority": 1,
             "apply_patch_tool_type": "freeform",
             "supports_search_tool": True,
         },
         {
-            "slug": "gpt-5.4",
+            "slug": "gpt-5.6-terra",
             "priority": 2,
             "apply_patch_tool_type": "freeform",
             "supports_search_tool": True,
         },
         {
-            "slug": "gpt-5.4-mini",
-            "priority": 4,
+            "slug": "gpt-5.6-luna",
+            "priority": 3,
             "apply_patch_tool_type": "freeform",
             "supports_search_tool": True,
         },
         {
-            "slug": "gpt-5.3-codex",
-            "priority": 6,
+            "slug": "gpt-5.5",
+            "priority": 7,
+            "apply_patch_tool_type": "freeform",
+            "supports_search_tool": True,
+        },
+        {
+            "slug": "gpt-5.4",
+            "priority": 16,
+            "apply_patch_tool_type": "freeform",
+            "supports_search_tool": True,
+        },
+        {
+            "slug": "gpt-5.4-mini",
+            "priority": 23,
             "apply_patch_tool_type": "freeform",
             "supports_search_tool": True,
         },
         {
             "slug": "gpt-5.2",
-            "priority": 10,
+            "priority": 29,
             "apply_patch_tool_type": "freeform",
             "supports_search_tool": True,
         },
         {
             "slug": "codex-auto-review",
-            "priority": 29,
+            "priority": 43,
             "apply_patch_tool_type": "freeform",
             "supports_search_tool": True,
         },


### PR DESCRIPTION
Hi, I am Claude acting on Sami Jawhar (sjawhar)'s behalf.

This refreshes the bundled Codex fallback catalog from `openai/codex` `rust-v0.145.0` (July 2026), including the current `gpt-5.6-sol` latest entry and its live priorities. It keeps the fallback aligned when the version-matched catalog cannot be fetched.

Validation:
- `uv run pytest tests/test_codex_agentbinary.py::test_bundled_catalog_tracks_live_latest -v`
- `uv run pytest tests/test_codex_agentbinary.py tests/test_codex_model_catalog.py tests/test_codex_align.py -q`
- Ruff and mypy on the changed snapshot module

Separate observation: the drift test docstring says it is github-action-gated, but the test body only skips when its live fetch fails. A newly shipped model can therefore hard-fail CI until the snapshot is refreshed. I can send a separate follow-up if maintainers would like that gate implemented; this PR intentionally only refreshes the snapshot.