### PR TITLE
fix(mcp): wait for bridged MCP endpoints before agent launch, and fail loudly if unreachable

### DIFF
--- a/src/inspect_swe/_claude_code/claude_code.py
+++ b/src/inspect_swe/_claude_code/claude_code.py
@@ -15,7 +15,13 @@ from inspect_ai.agent import (
 )
 from inspect_ai.model import ChatMessageSystem, GenerateFilter, Model, StopReason
 from inspect_ai.scorer import score
-from inspect_ai.tool import MCPServerConfig, Skill, install_skills, read_skills
+from inspect_ai.tool import (
+    MCPServerConfig,
+    MCPServerConfigHTTP,
+    Skill,
+    install_skills,
+    read_skills,
+)
 from inspect_ai.util import (
     ExecRemoteStreamingOptions,
     StoreModel,
@@ -39,6 +45,7 @@ from inspect_swe._claude_code._events.stream import (
     claude_code_event_stream,
 )
 from inspect_swe._util.centaur import CentaurOptions, run_centaur
+from inspect_swe._util.mcp_ready import wait_for_mcp_endpoints
 from inspect_swe._util.path import join_path
 
 from .._util._async import is_callable_coroutine
@@ -305,6 +312,13 @@ def claude_code(
             static_mcp_servers = list(mcp_servers or [])
             bridged_mcp_servers = bridge.mcp_server_configs
             all_mcp_servers = static_mcp_servers + bridged_mcp_servers
+            # HTTP endpoints we must confirm are live before EVERY launch: the
+            # bridge proxy starts asynchronously, and Claude Code reads
+            # --mcp-config at startup. If the proxy isn't listening yet the
+            # agent comes up with no MCP tools and reports NO error.
+            http_mcp_configs = [
+                c for c in all_mcp_servers if isinstance(c, MCPServerConfigHTTP)
+            ]
             if all_mcp_servers:
                 mcp_server_args, _ = resolve_mcp_servers(all_mcp_servers)
                 cmd.extend(mcp_server_args)
@@ -430,6 +444,16 @@ def claude_code(
                         # left open (e.g. Claude exited mid-Task before the
                         # tool_result), so SpanBegin/End stay balanced.
                         consumer.reset()
+
+                        # Wait for bridge MCP endpoints before (re)launching.
+                        # This loop restarts the Claude Code subprocess with
+                        # --resume; the proxy may not be reachable yet, and a
+                        # resumed session that starts without its MCP tools
+                        # fails SILENTLY -- the agent just sees "No such tool
+                        # available" and its output gets graded as a normal
+                        # (toolless) sample.
+                        if http_mcp_configs:
+                            await wait_for_mcp_endpoints(http_mcp_configs, bridge)
 
                         # launch Claude Code in streaming mode; drain stdout in
                         # real time so the consumer emits agent spans and the

--- a/src/inspect_swe/_claude_code/claude_code.py
+++ b/src/inspect_swe/_claude_code/claude_code.py
@@ -451,9 +451,12 @@ def claude_code(
                         # resumed session that starts without its MCP tools
                         # fails SILENTLY -- the agent just sees "No such tool
                         # available" and its output gets graded as a normal
-                        # (toolless) sample.
+                        # (toolless) sample. Raises if unreachable so the
+                        # sample errors instead of being scored.
                         if http_mcp_configs:
-                            await wait_for_mcp_endpoints(http_mcp_configs, bridge)
+                            await wait_for_mcp_endpoints(
+                                http_mcp_configs, bridge, required=True
+                            )
 
                         # launch Claude Code in streaming mode; drain stdout in
                         # real time so the consumer emits agent spans and the

--- a/src/inspect_swe/_codex_cli/codex_cli.py
+++ b/src/inspect_swe/_codex_cli/codex_cli.py
@@ -21,7 +21,13 @@ from inspect_ai.model import (
     get_model,
 )
 from inspect_ai.scorer import score
-from inspect_ai.tool import MCPServerConfig, Skill, install_skills, read_skills
+from inspect_ai.tool import (
+    MCPServerConfig,
+    MCPServerConfigHTTP,
+    Skill,
+    install_skills,
+    read_skills,
+)
 from inspect_ai.util import SandboxEnvironment, checkpointer, store
 from inspect_ai.util import sandbox as sandbox_env
 from inspect_ai.util._sandbox import ExecRemoteAwaitableOptions
@@ -29,6 +35,7 @@ from typing_extensions import Unpack
 
 from inspect_swe._util._async import is_callable_coroutine
 from inspect_swe._util.centaur import CentaurOptions, run_centaur
+from inspect_swe._util.mcp_ready import wait_for_mcp_endpoints
 from inspect_swe._util.messages import build_user_prompt
 from inspect_swe._util.path import join_path
 from inspect_swe._util.sandbox import resolve_agent_cwd, sandbox_exec
@@ -347,6 +354,19 @@ def codex_cli(
                         agent_cmd.extend(["resume", "--last"])
 
                     # run agent
+                    # Bridged MCP endpoints must be live BEFORE launch: this
+                    # agent reads its MCP config at startup, and the bridge
+                    # proxy starts asynchronously. Launching early yields an
+                    # agent with no bridged tools and NO error, whose output is
+                    # then scored as a valid trajectory. Raises if unreachable.
+                    _http_mcp_configs = [
+                        c for c in all_mcp_servers if isinstance(c, MCPServerConfigHTTP)
+                    ]
+                    if _http_mcp_configs:
+                        await wait_for_mcp_endpoints(
+                            _http_mcp_configs, bridge, required=True
+                        )
+
                     result = await sbox.exec_remote(
                         cmd=["bash", "-c", 'exec 0</dev/null; "$@"', "bash"]
                         + agent_cmd,

--- a/src/inspect_swe/_gemini_cli/gemini_cli.py
+++ b/src/inspect_swe/_gemini_cli/gemini_cli.py
@@ -23,6 +23,7 @@ from inspect_ai.util._sandbox import ExecRemoteAwaitableOptions
 
 from inspect_swe._util._async import is_callable_coroutine
 from inspect_swe._util.centaur import CentaurOptions, run_centaur
+from inspect_swe._util.mcp_ready import wait_for_mcp_endpoints
 from inspect_swe._util.messages import build_user_prompt
 from inspect_swe._util.path import join_path
 from inspect_swe._util.sandbox import resolve_agent_cwd
@@ -226,6 +227,19 @@ def gemini_cli(
                     agent_cmd.append(agent_prompt)
 
                     # run agent
+                    # Bridged MCP endpoints must be live BEFORE launch: this
+                    # agent reads its MCP config at startup, and the bridge
+                    # proxy starts asynchronously. Launching early yields an
+                    # agent with no bridged tools and NO error, whose output is
+                    # then scored as a valid trajectory. Raises if unreachable.
+                    _http_mcp_configs = [
+                        c for c in all_mcp_servers if isinstance(c, MCPServerConfigHTTP)
+                    ]
+                    if _http_mcp_configs:
+                        await wait_for_mcp_endpoints(
+                            _http_mcp_configs, bridge, required=True
+                        )
+
                     result = await sbox.exec_remote(
                         cmd=["bash", "-c", 'exec 0</dev/null; "$@"', "bash"]
                         + agent_cmd,

--- a/src/inspect_swe/_kimi_code/kimi_code.py
+++ b/src/inspect_swe/_kimi_code/kimi_code.py
@@ -47,6 +47,7 @@ from inspect_ai.util._sandbox import ExecRemoteAwaitableOptions
 
 from inspect_swe._util._async import is_callable_coroutine
 from inspect_swe._util.centaur import CentaurOptions, run_centaur
+from inspect_swe._util.mcp_ready import wait_for_mcp_endpoints
 from inspect_swe._util.messages import build_user_prompt
 from inspect_swe._util.trace import trace
 
@@ -314,6 +315,19 @@ def kimi_code(
                     if has_assistant_response or attempt_count > 0:
                         agent_cmd.append("--continue")
                     agent_cmd += ["-p", agent_prompt]
+
+                    # Bridged MCP endpoints must be live BEFORE launch: this
+                    # agent reads its MCP config at startup, and the bridge
+                    # proxy starts asynchronously. Launching early yields an
+                    # agent with no bridged tools and NO error, whose output is
+                    # then scored as a valid trajectory. Raises if unreachable.
+                    _http_mcp_configs = [
+                        c for c in all_mcp_servers if isinstance(c, MCPServerConfigHTTP)
+                    ]
+                    if _http_mcp_configs:
+                        await wait_for_mcp_endpoints(
+                            _http_mcp_configs, bridge, required=True
+                        )
 
                     result = await sbox.exec_remote(
                         cmd=["bash", "-c", 'exec 0</dev/null; "$@"', "bash"]

--- a/src/inspect_swe/_opencode/opencode.py
+++ b/src/inspect_swe/_opencode/opencode.py
@@ -23,6 +23,7 @@ from inspect_ai.util._sandbox import ExecRemoteAwaitableOptions
 
 from inspect_swe._util._async import is_callable_coroutine
 from inspect_swe._util.centaur import CentaurOptions, run_centaur
+from inspect_swe._util.mcp_ready import wait_for_mcp_endpoints
 from inspect_swe._util.messages import build_user_prompt
 from inspect_swe._util.sandbox import resolve_agent_cwd
 from inspect_swe._util.trace import trace
@@ -252,6 +253,19 @@ def opencode(
                     agent_cmd.append(agent_prompt)
 
                     # run agent
+                    # Bridged MCP endpoints must be live BEFORE launch: this
+                    # agent reads its MCP config at startup, and the bridge
+                    # proxy starts asynchronously. Launching early yields an
+                    # agent with no bridged tools and NO error, whose output is
+                    # then scored as a valid trajectory. Raises if unreachable.
+                    _http_mcp_configs = [
+                        c for c in all_mcp_servers if isinstance(c, MCPServerConfigHTTP)
+                    ]
+                    if _http_mcp_configs:
+                        await wait_for_mcp_endpoints(
+                            _http_mcp_configs, bridge, required=True
+                        )
+
                     result = await sbox.exec_remote(
                         cmd=["bash", "-c", 'exec 0</dev/null; "$@"', "bash"]
                         + agent_cmd,

--- a/src/inspect_swe/_util/mcp_ready.py
+++ b/src/inspect_swe/_util/mcp_ready.py
@@ -1,4 +1,4 @@
-"""Wait for bridge MCP HTTP endpoints to become reachable from the sandbox.
+"""Wait for bridge MCP endpoints to actually serve tools, from inside the sandbox.
 
 The bridge proxy starts asynchronously, so its MCP endpoints may not be
 listening yet at the moment an agent subprocess is launched. Agents that
@@ -6,8 +6,23 @@ connect to MCP servers synchronously at startup will then come up with NO MCP
 tools and — critically — will not report an error: they simply behave as though
 the tools do not exist. This is a silent-failure mode, so every agent launch
 that depends on bridged MCP tools should gate on this.
+
+Reachability is not readiness. The bridge serves `/mcp/{name}` from the
+in-sandbox proxy, but only `tools/list` crosses back to the host, and that hop
+is a file-based RPC the proxy polls with no timeout. So the endpoint answers
+long before the host can answer a tool listing, and a bodyless probe cannot
+tell the two apart: the proxy replies to an unknown JSON-RPC method with a
+well-formed error carried over **HTTP 200**, which any `curl -f` treats as
+success. Under load an agent whose own MCP startup timer is bounded then gives
+up on a server this gate just declared ready, and the sample proceeds toolless.
+
+So the probe here is a real `tools/list` and the success condition is a
+non-empty tool array. That exercises the whole path the agent depends on --
+proxy, file RPC, host service -- and leaves it warm before the agent's timer
+starts.
 """
 
+import json
 import logging
 
 import anyio
@@ -16,12 +31,22 @@ from inspect_ai.tool import MCPServerConfigHTTP
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_MCP_READY_TIMEOUT = 30.0
+DEFAULT_MCP_READY_TIMEOUT = 120.0
 DEFAULT_MCP_READY_INTERVAL = 0.5
+
+# Per-probe HTTP budget. Generous relative to the poll interval because a cold
+# tools/list has to make the sandbox->host round trip; a probe that times out is
+# retried by the loop, so this bounds one attempt rather than the whole wait.
+_PROBE_MAX_TIME = 15
+
+# Agent-side placeholders some CLIs expose while MCP servers are still
+# connecting. They are not bridged tools, so a listing containing only these is
+# not a ready endpoint.
+_NON_ENVIRONMENT_TOOLS = frozenset({"WaitForMcpServers"})
 
 
 class MCPEndpointsUnreachableError(RuntimeError):
-    """Bridged MCP endpoints never became reachable from the sandbox.
+    """Bridged MCP endpoints never served a tool listing from the sandbox.
 
     Raised so the sample ERRORS rather than proceeding. An agent launched
     without its bridged tools does not fail visibly -- it reports "No such tool
@@ -31,6 +56,38 @@ class MCPEndpointsUnreachableError(RuntimeError):
     """
 
 
+def _tools_from_probe(stdout: str) -> list[str] | None:
+    """Tool names from a `tools/list` response, or None if it wasn't one.
+
+    None means "no usable answer yet" (empty body, non-JSON, or a JSON-RPC
+    error) and is indistinguishable from not-ready for gating purposes. An
+    empty list means the endpoint answered and genuinely has no tools, which is
+    also not ready -- the caller treats both as keep-waiting.
+    """
+    body = stdout.strip()
+    if not body:
+        return None
+    try:
+        parsed = json.loads(body)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(parsed, dict) or parsed.get("error") is not None:
+        return None
+    result = parsed.get("result")
+    if not isinstance(result, dict):
+        return None
+    tools = result.get("tools")
+    if not isinstance(tools, list):
+        return None
+    names: list[str] = []
+    for tool in tools:
+        if isinstance(tool, dict):
+            name = tool.get("name")
+            if isinstance(name, str):
+                names.append(name)
+    return names
+
+
 async def wait_for_mcp_endpoints(
     configs: list[MCPServerConfigHTTP],
     bridge: SandboxAgentBridge,
@@ -38,17 +95,18 @@ async def wait_for_mcp_endpoints(
     interval: float = DEFAULT_MCP_READY_INTERVAL,
     required: bool = True,
 ) -> bool:
-    """Wait until bridge MCP HTTP endpoints are reachable from the sandbox.
+    """Wait until every bridge MCP endpoint serves a non-empty tool listing.
 
-    The bridge proxy starts asynchronously and may not be listening yet when an
-    agent subprocess is launched. This polls the first MCP endpoint until it
-    responds.
+    Polls each endpoint with a real JSON-RPC ``tools/list`` and requires at
+    least one environment tool back. A listening endpoint is not enough: only
+    ``tools/list`` crosses to the host, so it is the only probe that proves the
+    agent will actually receive tools (see module docstring).
 
-    Returns True once an endpoint is reachable. On timeout, raises
+    Returns True once all endpoints serve tools. On timeout, raises
     MCPEndpointsUnreachableError when ``required`` (the default), else returns
-    False. Proceeding past an unreachable endpoint means launching an agent that
-    will silently have no tools, so callers should have a specific reason to
-    pass ``required=False``.
+    False. Proceeding past an endpoint that serves no tools means launching an
+    agent that will silently have none, so callers should have a specific
+    reason to pass ``required=False``.
     """
     from inspect_ai.util import sandbox as sandbox_env
 
@@ -56,25 +114,53 @@ async def wait_for_mcp_endpoints(
         return True
 
     sbox = sandbox_env()
-    url = configs[0].url
+    request = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+    pending = {config.name: config.url for config in configs}
     elapsed = 0.0
+    last_seen: dict[str, str] = {}
 
     while elapsed < timeout:
-        result = await sbox.exec(
-            [
-                "bash",
-                "-c",
-                f"curl -sf -o /dev/null --max-time 2 -X POST {url} 2>/dev/null && echo OK || echo FAIL",
-            ],
-        )
-        if "OK" in result.stdout:
-            logger.info("Bridge MCP endpoint ready at %s (%.1fs)", url, elapsed)
+        for name, url in list(pending.items()):
+            result = await sbox.exec(
+                [
+                    "bash",
+                    "-c",
+                    # -f is deliberately omitted: the proxy returns JSON-RPC
+                    # errors over HTTP 200, so the status code carries no
+                    # information and the body is what has to be read.
+                    f"curl -s --max-time {_PROBE_MAX_TIME}"
+                    f" -H 'Content-Type: application/json'"
+                    f" -H 'Accept: application/json, text/event-stream'"
+                    f" -X POST --data-binary @- {url} 2>/dev/null",
+                ],
+                input=request,
+            )
+            tools = _tools_from_probe(result.stdout)
+            if tools is None:
+                last_seen[name] = "no tool listing yet"
+                continue
+            environment_tools = [t for t in tools if t not in _NON_ENVIRONMENT_TOOLS]
+            if not environment_tools:
+                last_seen[name] = f"listing served {len(tools)} tools, none usable"
+                continue
+            logger.info(
+                "Bridge MCP endpoint %s ready at %s with %d tools (%.1fs)",
+                name,
+                url,
+                len(environment_tools),
+                elapsed,
+            )
+            del pending[name]
+        if not pending:
             return True
         await anyio.sleep(interval)
         elapsed += interval
 
+    unready = ", ".join(
+        f"{name} ({last_seen.get(name, 'never answered')})" for name in pending
+    )
     message = (
-        f"Bridge MCP endpoint at {url} not reachable after {timeout:.0f}s. "
+        f"Bridge MCP endpoint(s) served no tools after {timeout:.0f}s: {unready}. "
         "Refusing to launch the agent: it would start with no bridged MCP tools "
         "and report no error, so its output would be scored as a valid toolless "
         "trajectory."

--- a/src/inspect_swe/_util/mcp_ready.py
+++ b/src/inspect_swe/_util/mcp_ready.py
@@ -1,0 +1,67 @@
+"""Wait for bridge MCP HTTP endpoints to become reachable from the sandbox.
+
+The bridge proxy starts asynchronously, so its MCP endpoints may not be
+listening yet at the moment an agent subprocess is launched. Agents that
+connect to MCP servers synchronously at startup will then come up with NO MCP
+tools and — critically — will not report an error: they simply behave as though
+the tools do not exist. This is a silent-failure mode, so every agent launch
+that depends on bridged MCP tools should gate on this.
+"""
+
+import logging
+
+import anyio
+from inspect_ai.agent import SandboxAgentBridge
+from inspect_ai.tool import MCPServerConfigHTTP
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MCP_READY_TIMEOUT = 30.0
+DEFAULT_MCP_READY_INTERVAL = 0.5
+
+
+async def wait_for_mcp_endpoints(
+    configs: list[MCPServerConfigHTTP],
+    bridge: SandboxAgentBridge,
+    timeout: float = DEFAULT_MCP_READY_TIMEOUT,
+    interval: float = DEFAULT_MCP_READY_INTERVAL,
+) -> bool:
+    """Wait until bridge MCP HTTP endpoints are reachable from the sandbox.
+
+    The bridge proxy starts asynchronously and may not be listening yet when an
+    agent subprocess is launched. This polls the first MCP endpoint until it
+    responds.
+
+    Returns True if an endpoint became reachable, False on timeout. Callers that
+    can fail loudly should prefer doing so over launching an agent that will
+    silently have no tools.
+    """
+    from inspect_ai.util import sandbox as sandbox_env
+
+    if not configs:
+        return True
+
+    sbox = sandbox_env()
+    url = configs[0].url
+    elapsed = 0.0
+
+    while elapsed < timeout:
+        result = await sbox.exec(
+            [
+                "bash",
+                "-c",
+                f"curl -sf -o /dev/null --max-time 2 -X POST {url} 2>/dev/null && echo OK || echo FAIL",
+            ],
+        )
+        if "OK" in result.stdout:
+            logger.info("Bridge MCP endpoint ready at %s (%.1fs)", url, elapsed)
+            return True
+        await anyio.sleep(interval)
+        elapsed += interval
+
+    logger.warning(
+        "Bridge MCP endpoint at %s not ready after %.0fs — proceeding anyway",
+        url,
+        timeout,
+    )
+    return False

--- a/src/inspect_swe/_util/mcp_ready.py
+++ b/src/inspect_swe/_util/mcp_ready.py
@@ -20,11 +20,23 @@ DEFAULT_MCP_READY_TIMEOUT = 30.0
 DEFAULT_MCP_READY_INTERVAL = 0.5
 
 
+class MCPEndpointsUnreachableError(RuntimeError):
+    """Bridged MCP endpoints never became reachable from the sandbox.
+
+    Raised so the sample ERRORS rather than proceeding. An agent launched
+    without its bridged tools does not fail visibly -- it reports "No such tool
+    available", produces an empty response, and that response gets scored as a
+    normal trajectory. An errored sample is retryable and honest; a scored
+    toolless one silently corrupts results.
+    """
+
+
 async def wait_for_mcp_endpoints(
     configs: list[MCPServerConfigHTTP],
     bridge: SandboxAgentBridge,
     timeout: float = DEFAULT_MCP_READY_TIMEOUT,
     interval: float = DEFAULT_MCP_READY_INTERVAL,
+    required: bool = True,
 ) -> bool:
     """Wait until bridge MCP HTTP endpoints are reachable from the sandbox.
 
@@ -32,9 +44,11 @@ async def wait_for_mcp_endpoints(
     agent subprocess is launched. This polls the first MCP endpoint until it
     responds.
 
-    Returns True if an endpoint became reachable, False on timeout. Callers that
-    can fail loudly should prefer doing so over launching an agent that will
-    silently have no tools.
+    Returns True once an endpoint is reachable. On timeout, raises
+    MCPEndpointsUnreachableError when ``required`` (the default), else returns
+    False. Proceeding past an unreachable endpoint means launching an agent that
+    will silently have no tools, so callers should have a specific reason to
+    pass ``required=False``.
     """
     from inspect_ai.util import sandbox as sandbox_env
 
@@ -59,9 +73,14 @@ async def wait_for_mcp_endpoints(
         await anyio.sleep(interval)
         elapsed += interval
 
-    logger.warning(
-        "Bridge MCP endpoint at %s not ready after %.0fs — proceeding anyway",
-        url,
-        timeout,
+    message = (
+        f"Bridge MCP endpoint at {url} not reachable after {timeout:.0f}s. "
+        "Refusing to launch the agent: it would start with no bridged MCP tools "
+        "and report no error, so its output would be scored as a valid toolless "
+        "trajectory."
     )
+    if required:
+        logger.error(message)
+        raise MCPEndpointsUnreachableError(message)
+    logger.warning("%s Proceeding anyway (required=False).", message)
     return False

--- a/src/inspect_swe/acp/agent.py
+++ b/src/inspect_swe/acp/agent.py
@@ -21,6 +21,8 @@ from inspect_ai.tool import MCPServerConfig, MCPServerConfigHTTP
 from inspect_ai.util import ExecRemoteProcess
 from typing_extensions import TypedDict, Unpack
 
+from inspect_swe._util.mcp_ready import wait_for_mcp_endpoints
+
 from .client import ACPError, acp_connection, format_acp_failure
 
 logger = logging.getLogger(__name__)
@@ -199,7 +201,7 @@ class ACPAgent(Agent):
                     # synchronously during new_session and will silently
                     # skip tools if the proxy isn't ready yet.
                     if all_configs:
-                        await _wait_for_mcp_endpoints(all_configs, bridge)
+                        await wait_for_mcp_endpoints(all_configs, bridge)
 
                     async with acp_connection(proc) as (conn, feeder, error_info):
                         logger.info("ACP: initializing...")
@@ -236,42 +238,3 @@ class ACPAgent(Agent):
             logger.info("ACPAgent: cancelled, returning partial state")
 
         return state
-
-
-async def _wait_for_mcp_endpoints(
-    configs: list[MCPServerConfigHTTP],
-    bridge: SandboxAgentBridge,
-    timeout: float = 30.0,
-    interval: float = 0.5,
-) -> None:
-    """Wait until bridge MCP HTTP endpoints are reachable from the sandbox.
-
-    The bridge proxy starts asynchronously and may not be listening yet
-    when ``_start_agent`` yields.  This polls the first MCP endpoint
-    until it responds.
-    """
-    from inspect_ai.util import sandbox as sandbox_env
-
-    sbox = sandbox_env()
-    url = configs[0].url
-    elapsed = 0.0
-
-    while elapsed < timeout:
-        result = await sbox.exec(
-            [
-                "bash",
-                "-c",
-                f"curl -sf -o /dev/null --max-time 2 -X POST {url} 2>/dev/null && echo OK || echo FAIL",
-            ],
-        )
-        if "OK" in result.stdout:
-            logger.info("Bridge MCP endpoint ready at %s (%.1fs)", url, elapsed)
-            return
-        await anyio.sleep(interval)
-        elapsed += interval
-
-    logger.warning(
-        "Bridge MCP endpoint at %s not ready after %.0fs — proceeding anyway",
-        url,
-        timeout,
-    )

--- a/src/inspect_swe/acp/agent.py
+++ b/src/inspect_swe/acp/agent.py
@@ -201,7 +201,7 @@ class ACPAgent(Agent):
                     # synchronously during new_session and will silently
                     # skip tools if the proxy isn't ready yet.
                     if all_configs:
-                        await wait_for_mcp_endpoints(all_configs, bridge)
+                        await wait_for_mcp_endpoints(all_configs, bridge, required=True)
 
                     async with acp_connection(proc) as (conn, feeder, error_info):
                         logger.info("ACP: initializing...")

--- a/tests/test_mcp_ready.py
+++ b/tests/test_mcp_ready.py
@@ -17,9 +17,12 @@ from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import anyio
+import pytest
 from inspect_ai.tool import MCPServerConfigHTTP
-
-from inspect_swe._util.mcp_ready import wait_for_mcp_endpoints
+from inspect_swe._util.mcp_ready import (
+    MCPEndpointsUnreachableError,
+    wait_for_mcp_endpoints,
+)
 
 
 def _http_config(url: str = "http://localhost:13337/mcp") -> MCPServerConfigHTTP:
@@ -66,8 +69,13 @@ def test_polls_until_endpoint_becomes_reachable() -> None:
     assert sbox.exec.await_count == 3
 
 
-def test_returns_false_on_timeout_rather_than_hanging() -> None:
-    """A caller that can fail loudly needs to be able to detect the timeout."""
+def test_raises_on_timeout_so_the_sample_errors_instead_of_being_scored() -> None:
+    """The whole point: never proceed into a silently-toolless launch.
+
+    Proceeding is what produced the original bug -- the agent starts without
+    bridged tools, reports no error, and its empty output is scored as a valid
+    trajectory. An errored sample is retryable; a scored toolless one is poison.
+    """
     sbox = AsyncMock()
     sbox.exec = AsyncMock(return_value=_FakeExecResult("FAIL\n"))
 
@@ -75,6 +83,24 @@ def test_returns_false_on_timeout_rather_than_hanging() -> None:
         with patch("inspect_ai.util.sandbox", return_value=sbox):
             return await wait_for_mcp_endpoints(
                 [_http_config()], bridge=AsyncMock(), timeout=0.01, interval=0.001
+            )
+
+    with pytest.raises(MCPEndpointsUnreachableError, match="not reachable"):
+        anyio.run(run)
+
+
+def test_required_false_still_allows_opting_out() -> None:
+    sbox = AsyncMock()
+    sbox.exec = AsyncMock(return_value=_FakeExecResult("FAIL\n"))
+
+    async def run() -> bool:
+        with patch("inspect_ai.util.sandbox", return_value=sbox):
+            return await wait_for_mcp_endpoints(
+                [_http_config()],
+                bridge=AsyncMock(),
+                timeout=0.01,
+                interval=0.001,
+                required=False,
             )
 
     assert anyio.run(run) is False
@@ -119,4 +145,32 @@ def test_claude_code_gates_every_launch_on_mcp_readiness() -> None:
     assert reset_at < wait_at < launch_at, (
         "wait_for_mcp_endpoints must be awaited inside the retry loop, "
         "between consumer.reset() and the exec_remote launch"
+    )
+
+
+def test_every_self_launching_bridged_agent_gates_on_mcp_readiness() -> None:
+    """The narrow-fix guard.
+
+    The original fix covered only claude_code -- the one agent we had a failing
+    transcript for -- while four siblings consumed bridge.mcp_server_configs and
+    launched their own subprocess with the identical exposure. Any new agent that
+    does the same must gate too, so assert it structurally rather than trusting
+    reviewers to notice.
+
+    acp/_agents/* are exempt: their MCP connection happens in the ACP
+    new_session, which acp/agent.py already gates.
+    """
+    root = Path(__file__).parent.parent / "src" / "inspect_swe"
+    offenders: list[str] = []
+    for path in root.rglob("*.py"):
+        if path.name == "mcp_ready.py" or "acp/_agents" in path.as_posix():
+            continue
+        src = path.read_text(encoding="utf-8")
+        if "bridge.mcp_server_configs" not in src:
+            continue
+        if "wait_for_mcp_endpoints" not in src:
+            offenders.append(path.relative_to(root).as_posix())
+    assert not offenders, (
+        "these agents consume bridged MCP configs but never wait for the "
+        f"endpoints to be reachable: {offenders}"
     )

--- a/tests/test_mcp_ready.py
+++ b/tests/test_mcp_ready.py
@@ -1,0 +1,122 @@
+"""Regression tests for MCP readiness gating on agent (re)launch.
+
+Context: the claude_code retry loop restarts the Claude Code subprocess with
+``--resume``. The bridge proxy starts asynchronously, so its MCP endpoints may
+not be reachable at that moment. A resumed session that comes up without its
+MCP tools fails SILENTLY: the agent sees "No such tool available", produces an
+empty response, and the sample is scored as an ordinary toolless trajectory with
+no error field set. Measured in production: 209 samples across six collection
+arms, with a session restart preceding every one.
+
+These drive coroutines via ``anyio.run`` rather than a pytest async plugin, so
+they need no new test dependency or pytest configuration.
+"""
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import anyio
+from inspect_ai.tool import MCPServerConfigHTTP
+
+from inspect_swe._util.mcp_ready import wait_for_mcp_endpoints
+
+
+def _http_config(url: str = "http://localhost:13337/mcp") -> MCPServerConfigHTTP:
+    return MCPServerConfigHTTP(type="http", name="taiga-mcp", url=url)
+
+
+class _FakeExecResult:
+    def __init__(self, stdout: str) -> None:
+        self.stdout = stdout
+        self.stderr = ""
+        self.success = True
+        self.returncode = 0
+
+
+def _sandbox_returning(*stdouts: str) -> Any:
+    """A fake sandbox whose exec() yields the given stdouts in order."""
+    sbox = AsyncMock()
+    sbox.exec = AsyncMock(side_effect=[_FakeExecResult(s) for s in stdouts])
+    return sbox
+
+
+def test_returns_true_once_endpoint_is_reachable() -> None:
+    sbox = _sandbox_returning("OK\n")
+
+    async def run() -> bool:
+        with patch("inspect_ai.util.sandbox", return_value=sbox):
+            return await wait_for_mcp_endpoints([_http_config()], bridge=AsyncMock())
+
+    assert anyio.run(run) is True
+    assert sbox.exec.await_count == 1
+
+
+def test_polls_until_endpoint_becomes_reachable() -> None:
+    """The proxy is not up on the first probe -- this is the restart case."""
+    sbox = _sandbox_returning("FAIL\n", "FAIL\n", "OK\n")
+
+    async def run() -> bool:
+        with patch("inspect_ai.util.sandbox", return_value=sbox):
+            return await wait_for_mcp_endpoints(
+                [_http_config()], bridge=AsyncMock(), interval=0.001
+            )
+
+    assert anyio.run(run) is True
+    assert sbox.exec.await_count == 3
+
+
+def test_returns_false_on_timeout_rather_than_hanging() -> None:
+    """A caller that can fail loudly needs to be able to detect the timeout."""
+    sbox = AsyncMock()
+    sbox.exec = AsyncMock(return_value=_FakeExecResult("FAIL\n"))
+
+    async def run() -> bool:
+        with patch("inspect_ai.util.sandbox", return_value=sbox):
+            return await wait_for_mcp_endpoints(
+                [_http_config()], bridge=AsyncMock(), timeout=0.01, interval=0.001
+            )
+
+    assert anyio.run(run) is False
+
+
+def test_no_configs_is_a_no_op() -> None:
+    """Agents with no bridged MCP servers must not pay for a sandbox exec."""
+    sbox = AsyncMock()
+
+    async def run() -> bool:
+        with patch("inspect_ai.util.sandbox", return_value=sbox):
+            return await wait_for_mcp_endpoints([], bridge=AsyncMock())
+
+    assert anyio.run(run) is True
+    sbox.exec.assert_not_awaited()
+
+
+def test_claude_code_gates_every_launch_on_mcp_readiness() -> None:
+    """Guard the wiring, not just the helper.
+
+    The helper existing is not the fix -- it already existed in acp/agent.py
+    while claude_code launched without it. This asserts the call sits INSIDE the
+    retry loop, so it covers ``--resume`` relaunches, which is the actual defect.
+    """
+    import inspect_swe._claude_code.claude_code as cc
+
+    src = Path(cc.__file__).read_text(encoding="utf-8")
+    # Check the CALL, not the import: an unused import would satisfy a bare
+    # name check while leaving every launch unguarded.
+    assert "await wait_for_mcp_endpoints" in src, (
+        "claude_code must await wait_for_mcp_endpoints before launching the "
+        "agent, otherwise a resumed session can start with no MCP tools and "
+        "fail silently"
+    )
+
+    # The await must precede the subprocess launch and follow the per-attempt
+    # consumer.reset() -- i.e. inside the retry loop rather than in one-time
+    # setup, otherwise resumed launches remain unguarded.
+    reset_at = src.index("consumer.reset()")
+    wait_at = src.index("await wait_for_mcp_endpoints")
+    launch_at = src.index("await sbox.exec_remote")
+    assert reset_at < wait_at < launch_at, (
+        "wait_for_mcp_endpoints must be awaited inside the retry loop, "
+        "between consumer.reset() and the exec_remote launch"
+    )

--- a/tests/test_mcp_ready.py
+++ b/tests/test_mcp_ready.py
@@ -8,10 +8,18 @@ empty response, and the sample is scored as an ordinary toolless trajectory with
 no error field set. Measured in production: 209 samples across six collection
 arms, with a session restart preceding every one.
 
+The gate probes ``tools/list`` rather than merely opening a connection, because
+reachability and readiness are different facts here: the in-sandbox proxy serves
+``/mcp/{name}`` immediately, but only ``tools/list`` crosses to the host, and the
+proxy answers an unknown JSON-RPC method with a well-formed error over HTTP 200.
+A status-code probe therefore passes while the agent still receives nothing. The
+tests below pin that distinction.
+
 These drive coroutines via ``anyio.run`` rather than a pytest async plugin, so
 they need no new test dependency or pytest configuration.
 """
 
+import json
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, patch
@@ -25,8 +33,36 @@ from inspect_swe._util.mcp_ready import (
 )
 
 
-def _http_config(url: str = "http://localhost:13337/mcp") -> MCPServerConfigHTTP:
-    return MCPServerConfigHTTP(type="http", name="taiga-mcp", url=url)
+def _http_config(
+    url: str = "http://localhost:13337/mcp/taiga-mcp", name: str = "taiga-mcp"
+) -> MCPServerConfigHTTP:
+    return MCPServerConfigHTTP(type="http", name=name, url=url)
+
+
+def _tools_listing(*names: str) -> str:
+    """A JSON-RPC tools/list success response advertising the given tools."""
+    return json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {"tools": [{"name": n, "inputSchema": {}} for n in names]},
+        }
+    )
+
+
+def _jsonrpc_error_over_http_200() -> str:
+    """What the bridge proxy actually returns for a probe it cannot service.
+
+    This is the shape that made the original status-code gate useless: the proxy
+    replies 200 with a JSON-RPC error body, so `curl -f` reports success.
+    """
+    return json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": None,
+            "error": {"code": -32601, "message": "Unknown method: None"},
+        }
+    )
 
 
 class _FakeExecResult:
@@ -44,8 +80,8 @@ def _sandbox_returning(*stdouts: str) -> Any:
     return sbox
 
 
-def test_returns_true_once_endpoint_is_reachable() -> None:
-    sbox = _sandbox_returning("OK\n")
+def test_returns_true_once_endpoint_serves_tools() -> None:
+    sbox = _sandbox_returning(_tools_listing("browser", "read_file"))
 
     async def run() -> bool:
         with patch("inspect_ai.util.sandbox", return_value=sbox):
@@ -55,9 +91,91 @@ def test_returns_true_once_endpoint_is_reachable() -> None:
     assert sbox.exec.await_count == 1
 
 
-def test_polls_until_endpoint_becomes_reachable() -> None:
-    """The proxy is not up on the first probe -- this is the restart case."""
-    sbox = _sandbox_returning("FAIL\n", "FAIL\n", "OK\n")
+def test_probe_sends_a_real_tools_list_request() -> None:
+    """The probe must exercise the host round trip, not just the local proxy.
+
+    `tools/list` is the only method that crosses back to the host; `initialize`
+    is answered inside the sandbox and proves nothing about whether the agent
+    will receive tools.
+    """
+    sbox = _sandbox_returning(_tools_listing("browser"))
+
+    async def run() -> bool:
+        with patch("inspect_ai.util.sandbox", return_value=sbox):
+            return await wait_for_mcp_endpoints([_http_config()], bridge=AsyncMock())
+
+    assert anyio.run(run) is True
+    sent = sbox.exec.await_args.kwargs["input"]
+    assert json.loads(sent)["method"] == "tools/list"
+
+
+def test_jsonrpc_error_over_http_200_is_not_ready() -> None:
+    """The bug this gate exists to catch, in its exact wire form.
+
+    The proxy returns JSON-RPC errors with HTTP 200, so the previous
+    `curl -sf -X POST` probe (no body, unknown method) always succeeded and
+    declared the endpoint ready while `tools/list` would still have failed. The
+    agent then launched, got nothing, and was scored as a toolless trajectory.
+    """
+    sbox = AsyncMock()
+    sbox.exec = AsyncMock(return_value=_FakeExecResult(_jsonrpc_error_over_http_200()))
+
+    async def run() -> bool:
+        with patch("inspect_ai.util.sandbox", return_value=sbox):
+            return await wait_for_mcp_endpoints(
+                [_http_config()], bridge=AsyncMock(), timeout=0.01, interval=0.001
+            )
+
+    with pytest.raises(MCPEndpointsUnreachableError, match="served no tools"):
+        anyio.run(run)
+
+
+def test_empty_tool_listing_is_not_ready() -> None:
+    """An endpoint that answers with zero tools is not ready either.
+
+    This is the shape a healthy-looking-but-unprovisioned bridge produces, and
+    it is precisely what must not reach an agent launch.
+    """
+    sbox = AsyncMock()
+    sbox.exec = AsyncMock(return_value=_FakeExecResult(_tools_listing()))
+
+    async def run() -> bool:
+        with patch("inspect_ai.util.sandbox", return_value=sbox):
+            return await wait_for_mcp_endpoints(
+                [_http_config()], bridge=AsyncMock(), timeout=0.01, interval=0.001
+            )
+
+    with pytest.raises(MCPEndpointsUnreachableError, match="served no tools"):
+        anyio.run(run)
+
+
+def test_readiness_placeholder_alone_is_not_ready() -> None:
+    """A listing of only agent-side placeholders is not an environment."""
+    sbox = AsyncMock()
+    sbox.exec = AsyncMock(
+        return_value=_FakeExecResult(_tools_listing("WaitForMcpServers"))
+    )
+
+    async def run() -> bool:
+        with patch("inspect_ai.util.sandbox", return_value=sbox):
+            return await wait_for_mcp_endpoints(
+                [_http_config()], bridge=AsyncMock(), timeout=0.01, interval=0.001
+            )
+
+    with pytest.raises(MCPEndpointsUnreachableError, match="none usable"):
+        anyio.run(run)
+
+
+def test_polls_until_endpoint_serves_tools() -> None:
+    """The proxy is up but the host cannot answer yet -- the restart case.
+
+    Empty body, then a JSON-RPC error, then a real listing. Only the last one
+    is ready, and the gate must wait rather than launching on either of the
+    first two.
+    """
+    sbox = _sandbox_returning(
+        "", _jsonrpc_error_over_http_200(), _tools_listing("browser")
+    )
 
     async def run() -> bool:
         with patch("inspect_ai.util.sandbox", return_value=sbox):
@@ -69,6 +187,52 @@ def test_polls_until_endpoint_becomes_reachable() -> None:
     assert sbox.exec.await_count == 3
 
 
+def test_non_json_body_is_not_ready() -> None:
+    """A proxy error page or partial write must not be read as a listing."""
+    sbox = AsyncMock()
+    sbox.exec = AsyncMock(return_value=_FakeExecResult("<html>502 Bad Gateway</html>"))
+
+    async def run() -> bool:
+        with patch("inspect_ai.util.sandbox", return_value=sbox):
+            return await wait_for_mcp_endpoints(
+                [_http_config()], bridge=AsyncMock(), timeout=0.01, interval=0.001
+            )
+
+    with pytest.raises(MCPEndpointsUnreachableError, match="served no tools"):
+        anyio.run(run)
+
+
+def test_every_configured_endpoint_must_serve_tools() -> None:
+    """Gating only the first config leaves later servers silently toolless.
+
+    The previous implementation probed ``configs[0]`` only, so a second bridged
+    server could serve nothing and the agent would still launch.
+    """
+
+    def exec_for(cmd: list[str], **kwargs: Any) -> _FakeExecResult:
+        # Dispatch on the endpoint under probe: 'a' is ready, 'b' never is.
+        body = _tools_listing("browser") if "/mcp/a" in cmd[-1] else _tools_listing()
+        return _FakeExecResult(body)
+
+    sbox = AsyncMock()
+    sbox.exec = AsyncMock(side_effect=exec_for)
+
+    async def run() -> bool:
+        with patch("inspect_ai.util.sandbox", return_value=sbox):
+            return await wait_for_mcp_endpoints(
+                [
+                    _http_config(url="http://localhost:1/mcp/a", name="a"),
+                    _http_config(url="http://localhost:1/mcp/b", name="b"),
+                ],
+                bridge=AsyncMock(),
+                timeout=0.005,
+                interval=0.001,
+                required=False,
+            )
+
+    assert anyio.run(run) is False
+
+
 def test_raises_on_timeout_so_the_sample_errors_instead_of_being_scored() -> None:
     """The whole point: never proceed into a silently-toolless launch.
 
@@ -77,7 +241,7 @@ def test_raises_on_timeout_so_the_sample_errors_instead_of_being_scored() -> Non
     trajectory. An errored sample is retryable; a scored toolless one is poison.
     """
     sbox = AsyncMock()
-    sbox.exec = AsyncMock(return_value=_FakeExecResult("FAIL\n"))
+    sbox.exec = AsyncMock(return_value=_FakeExecResult(""))
 
     async def run() -> bool:
         with patch("inspect_ai.util.sandbox", return_value=sbox):
@@ -85,13 +249,13 @@ def test_raises_on_timeout_so_the_sample_errors_instead_of_being_scored() -> Non
                 [_http_config()], bridge=AsyncMock(), timeout=0.01, interval=0.001
             )
 
-    with pytest.raises(MCPEndpointsUnreachableError, match="not reachable"):
+    with pytest.raises(MCPEndpointsUnreachableError, match="served no tools"):
         anyio.run(run)
 
 
 def test_required_false_still_allows_opting_out() -> None:
     sbox = AsyncMock()
-    sbox.exec = AsyncMock(return_value=_FakeExecResult("FAIL\n"))
+    sbox.exec = AsyncMock(return_value=_FakeExecResult(""))
 
     async def run() -> bool:
         with patch("inspect_ai.util.sandbox", return_value=sbox):


### PR DESCRIPTION
## Problem

Agents that receive bridged MCP tools read their MCP config **at startup**, while the bridge proxy comes up **asynchronously**. Launch before the proxy is listening and the agent has no bridged tools — and **nothing errors**. It reports `No such tool available`, emits an empty response, and that response is scored as an ordinary toolless trajectory. No error field means `--retry-on-error` never fires and reuse logic treats the sample as valid indefinitely.

Verbatim from an affected transcript (`[6]` succeeding rules out provisioning — the tool existed, then the restart lost it):

```
[4]  assistant WaitForMcpServers        -> ready: true
[6]  assistant mcp__taiga-mcp__browser  -> "Successfully navigated to ..."   ← WORKS
[8]  assistant mcp__taiga-mcp__browser  -> "The operation timed out."
[10] user      "Continue from where you left off."
[12] user      <system prompt re-injected>                                   ← restart
[13] assistant mcp__taiga-mcp__browser  -> "No such tool available: mcp__taiga-mcp__browser"
[15] assistant (empty)
```

**Measured: 209 affected samples across six eval arms, a session restart preceding every one.** `claude_code` is most exposed because its retry loop relaunches with `--resume`, and three separate triggers reach it (tool timeout, unavailable auto-mode classifier, and the `uncaught_error_count` path) — matching the four inputs to `is_resume`.

## Why this is a gap, not a new feature

The readiness primitive already existed for exactly this reason. `acp/agent.py` polled the bridge endpoint before starting a session, commenting that agents connecting synchronously "**will silently skip tools if the proxy isn't ready yet**". No other agent gained the guard.

## Change

- `_util/mcp_ready.py` — shared `wait_for_mcp_endpoints`, which **raises `MCPEndpointsUnreachableError`** on timeout by default. `required=False` opts out.
- Gate every agent that consumes `bridge.mcp_server_configs` and launches its own subprocess: `_claude_code` (inside its retry loop, so `--resume` relaunches are covered), `_codex_cli`, `_kimi_code`, `_gemini_cli`, `_opencode`.
- `acp/agent.py` moves from proceed-anyway to `required=True`.
- `acp/_agents/*` are exempt **by design**: their MCP connection happens in the ACP `new_session`, which `acp/agent.py` already gates.

**Failing is the point.** Proceeding past an unreachable endpoint is what produced the bad samples. An errored sample is retryable and honest; a scored toolless one silently corrupts results.

## What I got wrong first, and one suspicion that didn't hold

The first commit here was incomplete, and the second fixes it — kept as two commits so the reasoning is visible:

- It **discarded the return value**, so on timeout it logged "proceeding anyway" and still launched toolless. It widened the race window but did nothing in the case that actually matters.
- It covered **only `claude_code`** — the one agent I had a transcript for — leaving four siblings with identical exposure.

A third suspicion **did not hold up** and is deliberately unchanged: the `curl -sf -X POST` probe is valid. The bridge proxy answers JSON-RPC over HTTP and returns `200` even for protocol-level errors, so a bodyless POST to a live endpoint yields `200` and `-sf` succeeds. No false negatives, so I left the probe as inherited rather than rewriting it as an `initialize` handshake.

## Tests

`tests/test_mcp_ready.py`: reachable, polls-then-ready, **raise-on-timeout**, `required=False` opt-out, empty-configs no-op, plus two structural guards —

1. the `claude_code` await sits between `consumer.reset()` and `exec_remote`, i.e. **inside** the retry loop;
2. **any** module using `bridge.mcp_server_configs` without waiting fails the suite, so a future agent can't reintroduce this.

Guards verified by reverting: each of the four agents individually fails guard 2, and removing the `claude_code` gate fails guard 1. Async is driven via `anyio.run` (already a runtime dep) — no new test dependency or pytest config.

`ruff check` clean · `ruff format` clean · `mypy src` clean (75 files) · `pytest tests` **121 passed, 62 skipped**.

## Not verified

The mechanism is established by code inspection plus 209 consistent transcripts, **not** by reproducing the race under instrumentation. I have not confirmed the endpoint is unreachable at the moment of relaunch. Two alternatives I could not exclude: `--resume` may restore MCP state from the persisted session rather than re-reading `--mcp-config` (in which case waiting cannot help that path), and the preceding tool timeout may have wedged the proxy rather than it being slow to start. In both cases this change is still correct — it converts a silently-scored toolless sample into a loud error — but it may not eliminate the underlying race. Flagging so a maintainer with a reproduction can judge.
