### PR TITLE
fix: default Claude Code env to disable SDK retry watchdogs behind the bridge

### DIFF
--- a/src/inspect_swe/acp/_agents/claude_code/claude_code.py
+++ b/src/inspect_swe/acp/_agents/claude_code/claude_code.py
@@ -21,31 +21,25 @@ from .agentbinary import ensure_claude_code_acp_setup
 logger = logging.getLogger(__name__)
 
 
-# claude-agent-sdk (bundled with claude-agent-acp) has three independent
-# watchdogs that abort an in-flight request and re-send it if the SSE stream
-# stalls: Bun fetch requestTimeout (300 s), the SDK client timeout (600 s),
-# and an event-idle stream watchdog (300 s). When a bridge GenerateFilter
-# blocks the model proxy for longer than that — common when the caller does
-# heavy per-request work — the retry replays a stale request through the
-# bridge. Disable / raise all of them by default; user-provided ``env``
-# overrides.
+# Claude Code has several client-side watchdogs that abort an in-flight
+# request and re-send it when the bridged model call stalls. A bridge
+# GenerateFilter that deliberately blocks the model proxy trips them, and
+# the retry replays a stale request. Disable them by default; user ``env``
+# still overrides.
 _BRIDGE_SAFE_ENV: dict[str, str] = {
-    # Bun fetch requestTimeout → timeout:false
+    # Bun fetch requestTimeout
     "API_FORCE_IDLE_TIMEOUT": "0",
-    # Anthropic SDK client timeout (AbortSignal on the request)
-    "API_TIMEOUT_MS": "3600000",
-    # SSE event-idle watchdog (floor-clamped to 300 s, so must disable)
+    # SDK client timeout — no disable sentinel, so use a large value
+    "API_TIMEOUT_MS": "100000000",
+    # SSE event-idle watchdog
     "CLAUDE_ENABLE_STREAM_WATCHDOG": "0",
-    # MCP-tool idle watchdog on bridged tools (300 s for http/SSE transports)
+    # Idle watchdog on bridged MCP tool calls
     "CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT": "0",
-    # MCP server connect/init timeouts (defaults 5 s / 30 s). Bridge MCP
-    # servers are proxied over the sandbox exec channel; under many
-    # concurrent samples the first `initialize` round-trip can exceed the
-    # 5 s default and the server is silently dropped from the tool list.
+    # MCP server connect/init handshake (defaults 5 s / 30 s); on timeout the
+    # server is silently dropped and its tools never appear
     "MCP_CONNECT_TIMEOUT_MS": "60000",
     "MCP_TIMEOUT": "60000",
-    # Telemetry, error reporting, model-list probe, update checks — none of
-    # which should reach outside the sandbox
+    # No telemetry or update checks from inside the sandbox
     "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
     "DISABLE_AUTOUPDATER": "1",
 }

--- a/src/inspect_swe/acp/_agents/claude_code/claude_code.py
+++ b/src/inspect_swe/acp/_agents/claude_code/claude_code.py
@@ -31,14 +31,27 @@ _BRIDGE_SAFE_ENV: dict[str, str] = {
     "API_FORCE_IDLE_TIMEOUT": "0",
     # SDK client timeout — no disable sentinel, so use a large value
     "API_TIMEOUT_MS": "100000000",
-    # SSE event-idle watchdog
+    # SSE event-idle watchdog (dead code as of CC 2.1.220 — the chunk-idle
+    # byte watchdog below replaced it; kept for older CC versions)
     "CLAUDE_ENABLE_STREAM_WATCHDOG": "0",
+    # SSE chunk-idle byte watchdog (~180 s default, remotely tunable via a
+    # feature gate). Currently only arms on first-party base URLs, so it does
+    # not fire behind the bridge's localhost ANTHROPIC_BASE_URL — disabled
+    # explicitly rather than relying on that implementation detail
+    "CLAUDE_ENABLE_BYTE_WATCHDOG": "0",
     # Idle watchdog on bridged MCP tool calls
     "CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT": "0",
+    # Block the first model call until MCP servers are connected; otherwise a
+    # slow bridge handshake yields a first call with no bridged tools (only a
+    # WaitForMcpServers placeholder) and the sample silently proceeds toolless.
+    # Inverted polarity: unset and "1" both mean non-blocking; only an explicit
+    # falsy token ("0"/"false"/"no"/"off") blocks
+    "MCP_CONNECTION_NONBLOCKING": "0",
     # MCP server connect/init handshake (defaults 5 s / 30 s); on timeout the
-    # server is silently dropped and its tools never appear
-    "MCP_CONNECT_TIMEOUT_MS": "60000",
-    "MCP_TIMEOUT": "60000",
+    # server is silently dropped and its tools never appear. 300 s to cover
+    # slow sandbox backends under many-concurrent-samples startup contention
+    "MCP_CONNECT_TIMEOUT_MS": "300000",
+    "MCP_TIMEOUT": "300000",
     # No telemetry or update checks from inside the sandbox
     "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
     "DISABLE_AUTOUPDATER": "1",

--- a/src/inspect_swe/acp/_agents/claude_code/claude_code.py
+++ b/src/inspect_swe/acp/_agents/claude_code/claude_code.py
@@ -21,6 +21,36 @@ from .agentbinary import ensure_claude_code_acp_setup
 logger = logging.getLogger(__name__)
 
 
+# claude-agent-sdk (bundled with claude-agent-acp) has three independent
+# watchdogs that abort an in-flight request and re-send it if the SSE stream
+# stalls: Bun fetch requestTimeout (300 s), the SDK client timeout (600 s),
+# and an event-idle stream watchdog (300 s). When a bridge GenerateFilter
+# blocks the model proxy for longer than that — common when the caller does
+# heavy per-request work — the retry replays a stale request through the
+# bridge. Disable / raise all of them by default; user-provided ``env``
+# overrides.
+_BRIDGE_SAFE_ENV: dict[str, str] = {
+    # Bun fetch requestTimeout → timeout:false
+    "API_FORCE_IDLE_TIMEOUT": "0",
+    # Anthropic SDK client timeout (AbortSignal on the request)
+    "API_TIMEOUT_MS": "3600000",
+    # SSE event-idle watchdog (floor-clamped to 300 s, so must disable)
+    "CLAUDE_ENABLE_STREAM_WATCHDOG": "0",
+    # MCP-tool idle watchdog on bridged tools (300 s for http/SSE transports)
+    "CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT": "0",
+    # MCP server connect/init timeouts (defaults 5 s / 30 s). Bridge MCP
+    # servers are proxied over the sandbox exec channel; under many
+    # concurrent samples the first `initialize` round-trip can exceed the
+    # 5 s default and the server is silently dropped from the tool list.
+    "MCP_CONNECT_TIMEOUT_MS": "60000",
+    "MCP_TIMEOUT": "60000",
+    # Telemetry, error reporting, model-list probe, update checks — none of
+    # which should reach outside the sandbox
+    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+    "DISABLE_AUTOUPDATER": "1",
+}
+
+
 class ClaudeCode(ACPAgent):
     """Claude Code agent via the ``claude-agent-acp`` ACP adapter.
 
@@ -92,41 +122,43 @@ class ClaudeCode(ACPAgent):
 
             # Use canonical model names — the bridge resolves them via
             # model_aliases to Model instances directly.
-            agent_env = {
-                "ANTHROPIC_BASE_URL": f"http://localhost:{bridge.port}",
-                "ANTHROPIC_AUTH_TOKEN": "sk-ant-api03-DOq5tyLPrk9M4hPE",
-                "ANTHROPIC_MODEL": default_model,
-                "ANTHROPIC_DEFAULT_OPUS_MODEL": get_model(
-                    self._opus_model
-                ).canonical_name()
-                if self._opus_model
-                else default_model,
-                "ANTHROPIC_DEFAULT_SONNET_MODEL": get_model(
-                    self._sonnet_model
-                ).canonical_name()
-                if self._sonnet_model
-                else default_model,
-                "ANTHROPIC_DEFAULT_HAIKU_MODEL": get_model(
-                    self._haiku_model
-                ).canonical_name()
-                if self._haiku_model
-                else default_model,
-                "CLAUDE_CODE_SUBAGENT_MODEL": get_model(
-                    self._subagent_model
-                ).canonical_name()
-                if self._subagent_model
-                else default_model,
-                "ANTHROPIC_SMALL_FAST_MODEL": get_model(
-                    self._haiku_model
-                ).canonical_name()
-                if self._haiku_model
-                else default_model,
-                "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
-                "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
-                "API_TIMEOUT_MS": "100000000",
-                "IS_SANDBOX": "1",
-                "PATH": f"{node_dir}:/usr/local/bin:/usr/bin:/bin",
-            } | self.env
+            agent_env = (
+                _BRIDGE_SAFE_ENV
+                | {
+                    "ANTHROPIC_BASE_URL": f"http://localhost:{bridge.port}",
+                    "ANTHROPIC_AUTH_TOKEN": "sk-ant-api03-DOq5tyLPrk9M4hPE",
+                    "ANTHROPIC_MODEL": default_model,
+                    "ANTHROPIC_DEFAULT_OPUS_MODEL": get_model(
+                        self._opus_model
+                    ).canonical_name()
+                    if self._opus_model
+                    else default_model,
+                    "ANTHROPIC_DEFAULT_SONNET_MODEL": get_model(
+                        self._sonnet_model
+                    ).canonical_name()
+                    if self._sonnet_model
+                    else default_model,
+                    "ANTHROPIC_DEFAULT_HAIKU_MODEL": get_model(
+                        self._haiku_model
+                    ).canonical_name()
+                    if self._haiku_model
+                    else default_model,
+                    "CLAUDE_CODE_SUBAGENT_MODEL": get_model(
+                        self._subagent_model
+                    ).canonical_name()
+                    if self._subagent_model
+                    else default_model,
+                    "ANTHROPIC_SMALL_FAST_MODEL": get_model(
+                        self._haiku_model
+                    ).canonical_name()
+                    if self._haiku_model
+                    else default_model,
+                    "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
+                    "IS_SANDBOX": "1",
+                    "PATH": f"{node_dir}:/usr/local/bin:/usr/bin:/bin",
+                }
+                | self.env
+            )
 
             # System prompt via env (the ACP adapter will forward to CC)
             resolved_prompt = self._resolve_system_prompt(state)


### PR DESCRIPTION
## Problem

`claude-agent-sdk` (bundled with `claude-agent-acp`) has three independent watchdogs that abort an in-flight request and re-send it if the SSE stream stalls, plus a per-tool idle timeout on bridged MCP tools:

| watchdog | default | env var |
|---|---|---|
| Bun `fetch` `requestTimeout` | 300 s | `API_FORCE_IDLE_TIMEOUT` |
| Anthropic SDK client `timeout` (AbortSignal) | 600 s | `API_TIMEOUT_MS` |
| SSE event-idle stream watchdog | 300 s (floor-clamped) | `CLAUDE_ENABLE_STREAM_WATCHDOG` |
| MCP-tool idle (http/SSE transports) | 300 s | `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT` |

When a `sandbox_agent_bridge` `GenerateFilter` blocks the model proxy for longer than any of these — common when the caller does heavy per-request work (e.g. petri-dish's auditor round-trip is routinely 5–20 min under BoN critique-refine) — Claude Code aborts and re-sends the identical request, replaying stale state through the bridge. Observed as identical requests every 300 s in AISI's owlbear sabotage-cr8 v1 run (`claude-agent-acp@0.59.0` / `claude-agent-sdk@0.3.207`).

Separately, CC's MCP client connect (`MCP_CONNECT_TIMEOUT_MS`, default **5 s**) and protocol init (`MCP_TIMEOUT`, default 30 s) can be exceeded by the bridge proxy's first `initialize` round-trip under many-concurrent-samples docker-startup contention. CC then **silently drops** the bridged server from its tool list, so bridged MCP tools never surface. Observed at ~1.1–1.3% of samples in the same runs.

## Change

Add `_BRIDGE_SAFE_ENV` and merge it under the ACP `claude_code` agent's `agent_env` (before user-provided `env`, so it can still be overridden). Also folds in `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1` and `DISABLE_AUTOUPDATER=1` (previously inline). Values determined by reverse-engineering CC 2.1.207's minified `cli.js`; note `API_FORCE_IDLE_TIMEOUT` must be `"0"` (not `"1"`) — the disable guard is `!isTruthy(v) && (hasBodyIdleWatchdog || isExplicitlyFalsy(v))`, and `hasBodyIdleWatchdog` is false on any non-`api.anthropic.com` `ANTHROPIC_BASE_URL`.

Companion PR meridianlabs-ai/petri_dish#22 fails the sample loudly if a bridged server is dropped despite the raised timeout.

## Testing

`ruff check`/`ruff format --check`/`mypy` clean on the changed file. (`make check` on `origin/main` currently fails with 7 pre-existing errors in `_mini_swe_agent/resumable_agent.py` — unrelated to this change.) Verified in a running container's `/proc/<claude>/environ` and by observing no scaffold-side retries across the AISI owlbear sabotage-cr8 v3/v4 runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)