### PR TITLE
feat(bridge): add transparent_proxy to codex_cli and claude_code

### DIFF
--- a/src/inspect_swe/_claude_code/claude_code.py
+++ b/src/inspect_swe/_claude_code/claude_code.py
@@ -129,6 +129,7 @@ def claude_code(
     model: str | None = None,
     model_config: str | None = None,
     model_aliases: dict[str, str | Model] | None = None,
+    transparent_proxy: bool = False,
     opus_model: str | None = None,
     sonnet_model: str | None = None,
     haiku_model: str | None = None,
@@ -188,6 +189,17 @@ def claude_code(
         model_aliases: Optional mapping of model names to Model instances or model name strings.
             Allows using custom Model implementations (e.g., wrapped Agents) instead of standard models.
             When a model name in the mapping is referenced, the corresponding Model/string is used.
+        transparent_proxy: Run the bridge as a faithful transparent proxy (defaults
+            to `False`). When `True`, each request is routed to the model the agent
+            actually asked for -- no alias table and no fallback collapse onto the
+            session model -- and the client's generation parameters are treated as
+            authoritative. Required when the agent makes internal model calls of its
+            own that must reach their real provider model rather than being served by
+            the session model, e.g. Claude Code's auto-mode security classifier under
+            `auto_mode=True`. With the default `False`, the presented-identity aliases
+            and the fallback model collapse such a request onto the session model, so
+            the classifier is served by the wrong model (and its generation parameters,
+            e.g. `max_tokens`, are dropped).
         opus_model: The model to use for `opus`, or for `opusplan` when Plan Mode is active. Defaults to `model`.
         sonnet_model: The model to use for `sonnet`, or for `opusplan` when Plan Mode is not active. Defaults to `model`.
         haiku_model: The model to use for haiku, or [background functionality](https://code.claude.com/docs/en/costs#background-token-usage). Defaults to `model`.
@@ -283,8 +295,9 @@ def claude_code(
             checkpointer() as cp,
             sandbox_agent_bridge(
                 state,
-                model=models.bridge_model,
-                model_aliases=models.aliases,
+                model=None if transparent_proxy else models.bridge_model,
+                model_aliases=None if transparent_proxy else models.aliases,
+                forward_generation_config=transparent_proxy,
                 filter=filter,
                 sandbox=sandbox,
                 retry_refusals=retry_refusals,

--- a/src/inspect_swe/_claude_code/claude_code.py
+++ b/src/inspect_swe/_claude_code/claude_code.py
@@ -189,17 +189,17 @@ def claude_code(
         model_aliases: Optional mapping of model names to Model instances or model name strings.
             Allows using custom Model implementations (e.g., wrapped Agents) instead of standard models.
             When a model name in the mapping is referenced, the corresponding Model/string is used.
-        transparent_proxy: Run the bridge as a faithful transparent proxy (defaults
-            to `False`). When `True`, each request is routed to the model the agent
-            actually asked for -- no alias table and no fallback collapse onto the
-            session model -- and the client's generation parameters are treated as
-            authoritative. Required when the agent makes internal model calls of its
-            own that must reach their real provider model rather than being served by
-            the session model, e.g. Claude Code's auto-mode security classifier under
-            `auto_mode=True`. With the default `False`, the presented-identity aliases
-            and the fallback model collapse such a request onto the session model, so
-            the classifier is served by the wrong model (and its generation parameters,
-            e.g. `max_tokens`, are dropped).
+        transparent_proxy: Forward the client's generation parameters as
+            authoritative instead of merging in the eval's active
+            `GenerateConfig` (defaults to `False`). Claude Code's auto-mode
+            security classifier makes its own internal model call under
+            `permission_mode="auto"`, and by default the classifier's own
+            generation parameters (e.g. `max_tokens`) are dropped in favor of
+            the eval's `GenerateConfig`. The classifier's model identity is
+            unaffected either way -- it already resolves through the
+            presented-identity/role aliases above (or the fallback model, for
+            any identity not covered by those), the same as every other
+            bridged request.
         opus_model: The model to use for `opus`, or for `opusplan` when Plan Mode is active. Defaults to `model`.
         sonnet_model: The model to use for `sonnet`, or for `opusplan` when Plan Mode is not active. Defaults to `model`.
         haiku_model: The model to use for haiku, or [background functionality](https://code.claude.com/docs/en/costs#background-token-usage). Defaults to `model`.
@@ -295,8 +295,8 @@ def claude_code(
             checkpointer() as cp,
             sandbox_agent_bridge(
                 state,
-                model=None if transparent_proxy else models.bridge_model,
-                model_aliases=None if transparent_proxy else models.aliases,
+                model=models.bridge_model,
+                model_aliases=models.aliases,
                 forward_generation_config=transparent_proxy,
                 filter=filter,
                 sandbox=sandbox,

--- a/src/inspect_swe/_codex_cli/codex_cli.py
+++ b/src/inspect_swe/_codex_cli/codex_cli.py
@@ -162,16 +162,20 @@ def codex_cli(
         model_aliases: Optional mapping of model names to Model instances or model name strings.
             Allows using custom Model implementations (e.g., wrapped Agents) instead of standard models.
             When a model name in the mapping is referenced, the corresponding Model/string is used.
-        transparent_proxy: Run the bridge as a faithful transparent proxy (defaults
-            to `False`). When `True`, each request is routed to the model the agent
-            actually asked for -- no alias table and no fallback collapse onto the
-            session model -- and the client's generation parameters are treated as
-            authoritative. Required when the agent makes internal model calls of its
-            own that must reach their real provider model rather than being served by
-            the session model, e.g. Codex's `auto_review` reviewer (`codex-auto-review`)
-            under `approval_policy="on-request"`. With the default `False`, such a
-            request falls through to the fallback model, so the reviewer is silently
-            served by the session model instead of OpenAI's reviewer.
+        transparent_proxy: Bind the `auto_review` guardian slug
+            (`codex-auto-review`) to the real target model even when
+            `auto_review` doesn't configure its own `model`, and forward the
+            client's generation parameters as authoritative instead of merging
+            in the eval's active `GenerateConfig` (defaults to `False`). Codex
+            hardcodes that guardian slug into every reviewer request
+            regardless of configuration, so without this the request has no
+            alias, falls through to the session model instead of the intended
+            guardian, and the guardian's own generation parameters (e.g.
+            `max_tokens`) are dropped. Required for `auto_review=True` with
+            `approval_policy="on-request"` when no explicit
+            `CodexAutoReview(model=...)` is set. The ordinary bridged request
+            (Codex's own `--model` slug) is unaffected -- it keeps resolving
+            to the real target model exactly as it does with `transparent_proxy=False`.
         filter: Filter for intercepting bridged model requests.
         retry_refusals: Should refusals be retried? (pass number of times to retry)
         home_dir: Home directory to use for codex cli. If set, AGENTS.md, skills, and the MCP configuration will be written here.
@@ -360,11 +364,11 @@ def codex_cli(
             checkpointer() as cp,
             sandbox_agent_bridge(
                 state,
-                model=None if transparent_proxy else bridge_model,
-                model_aliases=None
-                if transparent_proxy
-                else resolve_codex_auto_review_model_aliases(
-                    resolved_auto_review, model_aliases
+                model=bridge_model,
+                model_aliases=resolve_codex_auto_review_model_aliases(
+                    resolved_auto_review,
+                    model_aliases,
+                    default=get_model(model) if transparent_proxy else None,
                 ),
                 forward_generation_config=transparent_proxy,
                 filter=filter,

--- a/src/inspect_swe/_codex_cli/codex_cli.py
+++ b/src/inspect_swe/_codex_cli/codex_cli.py
@@ -105,6 +105,7 @@ def codex_cli(
     attempts: int | AgentAttempts = 1,
     model: str | None = None,
     model_aliases: dict[str, str | Model] | None = None,
+    transparent_proxy: bool = False,
     filter: GenerateFilter | None = None,
     retry_refusals: int | None = None,
     home_dir: str | None = None,
@@ -161,6 +162,16 @@ def codex_cli(
         model_aliases: Optional mapping of model names to Model instances or model name strings.
             Allows using custom Model implementations (e.g., wrapped Agents) instead of standard models.
             When a model name in the mapping is referenced, the corresponding Model/string is used.
+        transparent_proxy: Run the bridge as a faithful transparent proxy (defaults
+            to `False`). When `True`, each request is routed to the model the agent
+            actually asked for -- no alias table and no fallback collapse onto the
+            session model -- and the client's generation parameters are treated as
+            authoritative. Required when the agent makes internal model calls of its
+            own that must reach their real provider model rather than being served by
+            the session model, e.g. Codex's `auto_review` reviewer (`codex-auto-review`)
+            under `approval_policy="on-request"`. With the default `False`, such a
+            request falls through to the fallback model, so the reviewer is silently
+            served by the session model instead of OpenAI's reviewer.
         filter: Filter for intercepting bridged model requests.
         retry_refusals: Should refusals be retried? (pass number of times to retry)
         home_dir: Home directory to use for codex cli. If set, AGENTS.md, skills, and the MCP configuration will be written here.
@@ -349,10 +360,13 @@ def codex_cli(
             checkpointer() as cp,
             sandbox_agent_bridge(
                 state,
-                model=bridge_model,
-                model_aliases=resolve_codex_auto_review_model_aliases(
+                model=None if transparent_proxy else bridge_model,
+                model_aliases=None
+                if transparent_proxy
+                else resolve_codex_auto_review_model_aliases(
                     resolved_auto_review, model_aliases
                 ),
+                forward_generation_config=transparent_proxy,
                 filter=filter,
                 sandbox=sandbox,
                 retry_refusals=retry_refusals,

--- a/tests/test_claude_code_model.py
+++ b/tests/test_claude_code_model.py
@@ -5,6 +5,7 @@ Uses the keyless ``mockllm`` provider so these run without Docker or API keys
 and ``model_config`` override logic in ``resolve_claude_code_models``.
 """
 
+from inspect_ai.agent._bridge.util import resolve_inspect_model
 from inspect_ai.model import Model
 from inspect_swe._claude_code.model import resolve_claude_code_models
 
@@ -52,3 +53,16 @@ def test_caller_model_aliases_take_precedence() -> None:
         model_aliases={"model": "mockllm/override"},
     )
     assert models.aliases["model"] == "mockllm/override"
+
+
+def test_transparent_proxy_presented_identity_resolves_via_alias() -> None:
+    # reproduces the review finding on #100: claude_code's presented identity
+    # is a bare, unprefixed name (e.g. "claude-sonnet-4-5", or a real model's
+    # own bare name), which can't resolve as a raw model name -- get_model()
+    # requires "<api_name>/<model_name>". claude_code()'s execute() keeps the
+    # presented-identity alias table under transparent_proxy=True precisely
+    # so this, the main-line request, still resolves to the real served
+    # model instead of raising.
+    models = resolve_claude_code_models("mockllm/model", "claude-sonnet-4-5")
+    resolved = resolve_inspect_model(models.presented, models.aliases, None)
+    assert resolved.name == "model"

--- a/tests/test_codex_config.py
+++ b/tests/test_codex_config.py
@@ -1,7 +1,8 @@
 from typing import Any
 
 import pytest
-from inspect_ai.model import Model
+from inspect_ai.agent._bridge.util import resolve_inspect_model
+from inspect_ai.model import Model, get_model
 from inspect_ai.tool._mcp._config import MCPServerConfigHTTP
 from inspect_swe import codex_cli, interactive_codex_cli
 from inspect_swe._codex_cli.config import (
@@ -251,6 +252,38 @@ def test_codex_cli_accepts_auto_review() -> None:
 
 def test_codex_cli_accepts_auto_review_with_transparent_proxy() -> None:
     codex_cli(auto_review=True, transparent_proxy=True)
+
+
+def test_transparent_proxy_binds_guardian_without_explicit_model() -> None:
+    # reproduces the review finding on #100: with auto_review enabled but no
+    # explicit CodexAutoReview(model=...), codex's guardian request (hardcoded
+    # to GUARDIAN_MODEL_SLUG regardless of configuration) must still resolve
+    # to the real target model rather than raising or falling through to some
+    # other model -- this is exactly what codex_cli()'s execute() computes
+    # for the bridge's model_aliases under transparent_proxy=True.
+    real_model = get_model("mockllm/model")
+    aliases = resolve_codex_auto_review_model_aliases(
+        resolve_codex_auto_review(True), None, default=real_model
+    )
+    resolved = resolve_inspect_model(GUARDIAN_MODEL_SLUG, aliases, None)
+    assert resolved is real_model
+
+
+def test_transparent_proxy_keeps_main_line_fallback() -> None:
+    # the review also found that codex's own --model slug (a bare, unprefixed
+    # catalog slug like "gpt-5.1-codex") can't resolve as a raw model name --
+    # get_model() requires "<api_name>/<model_name>". codex_cli()'s execute()
+    # keeps passing the bridge sentinel as the fallback under
+    # transparent_proxy=True precisely so this ordinary request still
+    # resolves, the same as when transparent_proxy=False.
+    model = "mockllm/model"
+    real_model = get_model(model)
+    bridge_model = f"inspect/{model}"  # mirrors codex_cli()'s own bridge_model
+    aliases = resolve_codex_auto_review_model_aliases(
+        resolve_codex_auto_review(True), None, default=real_model
+    )
+    resolved = resolve_inspect_model("gpt-5.1-codex", aliases, bridge_model)
+    assert resolved.name == real_model.name
 
 
 def test_interactive_codex_cli_accepts_auto_review(

--- a/tests/test_codex_config.py
+++ b/tests/test_codex_config.py
@@ -249,6 +249,10 @@ def test_codex_cli_accepts_auto_review() -> None:
     )
 
 
+def test_codex_cli_accepts_auto_review_with_transparent_proxy() -> None:
+    codex_cli(auto_review=True, transparent_proxy=True)
+
+
 def test_interactive_codex_cli_accepts_auto_review(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

Adds an opt-in `transparent_proxy` mode to the Codex CLI and Claude Code bridges. When enabled, the bridge forwards the client's own generation parameters (via inspect_ai's `forward_generation_config`) instead of clearing them, so an evaluated agent's internal model calls reproduce the configuration the agent's SDK actually sent. The bridge alias table and fallback model are retained; this does not replace them.

## Notes

- `transparent_proxy` composes with `auto_review`. The Codex guardian slug (`codex-auto-review`) is bound via `default=get_model(model)` so it resolves under the flag instead of losing its alias.
- Generation params are forwarded bridge-wide, but the eval's explicitly-set `GenerateConfig` still takes precedence on the active model (forwarding only fills fields the eval leaves unset). In practice this changes the internal reviewer/classifier/guardian calls and otherwise-unset params.
- Opt-in: `transparent_proxy` defaults to `False`.

## Verification

- `KUBECONFIG=/dev/null uv run pytest tests/ -x -q` (140 passed, 63 skipped)
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy src tests`

Written by Claude, acting for Sami (@sjawhar).
