### PR TITLE
ci: skip build matrix on docs-only changes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,6 +27,7 @@ jobs:
       - uses: dorny/paths-filter@v4
         id: filter
         with:
+          predicate-quantifier: 'every'
           filters: |
             code:
               - '**'
@@ -35,7 +36,7 @@ jobs:
 
   py-ruff:
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -51,7 +52,7 @@ jobs:
 
   py-mypy:
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -79,7 +80,7 @@ jobs:
 
   py-test:
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -106,7 +107,7 @@ jobs:
 
   py-build:
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,31 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Detect whether anything outside docs changed, so the build matrix can be
+  # skipped on documentation-only changes. A skipped job-level `if` still
+  # reports a (non-blocking) check, unlike workflow-level `paths-ignore`
+  # which would strand the required checks.
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            code:
+              - '**'
+              - '!docs/**'
+              - '!**/*.md'
+
   py-ruff:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -26,6 +50,8 @@ jobs:
           args: "format --check"
 
   py-mypy:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -52,6 +78,8 @@ jobs:
           mypy --python-executable $(which python)
 
   py-test:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -77,6 +105,8 @@ jobs:
         run: pytest
 
   py-build:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## Summary

Docs-only changes (anything under `docs/` or `*.md` files) currently trigger the full build matrix — ruff, mypy, pytest, and package build across Python 3.10/3.11. This PR adds a `dorny/paths-filter` `changes` job and gates all four build jobs on it, so documentation-only PRs skip the full build.

## Why job-level `if` instead of `paths-ignore`

The `main` ruleset requires all eight `py-*` matrix checks. With workflow-level `paths-ignore`, a docs-only PR would never report those checks and they'd sit in "Expected" forever, blocking merge. A job-level skip still reports each check with a `skipped` conclusion, which satisfies the required status checks.

This mirrors the pattern already used in [inspect_ai's build workflow](https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/.github/workflows/build.yml).

## Behavior

- Docs-only PR → `changes` runs (~5s), build matrix skipped, checks report as skipped and merge is unblocked
- Any code change → everything runs exactly as before
- Applies to pushes to `main` as well as PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)