### PR TITLE
fix(codex_cli): support Codex Multi-Agent V2 — package-archive install and sub-agent span reconstruction

### DIFF
--- a/src/inspect_swe/_codex_cli/_events/consumer.py
+++ b/src/inspect_swe/_codex_cli/_events/consumer.py
@@ -48,7 +48,9 @@ from inspect_ai.model._model import ModelEventSink
 from inspect_ai.util._span import current_span_id
 
 from .detection import (
+    agent_message_recipients,
     completed_thread_ids,
+    final_answer_authors,
     find_close_targets,
     find_spawned_agents,
     is_compaction_request,
@@ -71,6 +73,7 @@ class _OpenAgent:
     call_id: str
     span_id: str
     prompt: str
+    name: str = "agent"
     thread_id: str | None = None
 
 
@@ -118,9 +121,12 @@ class CodexConsumer(ModelEventSink):
 
     def on_pending(self, event: ModelEvent) -> None:
         # bind thread ids from any spawn results, then close completed threads
+        # (V1: wait/close status dicts; V2: FINAL_ANSWER agent_messages)
         self._harvest_bindings(event.input)
         for thread_id in completed_thread_ids(event.input):
             self._close_thread(thread_id)
+        for author in final_answer_authors(event.input):
+            self._close_thread(author)
 
         # attribute this call to a span
         span_id = self._attribute(event.input)
@@ -161,8 +167,11 @@ class CodexConsumer(ModelEventSink):
                     call_id=spawned.call_id,
                     span_id=span_id,
                     prompt=spawned.message,
+                    name=spawned.name,
                 )
                 metadata: dict[str, str] = {"agent_type": spawned.agent_type}
+                if spawned.task_name:
+                    metadata["task_name"] = spawned.task_name
                 if spawned.reasoning_effort:
                     metadata["reasoning_effort"] = spawned.reasoning_effort
                 transcript()._event(
@@ -170,7 +179,7 @@ class CodexConsumer(ModelEventSink):
                         id=span_id,
                         parent_id=parent_span_id,
                         type="agent",
-                        name=spawned.agent_type,
+                        name=spawned.name,
                         metadata=metadata,
                     )
                 )
@@ -214,12 +223,20 @@ class CodexConsumer(ModelEventSink):
     def _attribute(self, input_messages: list[ChatMessage]) -> str | None:
         """Resolve the span_id for an incoming bridge call.
 
-        Substring-matches the call's user-message text against open spawn
-        prompts. Exactly one match → that sub-agent's span; zero/multiple →
-        outer span (defensive default).
+        Multi-Agent V2 first: every agent_message in a request is inbound to
+        the requester, so a single recipient path identifies the calling agent
+        exactly (spawn prompts are encrypted under V2, so substring matching
+        cannot work). Falls back to the V1 heuristic: substring-match the
+        call's user-message text against open spawn prompts. Exactly one
+        match → that sub-agent's span; zero/multiple → outer span (defensive
+        default).
         """
         if not self._agents:
             return self.outer_span_id
+
+        span_id = self._attribute_by_recipient(input_messages)
+        if span_id is not None:
+            return span_id
 
         user_text = self._user_text(input_messages)
         if not user_text:
@@ -233,6 +250,44 @@ class CodexConsumer(ModelEventSink):
         if len(matches) == 1:
             return matches[0].span_id
         return self.outer_span_id
+
+    def _attribute_by_recipient(self, input_messages: list[ChatMessage]) -> str | None:
+        """Resolve a call's span from its agent_message recipient (V2).
+
+        A bound thread id (from a spawn result or an earlier call) resolves
+        directly. Otherwise the recipient's final path segment is matched
+        against open spawns awaiting their first call (the spawn call carries
+        the relative task_name, the recipient carries the absolute path, e.g.
+        "write_fizzbuzz" vs "/root/write_fizzbuzz") — a unique match binds the
+        thread id so later calls and FINAL_ANSWER closes resolve directly.
+        Returns None (fall through) when no unambiguous match exists.
+        """
+        recipients = agent_message_recipients(input_messages)
+        if len(recipients) != 1:
+            return None
+        recipient = next(iter(recipients))
+
+        # already bound (spawn result or earlier call)
+        call_id = self._thread_index.get(recipient)
+        if call_id is not None:
+            agent = self._agents.get(call_id)
+            if agent is not None:
+                return agent.span_id
+
+        # first call from this thread: bind by task name (last path segment)
+        basename = recipient.rsplit("/", 1)[-1]
+        candidates = [
+            agent
+            for agent in self._agents.values()
+            if agent.thread_id is None and agent.name == basename
+        ]
+        if len(candidates) == 1:
+            agent = candidates[0]
+            agent.thread_id = recipient
+            self._thread_index[recipient] = agent.call_id
+            return agent.span_id
+
+        return None
 
     @staticmethod
     def _user_text(input_messages: list[ChatMessage]) -> str:

--- a/src/inspect_swe/_codex_cli/_events/detection.py
+++ b/src/inspect_swe/_codex_cli/_events/detection.py
@@ -38,6 +38,52 @@ class SpawnedAgent:
     agent_type: str
     message: str
     reasoning_effort: str | None
+    task_name: str | None = None
+    """Multi-Agent V2 task name (e.g. "write_fizzbuzz"); None under V1."""
+
+    @property
+    def name(self) -> str:
+        """Display name for the agent's span (V2 task_name, else V1 agent_type)."""
+        return self.task_name or self.agent_type
+
+
+def agent_message_recipients(input_messages: list[ChatMessage]) -> set[str]:
+    """Recipients of the agent_message items in a request's input.
+
+    Multi-Agent V2 delivers inter-agent messages as `agent_message` input items;
+    the bridge preserves each raw item (author/recipient) on ContentText.internal.
+    Every agent_message in a request is inbound to the requester, so the
+    recipient path (e.g. "/root/write_fizzbuzz") identifies the calling agent.
+    """
+    return {
+        recipient
+        for item in _agent_message_items(input_messages)
+        if isinstance(recipient := item.get("recipient"), str) and recipient
+    }
+
+
+def final_answer_authors(input_messages: list[ChatMessage]) -> set[str]:
+    """Authors of FINAL_ANSWER agent_message items in a request's input.
+
+    A FINAL_ANSWER is a sub-agent's terminal return under Multi-Agent V2 (the
+    `wait_agent` result no longer carries per-thread completion status), so its
+    author path marks that agent's thread as completed.
+    """
+    authors: set[str] = set()
+    for item in _agent_message_items(input_messages):
+        author = item.get("author")
+        if not (isinstance(author, str) and author):
+            continue
+        for part in item.get("content") or []:
+            if (
+                isinstance(part, dict)
+                and part.get("type") == "input_text"
+                and isinstance(text := part.get("text"), str)
+                and text.lstrip().startswith("Message Type: FINAL_ANSWER")
+            ):
+                authors.add(author)
+                break
+    return authors
 
 
 def find_spawned_agents(tool_calls: list[ToolCall] | None) -> list[SpawnedAgent]:
@@ -51,12 +97,14 @@ def find_spawned_agents(tool_calls: list[ToolCall] | None) -> list[SpawnedAgent]
         if not isinstance(message, str) or not message:
             continue
         reasoning = args.get("reasoning_effort")
+        task_name = args.get("task_name")
         result.append(
             SpawnedAgent(
                 call_id=tc.id,
                 agent_type=str(args.get("agent_type") or "agent"),
                 message=message,
                 reasoning_effort=str(reasoning) if reasoning else None,
+                task_name=str(task_name) if task_name else None,
             )
         )
     return result
@@ -88,12 +136,15 @@ def spawn_result(message: ChatMessageTool) -> SpawnResult | None:
     The result is correlated to its spawn call by `message.tool_call_id`, so the
     caller can bind thread_id → span without any ordering assumptions. The
     `nickname` (Codex's friendly per-agent name) is surfaced for tool views.
+
+    Multi-Agent V2 results carry `{"task_name": "/root/<name>"}` instead of
+    `agent_id`/`nickname`; the absolute task path serves as the thread id.
     """
     if message.function != SPAWN_AGENT:
         return None
     data = _loads(message.text)
     if isinstance(data, dict):
-        agent_id = data.get("agent_id")
+        agent_id = data.get("agent_id") or data.get("task_name")
         if isinstance(agent_id, str) and agent_id:
             nickname = data.get("nickname")
             return SpawnResult(
@@ -133,6 +184,21 @@ def is_compaction_request(input_messages: list[ChatMessage]) -> bool:
 # ---------------------------------------------------------------------------
 # internal
 # ---------------------------------------------------------------------------
+
+
+def _agent_message_items(input_messages: list[ChatMessage]) -> list[dict[str, Any]]:
+    """Raw agent_message items stashed on user-message content by the bridge."""
+    items: list[dict[str, Any]] = []
+    for msg in input_messages:
+        if not isinstance(msg, ChatMessageUser) or isinstance(msg.content, str):
+            continue
+        for content in msg.content:
+            internal = getattr(content, "internal", None)
+            if isinstance(internal, dict):
+                item = internal.get("agent_message")
+                if isinstance(item, dict):
+                    items.append(item)
+    return items
 
 
 def _loads(text: str) -> Any:

--- a/src/inspect_swe/_codex_cli/agentbinary.py
+++ b/src/inspect_swe/_codex_cli/agentbinary.py
@@ -30,15 +30,25 @@ def codex_cli_binary_source() -> AgentBinarySource:
         # Get release information
         release = await _fetch_release_assets(version)
 
-        # Get the platform-specific asset
+        # Get the platform-specific asset. Prefer the full package archive
+        # (ships companion executables codex needs at runtime, e.g.
+        # codex-code-mode-host, which gpt-5.6+ models require for execution;
+        # first published with rust-v0.133.0) and fall back to the single
+        # codex binary for older releases.
         arch = _platform_to_codex_arch(platform)
-        asset_name = f"codex-{arch}.tar.gz"
+        candidates = [
+            (f"codex-package-{arch}.tar.gz", True),
+            (f"codex-{arch}.tar.gz", False),
+        ]
 
         # Find the matching asset
+        assets = {a["name"]: a for a in release.get("assets", [])}
         asset = None
-        for a in release.get("assets", []):
-            if a["name"] == asset_name:
-                asset = a
+        package = False
+        for asset_name, is_package in candidates:
+            asset = assets.get(asset_name)
+            if asset is not None:
+                package = is_package
                 break
 
         if asset is None:
@@ -55,13 +65,20 @@ def codex_cli_binary_source() -> AgentBinarySource:
         # Get download URL
         download_url = asset["browser_download_url"]
 
-        return AgentBinaryVersion(version, expected_checksum, download_url)
+        return AgentBinaryVersion(version, expected_checksum, download_url, package)
 
     def cached_binary_path(version: str, platform: SandboxPlatform) -> Path:
         return cached_binary_dir / f"codex-{version}-{platform}"
 
+    def cached_package_path(version: str, platform: SandboxPlatform) -> Path:
+        return cached_binary_dir / f"codex-package-{version}-{platform}.tar.gz"
+
     def list_cached_binaries() -> list[Path]:
-        return list(cached_binary_dir.glob("codex-*"))
+        return [
+            f
+            for f in cached_binary_dir.glob("codex-*")
+            if not f.name.endswith("-models.json")
+        ]
 
     return AgentBinarySource(
         agent="codex cli",
@@ -71,6 +88,8 @@ def codex_cli_binary_source() -> AgentBinarySource:
         list_cached_binaries=list_cached_binaries,
         post_download=extract_tarball,
         post_install=None,
+        package_entrypoint="bin/codex",
+        cached_package_path=cached_package_path,
     )
 
 

--- a/src/inspect_swe/_tools/download.py
+++ b/src/inspect_swe/_tools/download.py
@@ -99,7 +99,9 @@ def cached_agent_binaries(
     binaries = source.list_cached_binaries()
 
     def parse_name(name: str) -> tuple[str, str, int, int, int]:
-        match = re.match(r"([a-z_]+)-(\d+)\.(\d+)\.(\d+)", name)
+        # artifact names are either "<agent>-<version>-<platform>" (single
+        # binary) or "<agent>-package-<version>-<platform>.tar.gz" (package)
+        match = re.match(r"([a-z_]+(?:-package)?)-(\d+)\.(\d+)\.(\d+)", name)
         if match:
             return (
                 match.group(1),  # agent type

--- a/src/inspect_swe/_util/agentbinary.py
+++ b/src/inspect_swe/_util/agentbinary.py
@@ -92,7 +92,12 @@ async def ensure_agent_binary_installed(
     # use concurrency so multiple samples don't attempt the same download all at once
     async with concurrency(f"{source.binary}-install", 1, visible=False):
         # if a specific version is requested, first try to read it directly from
-        # the cache (package archive first, then single binary)
+        # the cache. package-capable sources only honor a package cache hit
+        # here: a single-binary entry may predate package support (cached by an
+        # older inspect_swe), so it must not short-circuit resolution or the
+        # package install would be silently defeated for exactly the users this
+        # exists for. resolution below still prefers caches; the single-binary
+        # cache remains the offline fallback.
         binary_bytes: bytes | None = None
         package = False
         if version not in ["stable", "latest"]:
@@ -101,18 +106,31 @@ async def ensure_agent_binary_installed(
                     source.cached_package_path(version, platform), None
                 )
                 package = binary_bytes is not None
-            if binary_bytes is None:
+            else:
                 binary_bytes = read_cached_binary(source, version, platform, None)
             if binary_bytes is not None:
                 trace(f"Used {source.agent} binary from cache: {version} ({platform})")
 
         # download the binary
         if binary_bytes is None:
-            binary_bytes, resolved = await download_agent_binary_async(
-                source, version, platform, trace
-            )
-            resolved_version = resolved.version
-            package = resolved.package
+            try:
+                binary_bytes, resolved = await download_agent_binary_async(
+                    source, version, platform, trace
+                )
+                resolved_version = resolved.version
+                package = resolved.package
+            except Exception:
+                # offline fallback: a pinned version with a cached single
+                # binary still installs (without companion executables)
+                if version not in ["stable", "latest"]:
+                    binary_bytes = read_cached_binary(source, version, platform, None)
+                if binary_bytes is None:
+                    raise
+                trace(
+                    f"Unable to resolve {source.agent} {version}; using cached "
+                    f"single binary ({platform})"
+                )
+                resolved_version = version
         else:
             # If we got it from cache, version is already the resolved version
             resolved_version = version
@@ -128,9 +146,16 @@ async def ensure_agent_binary_installed(
                     "does not define a package_entrypoint"
                 )
             binary_path = f"{install_path}/{source.package_entrypoint}"
-            # skip write + extract if this version's package is already installed
-            probe = await sandbox.exec(bash_command(f"test -x {binary_path}"))
+            # skip write + extract if this version's package is already
+            # installed (probe as root to match the extraction below, so a
+            # non-traversable install dir can't force re-extraction each call)
+            probe = await sandbox.exec(
+                bash_command(f"test -x {binary_path}"), user="root"
+            )
             if not probe.success:
+                # tar preserves mode bits, so companion executables in the
+                # archive (e.g. bin/*, codex-resources/*) stay executable; only
+                # the entrypoint is chmod'd as a belt-and-suspenders measure
                 archive_path = f"{install_path}.tar.gz"
                 await sandbox.write_file(archive_path, binary_bytes)
                 await sandbox_exec(
@@ -172,7 +197,9 @@ async def download_agent_binary_async(
         resolved = await source.resolve_version(version, platform)
         with _resolve_version_lock:
             _resolved_versions[cache_key] = resolved
-    version, expected_checksum, download_url = resolved[:3]
+    version = resolved.version
+    expected_checksum = resolved.expected_checksum
+    download_url = resolved.download_url
 
     # resolve the cache location (package archives are cached verbatim, so
     # their checksum stays verifiable; single binaries transformed by
@@ -202,6 +229,14 @@ async def download_agent_binary_async(
 
         # save to cache
         write_cached_file(source, binary_data, cache_path)
+
+        # a package supersedes any single-binary cache entry for the same
+        # version (cached by an older inspect_swe): remove it so it can't be
+        # served later and doesn't hold an eviction slot
+        if resolved.package:
+            stale = source.cached_binary_path(version, platform)
+            if stale.exists():
+                stale.unlink()
 
         # trace
         logger(f"Downloaded {source.agent} binary: {version} ({platform})")

--- a/src/inspect_swe/_util/agentbinary.py
+++ b/src/inspect_swe/_util/agentbinary.py
@@ -23,6 +23,10 @@ class AgentBinaryVersion(NamedTuple):
     version: str
     expected_checksum: str
     download_url: str
+    # the artifact is a package archive (extracted in the sandbox) rather than
+    # a single binary. requires the source to define package_entrypoint and
+    # cached_package_path.
+    package: bool = False
 
 
 @dataclass
@@ -37,6 +41,11 @@ class AgentBinarySource:
     list_cached_binaries: Callable[[], list[Path]]
     post_download: Callable[[bytes], bytes] | None
     post_install: str | None
+    # package-archive support: relative path of the agent binary within the
+    # extracted package (e.g. "bin/codex") and the cache location for package
+    # archives. required when resolve_version can return package=True.
+    package_entrypoint: str | None = None
+    cached_package_path: Callable[[str, SandboxPlatform], Path] | None = None
 
 
 # In-process cache for version resolution results. When many samples run
@@ -82,31 +91,60 @@ async def ensure_agent_binary_installed(
 
     # use concurrency so multiple samples don't attempt the same download all at once
     async with concurrency(f"{source.binary}-install", 1, visible=False):
-        # if a specific version is requested, first try to read it directly from the cache
+        # if a specific version is requested, first try to read it directly from
+        # the cache (package archive first, then single binary)
+        binary_bytes: bytes | None = None
+        package = False
         if version not in ["stable", "latest"]:
-            binary_bytes: bytes | None = read_cached_binary(
-                source, version, platform, None
-            )
+            if source.cached_package_path is not None:
+                binary_bytes = read_cached_file(
+                    source.cached_package_path(version, platform), None
+                )
+                package = binary_bytes is not None
+            if binary_bytes is None:
+                binary_bytes = read_cached_binary(source, version, platform, None)
             if binary_bytes is not None:
                 trace(f"Used {source.agent} binary from cache: {version} ({platform})")
-        else:
-            binary_bytes = None
 
         # download the binary
         if binary_bytes is None:
-            binary_bytes, resolved_version = await download_agent_binary_async(
+            binary_bytes, resolved = await download_agent_binary_async(
                 source, version, platform, trace
             )
+            resolved_version = resolved.version
+            package = resolved.package
         else:
             # If we got it from cache, version is already the resolved version
             resolved_version = version
 
         # write it into the container and return it
-        binary_path = (
+        install_path = (
             f"{SANDBOX_INSTALL_DIR}/{source.binary}-{resolved_version}-{platform}"
         )
-        await sandbox.write_file(binary_path, binary_bytes)
-        await sandbox_exec(sandbox, f"chmod +x {binary_path}", user="root")
+        if package:
+            if source.package_entrypoint is None:
+                raise RuntimeError(
+                    f"{source.agent} resolved a package archive but the source "
+                    "does not define a package_entrypoint"
+                )
+            binary_path = f"{install_path}/{source.package_entrypoint}"
+            # skip write + extract if this version's package is already installed
+            probe = await sandbox.exec(bash_command(f"test -x {binary_path}"))
+            if not probe.success:
+                archive_path = f"{install_path}.tar.gz"
+                await sandbox.write_file(archive_path, binary_bytes)
+                await sandbox_exec(
+                    sandbox,
+                    f"mkdir -p {install_path} && "
+                    f"tar -xzf {archive_path} -C {install_path} && "
+                    f"rm -f {archive_path} && "
+                    f"chmod +x {binary_path}",
+                    user="root",
+                )
+        else:
+            binary_path = install_path
+            await sandbox.write_file(binary_path, binary_bytes)
+            await sandbox_exec(sandbox, f"chmod +x {binary_path}", user="root")
         if source.post_install:
             await sandbox_exec(
                 sandbox, f"{binary_path} {source.post_install}", user=user
@@ -119,7 +157,7 @@ async def download_agent_binary_async(
     version: Literal["stable", "latest"] | str,
     platform: SandboxPlatform,
     logger: Callable[[str], None] | None = None,
-) -> tuple[bytes, str]:
+) -> tuple[bytes, AgentBinaryVersion]:
     # resolve logger
     logger = logger or print
 
@@ -134,11 +172,24 @@ async def download_agent_binary_async(
         resolved = await source.resolve_version(version, platform)
         with _resolve_version_lock:
             _resolved_versions[cache_key] = resolved
-    version, expected_checksum, download_url = resolved
+    version, expected_checksum, download_url = resolved[:3]
 
-    # check the cache (if post_download is used, don't verify checksum since cached is processed)
-    cache_checksum = None if source.post_download else expected_checksum
-    binary_data = read_cached_binary(source, version, platform, cache_checksum)
+    # resolve the cache location (package archives are cached verbatim, so
+    # their checksum stays verifiable; single binaries transformed by
+    # post_download can't be verified against the download checksum)
+    if resolved.package:
+        if source.cached_package_path is None:
+            raise RuntimeError(
+                f"{source.agent} resolved a package archive but the source "
+                "does not define a cached_package_path"
+            )
+        cache_path = source.cached_package_path(version, platform)
+        cache_checksum: str | None = expected_checksum
+    else:
+        cache_path = source.cached_binary_path(version, platform)
+        cache_checksum = None if source.post_download else expected_checksum
+
+    binary_data = read_cached_file(cache_path, cache_checksum)
     if binary_data is None:
         # not in cache, download and verify checksum
         binary_data = await download_file(download_url)
@@ -146,11 +197,11 @@ async def download_agent_binary_async(
             raise ValueError("Checksum verification failed")
 
         # apply post-download processing if provided (e.g., extract from tar.gz)
-        if source.post_download is not None:
+        if not resolved.package and source.post_download is not None:
             binary_data = source.post_download(binary_data)
 
         # save to cache
-        write_cached_binary(source, binary_data, version, platform)
+        write_cached_file(source, binary_data, cache_path)
 
         # trace
         logger(f"Downloaded {source.agent} binary: {version} ({platform})")
@@ -158,7 +209,7 @@ async def download_agent_binary_async(
         logger(f"Used {source.agent} binary from cache: {version} ({platform})")
 
     # return data and resolved version
-    return binary_data, version
+    return binary_data, resolved
 
 
 def read_cached_binary(
@@ -167,8 +218,13 @@ def read_cached_binary(
     platform: SandboxPlatform,
     expected_checksum: str | None,
 ) -> bytes | None:
-    # no cached binary
-    cache_path = source.cached_binary_path(version, platform)
+    return read_cached_file(
+        source.cached_binary_path(version, platform), expected_checksum
+    )
+
+
+def read_cached_file(cache_path: Path, expected_checksum: str | None) -> bytes | None:
+    # no cached file
     if not cache_path.exists():
         return None
 
@@ -184,15 +240,12 @@ def read_cached_binary(
         return None
 
 
-def write_cached_binary(
+def write_cached_file(
     source: AgentBinarySource,
     binary_data: bytes,
-    version: str,
-    platform: SandboxPlatform,
+    cache_path: Path,
 ) -> None:
-    binary_path = source.cached_binary_path(version, platform)
-
-    with open(binary_path, "wb") as f:
+    with open(cache_path, "wb") as f:
         f.write(binary_data)
 
     _cleanup_binary_cache(source, keep_count=3)

--- a/tests/test_agentbinary_install.py
+++ b/tests/test_agentbinary_install.py
@@ -176,3 +176,72 @@ def test_package_without_entrypoint_raises(tmp_path: Path) -> None:
             None,
             cast(SandboxEnvironment, sandbox),
         )
+
+
+def test_stale_single_binary_cache_still_installs_package(tmp_path: Path) -> None:
+    # a pinned version cached as a single binary by an older inspect_swe must
+    # not short-circuit resolution: the package is fetched, installed, and the
+    # superseded cache entry removed
+    data = b"package-tarball-bytes"
+    resolved = AgentBinaryVersion(
+        "9.9.7",
+        hashlib.sha256(data).hexdigest(),
+        "https://example.com/pkg.tar.gz",
+        True,
+    )
+    source = _package_source(tmp_path, resolved)
+    stale = source.cached_binary_path("9.9.7", "linux-arm64")
+    stale.write_bytes(b"stale-single-binary")
+
+    sandbox = _FakeSandbox(installed=False)
+    with (
+        patch.object(
+            agentbinary,
+            "detect_sandbox_platform",
+            AsyncMock(return_value="linux-arm64"),
+        ),
+        patch.object(agentbinary, "trace", lambda msg: None),
+        patch.object(agentbinary, "sandbox_exec", AsyncMock(return_value="")),
+        patch.object(agentbinary, "download_file", AsyncMock(return_value=data)),
+    ):
+        binary_path = anyio.run(
+            ensure_agent_binary_installed,
+            source,
+            "9.9.7",
+            None,
+            cast(SandboxEnvironment, sandbox),
+        )
+
+    assert binary_path.endswith("/bin/codex")
+    assert sandbox.written == [f"{SANDBOX_INSTALL_DIR}/codex-9.9.7-linux-arm64.tar.gz"]
+    assert source.cached_package_path is not None
+    assert source.cached_package_path("9.9.7", "linux-arm64").read_bytes() == data
+    assert not stale.exists()
+
+
+def test_offline_pinned_version_falls_back_to_cached_binary(tmp_path: Path) -> None:
+    # when resolution fails (offline) a pinned version with a cached single
+    # binary still installs, without the package
+    source = _package_source(tmp_path)  # resolve_version raises (resolved=None)
+    source.cached_binary_path("9.9.6", "linux-arm64").write_bytes(b"single-binary")
+
+    sandbox = _FakeSandbox(installed=False)
+    with (
+        patch.object(
+            agentbinary,
+            "detect_sandbox_platform",
+            AsyncMock(return_value="linux-arm64"),
+        ),
+        patch.object(agentbinary, "trace", lambda msg: None),
+        patch.object(agentbinary, "sandbox_exec", AsyncMock(return_value="")),
+    ):
+        binary_path = anyio.run(
+            ensure_agent_binary_installed,
+            source,
+            "9.9.6",
+            None,
+            cast(SandboxEnvironment, sandbox),
+        )
+
+    assert binary_path == f"{SANDBOX_INSTALL_DIR}/codex-9.9.6-linux-arm64"
+    assert sandbox.written == [binary_path]

--- a/tests/test_agentbinary_install.py
+++ b/tests/test_agentbinary_install.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, patch
 
 import anyio
 import pytest
+from inspect_ai.util import SandboxEnvironment
 from inspect_swe._util import agentbinary
 from inspect_swe._util.agentbinary import (
     AgentBinarySource,
@@ -15,7 +16,6 @@ from inspect_swe._util.agentbinary import (
     download_agent_binary_async,
     ensure_agent_binary_installed,
 )
-from inspect_ai.util import SandboxEnvironment
 from inspect_swe._util.sandbox import SANDBOX_INSTALL_DIR
 
 

--- a/tests/test_agentbinary_install.py
+++ b/tests/test_agentbinary_install.py
@@ -1,0 +1,178 @@
+"""Unit tests for package-archive installs in the agent binary machinery."""
+
+import hashlib
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import AsyncMock, patch
+
+import anyio
+import pytest
+from inspect_swe._util import agentbinary
+from inspect_swe._util.agentbinary import (
+    AgentBinarySource,
+    AgentBinaryVersion,
+    download_agent_binary_async,
+    ensure_agent_binary_installed,
+)
+from inspect_ai.util import SandboxEnvironment
+from inspect_swe._util.sandbox import SANDBOX_INSTALL_DIR
+
+
+def _package_source(
+    tmp_path: Path, resolved: AgentBinaryVersion | None = None
+) -> AgentBinarySource:
+    async def resolve_version(version: str, platform: str) -> AgentBinaryVersion:
+        assert resolved is not None
+        return resolved
+
+    return AgentBinarySource(
+        agent="codex cli",
+        binary="codex",
+        resolve_version=resolve_version,
+        cached_binary_path=lambda v, p: tmp_path / f"codex-{v}-{p}",
+        list_cached_binaries=lambda: [],
+        post_download=None,
+        post_install=None,
+        package_entrypoint="bin/codex",
+        cached_package_path=lambda v, p: tmp_path / f"codex-package-{v}-{p}.tar.gz",
+    )
+
+
+class _FakeSandbox:
+    """Records write_file calls; exec returns canned results by command."""
+
+    def __init__(self, installed: bool = False) -> None:
+        self.installed = installed
+        self.written: list[str] = []
+
+    async def exec(self, cmd: list[str], **kwargs: object) -> SimpleNamespace:
+        script = cmd[-1]
+        if script.startswith("test -x"):
+            return SimpleNamespace(success=self.installed, stdout="", stderr="")
+        return SimpleNamespace(success=True, stdout="", stderr="")
+
+    async def write_file(self, path: str, data: bytes) -> None:
+        self.written.append(path)
+
+
+def test_package_install_extracts_in_sandbox(tmp_path: Path) -> None:
+    source = _package_source(tmp_path)
+    assert source.cached_package_path is not None
+    cache = source.cached_package_path("9.9.9", "linux-arm64")
+    cache.write_bytes(b"tarball-bytes")
+
+    sandbox = _FakeSandbox(installed=False)
+    execs: list[str] = []
+
+    async def record_exec(sb: object, cmd: str, user: str | None = None) -> str:
+        execs.append(cmd)
+        return ""
+
+    with (
+        patch.object(
+            agentbinary,
+            "detect_sandbox_platform",
+            AsyncMock(return_value="linux-arm64"),
+        ),
+        patch.object(agentbinary, "trace", lambda msg: None),
+        patch.object(agentbinary, "sandbox_exec", record_exec),
+    ):
+        binary_path = anyio.run(
+            ensure_agent_binary_installed,
+            source,
+            "9.9.9",
+            None,
+            cast(SandboxEnvironment, sandbox),
+        )
+
+    install_dir = f"{SANDBOX_INSTALL_DIR}/codex-9.9.9-linux-arm64"
+    assert binary_path == f"{install_dir}/bin/codex"
+    assert sandbox.written == [f"{install_dir}.tar.gz"]
+    assert any("tar -xzf" in cmd and install_dir in cmd for cmd in execs)
+
+
+def test_package_install_skips_when_already_installed(tmp_path: Path) -> None:
+    source = _package_source(tmp_path)
+    assert source.cached_package_path is not None
+    source.cached_package_path("9.9.9", "linux-arm64").write_bytes(b"tarball-bytes")
+
+    sandbox = _FakeSandbox(installed=True)
+    with (
+        patch.object(
+            agentbinary,
+            "detect_sandbox_platform",
+            AsyncMock(return_value="linux-arm64"),
+        ),
+        patch.object(agentbinary, "trace", lambda msg: None),
+        patch.object(agentbinary, "sandbox_exec", AsyncMock(return_value="")),
+    ):
+        binary_path = anyio.run(
+            ensure_agent_binary_installed,
+            source,
+            "9.9.9",
+            None,
+            cast(SandboxEnvironment, sandbox),
+        )
+
+    assert binary_path.endswith("/bin/codex")
+    assert sandbox.written == []
+
+
+def test_download_caches_package_archive_verbatim(tmp_path: Path) -> None:
+    data = b"package-tarball-bytes"
+    resolved = AgentBinaryVersion(
+        "9.9.8",
+        hashlib.sha256(data).hexdigest(),
+        "https://example.com/pkg.tar.gz",
+        True,
+    )
+    source = _package_source(tmp_path, resolved)
+
+    with patch.object(agentbinary, "download_file", AsyncMock(return_value=data)):
+        downloaded, out = anyio.run(
+            download_agent_binary_async, source, "9.9.8", "linux-arm64"
+        )
+
+    assert downloaded == data
+    assert out.package is True
+    assert source.cached_package_path is not None
+    cache = source.cached_package_path("9.9.8", "linux-arm64")
+    assert cache.read_bytes() == data
+
+    # second call verifies the checksum against the verbatim cache (no download)
+    with patch.object(
+        agentbinary,
+        "download_file",
+        AsyncMock(side_effect=AssertionError("should not download")),
+    ):
+        cached, out = anyio.run(
+            download_agent_binary_async, source, "9.9.8", "linux-arm64"
+        )
+    assert cached == data
+
+
+def test_package_without_entrypoint_raises(tmp_path: Path) -> None:
+    source = _package_source(tmp_path)
+    source.package_entrypoint = None
+    assert source.cached_package_path is not None
+    source.cached_package_path("9.9.9", "linux-arm64").write_bytes(b"tarball-bytes")
+
+    sandbox = _FakeSandbox(installed=False)
+    with (
+        patch.object(
+            agentbinary,
+            "detect_sandbox_platform",
+            AsyncMock(return_value="linux-arm64"),
+        ),
+        patch.object(agentbinary, "trace", lambda msg: None),
+        patch.object(agentbinary, "sandbox_exec", AsyncMock(return_value="")),
+        pytest.raises(RuntimeError, match="package_entrypoint"),
+    ):
+        anyio.run(
+            ensure_agent_binary_installed,
+            source,
+            "9.9.9",
+            None,
+            cast(SandboxEnvironment, sandbox),
+        )

--- a/tests/test_codex_agentbinary.py
+++ b/tests/test_codex_agentbinary.py
@@ -108,3 +108,81 @@ def test_bundled_catalog_tracks_live_latest() -> None:
         f"bundled fallback's latest is '{bundled_latest}'; refresh "
         f"src/inspect_swe/_codex_cli/_bundled_catalog.py"
     )
+
+
+_RELEASE_WITH_PACKAGE = {
+    "assets": [
+        {
+            "name": "codex-aarch64-unknown-linux-musl.tar.gz",
+            "digest": "sha256:aaa",
+            "browser_download_url": "https://example.com/codex.tar.gz",
+        },
+        {
+            "name": "codex-package-aarch64-unknown-linux-musl.tar.gz",
+            "digest": "sha256:bbb",
+            "browser_download_url": "https://example.com/codex-package.tar.gz",
+        },
+    ]
+}
+
+_RELEASE_WITHOUT_PACKAGE = {
+    "assets": [
+        {
+            "name": "codex-aarch64-unknown-linux-musl.tar.gz",
+            "digest": "sha256:aaa",
+            "browser_download_url": "https://example.com/codex.tar.gz",
+        },
+    ]
+}
+
+
+def test_codex_resolve_version_prefers_package_asset() -> None:
+    # releases >= 0.133.0 ship codex-package-<arch>.tar.gz with the companion
+    # executables (codex-code-mode-host etc.); it should win over the single binary
+    source = agentbinary.codex_cli_binary_source()
+    with patch.object(
+        agentbinary,
+        "_fetch_release_assets",
+        AsyncMock(return_value=_RELEASE_WITH_PACKAGE),
+    ):
+        resolved = anyio.run(source.resolve_version, "0.147.0", "linux-arm64")
+    assert resolved.package is True
+    assert resolved.expected_checksum == "bbb"
+    assert resolved.download_url.endswith("codex-package.tar.gz")
+
+
+def test_codex_resolve_version_falls_back_to_single_binary() -> None:
+    # releases < 0.133.0 have no package asset; fall back to the codex binary
+    source = agentbinary.codex_cli_binary_source()
+    with patch.object(
+        agentbinary,
+        "_fetch_release_assets",
+        AsyncMock(return_value=_RELEASE_WITHOUT_PACKAGE),
+    ):
+        resolved = anyio.run(source.resolve_version, "0.130.0", "linux-arm64")
+    assert resolved.package is False
+    assert resolved.expected_checksum == "aaa"
+    assert resolved.download_url.endswith("codex.tar.gz")
+
+
+def test_codex_source_defines_package_support() -> None:
+    source = agentbinary.codex_cli_binary_source()
+    assert source.package_entrypoint == "bin/codex"
+    assert source.cached_package_path is not None
+    cache_path = source.cached_package_path("0.147.0", "linux-arm64")
+    assert cache_path.name == "codex-package-0.147.0-linux-arm64.tar.gz"
+
+
+def test_codex_list_cached_binaries_excludes_models_catalogs(tmp_path: Path) -> None:
+    # the models catalog cache lives alongside binaries; it must not be listed
+    # (or evicted-against) as a binary
+    with patch.object(agentbinary, "package_cache_dir", return_value=tmp_path):
+        source = agentbinary.codex_cli_binary_source()
+        (tmp_path / "codex-0.147.0-linux-arm64").write_bytes(b"binary")
+        (tmp_path / "codex-package-0.147.0-linux-arm64.tar.gz").write_bytes(b"pkg")
+        (tmp_path / "codex-0.147.0-models.json").write_text("{}")
+        names = {p.name for p in source.list_cached_binaries()}
+    assert names == {
+        "codex-0.147.0-linux-arm64",
+        "codex-package-0.147.0-linux-arm64.tar.gz",
+    }

--- a/tests/test_codex_subagent_spans.py
+++ b/tests/test_codex_subagent_spans.py
@@ -1,0 +1,347 @@
+"""Codex Multi-Agent V2 sub-agent span reconstruction (bridge-only).
+
+Multi-Agent V2 (codex >= 0.146, forced for gpt-5.6-terra/sol) changed every
+signal the CodexConsumer used to build the agent-span tree:
+
+- `spawn_agent` calls carry `task_name` (not `agent_type`) and an *encrypted*
+  `message`, so spans were named the generic "agent" and prompt-substring
+  attribution matched nothing (all model events landed on the outer span).
+- `spawn_agent` results carry `{"task_name": "/root/<name>"}` (not
+  `agent_id`/`nickname`).
+- completion arrives as a FINAL_ANSWER `agent_message` from the child (the
+  `wait_agent` result no longer carries per-thread status).
+
+The agent bridge (inspect_ai >= 0.3.253) converts each `agent_message` input
+item to a ChatMessageUser and preserves the raw item (author/recipient) on
+ContentText.internal — every agent_message in a request is inbound to the
+requester, so `recipient` identifies the calling agent exactly.
+
+Fixture shapes below are copied from a real gpt-5.6-sol eval log
+(codex 0.147.0, 2026-08-07).
+"""
+
+from typing import Any
+
+from inspect_ai._util.content import ContentText
+from inspect_ai.event import SpanBeginEvent, SpanEndEvent
+from inspect_ai.event._model import ModelEvent
+from inspect_ai.model import GenerateConfig, ModelOutput
+from inspect_ai.model._chat_message import (
+    ChatMessage,
+    ChatMessageAssistant,
+    ChatMessageTool,
+    ChatMessageUser,
+)
+from inspect_ai.tool import ToolCall
+from inspect_swe._codex_cli._events import consumer as consumer_module
+from inspect_swe._codex_cli._events.consumer import CodexConsumer
+from inspect_swe._codex_cli._events.detection import (
+    agent_message_recipients,
+    final_answer_authors,
+    find_spawned_agents,
+    spawn_result,
+)
+
+# ---------------------------------------------------------------------------
+# fixtures (shapes from a real codex 0.147.0 / gpt-5.6-sol run)
+# ---------------------------------------------------------------------------
+
+
+def _v2_spawn_call(call_id: str, task_name: str) -> ToolCall:
+    return ToolCall(
+        id=call_id,
+        function="spawn_agent",
+        arguments={
+            "task_name": task_name,
+            "fork_turns": "all",
+            "message": "gAAAAABqdjXI1bVTsv-encrypted-payload",
+        },
+    )
+
+
+def _v1_spawn_call(call_id: str, prompt: str) -> ToolCall:
+    return ToolCall(
+        id=call_id,
+        function="spawn_agent",
+        arguments={"agent_type": "explore", "message": prompt},
+    )
+
+
+def _agent_message_user(
+    author: str, recipient: str, message_type: str = "MESSAGE", payload: str = ""
+) -> ChatMessageUser:
+    """A ChatMessageUser as the bridge produces it from an agent_message item."""
+    envelope = (
+        f"Message Type: {message_type}\n"
+        f"Task name: {recipient}\n"
+        f"Sender: {author}\n"
+        f"Payload:\n{payload}"
+    )
+    raw_item: dict[str, Any] = {
+        "type": "agent_message",
+        "author": author,
+        "recipient": recipient,
+        "content": [{"type": "input_text", "text": envelope}],
+    }
+    return ChatMessageUser(
+        content=[
+            ContentText(
+                text=f"Agent message from {author}:\n{envelope}",
+                internal={"agent_message": raw_item},
+            )
+        ]
+    )
+
+
+def _spawn_result_tool_message(call_id: str, text: str) -> ChatMessageTool:
+    return ChatMessageTool(content=text, tool_call_id=call_id, function="spawn_agent")
+
+
+def _model_event(
+    input: list[ChatMessage], tool_calls: list[ToolCall] | None = None
+) -> ModelEvent:
+    message = ChatMessageAssistant(content="ok", tool_calls=tool_calls)
+    return ModelEvent(
+        model="openai/gpt-5.6-sol",
+        input=input,
+        tools=[],
+        tool_choice="auto",
+        config=GenerateConfig(),
+        output=ModelOutput.from_message(message),
+    )
+
+
+class _TranscriptStub:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    def _event(self, event: Any) -> None:
+        self.events.append(event)
+
+    def _event_updated(self, event: Any) -> None:
+        pass
+
+    def span_begins(self) -> list[SpanBeginEvent]:
+        return [e for e in self.events if isinstance(e, SpanBeginEvent)]
+
+    def span_ends(self) -> list[SpanEndEvent]:
+        return [e for e in self.events if isinstance(e, SpanEndEvent)]
+
+
+def _consumer(monkeypatch: Any) -> tuple[CodexConsumer, _TranscriptStub]:
+    stub = _TranscriptStub()
+    monkeypatch.setattr(consumer_module, "transcript", lambda: stub)
+    return CodexConsumer(), stub
+
+
+# ---------------------------------------------------------------------------
+# 1. detection: V2 spawn calls and results
+# ---------------------------------------------------------------------------
+
+
+def test_find_spawned_agents_uses_v2_task_name() -> None:
+    spawned = find_spawned_agents([_v2_spawn_call("call_1", "write_fizzbuzz")])
+    assert len(spawned) == 1
+    assert spawned[0].name == "write_fizzbuzz"
+
+
+def test_find_spawned_agents_keeps_v1_agent_type() -> None:
+    spawned = find_spawned_agents(
+        [_v1_spawn_call("call_1", "write a fizzbuzz program to /tmp/fizzbuzz.py")]
+    )
+    assert len(spawned) == 1
+    assert spawned[0].name == "explore"
+
+
+def test_spawn_result_parses_v2_task_name() -> None:
+    result = spawn_result(
+        _spawn_result_tool_message("call_1", '{"task_name":"/root/write_fizzbuzz"}')
+    )
+    assert result is not None
+    assert result.agent_id == "/root/write_fizzbuzz"
+    assert result.nickname is None
+
+
+def test_spawn_result_still_parses_v1_agent_id() -> None:
+    result = spawn_result(
+        _spawn_result_tool_message(
+            "call_1", '{"agent_id":"thread_abc","nickname":"Explorer"}'
+        )
+    )
+    assert result is not None
+    assert result.agent_id == "thread_abc"
+    assert result.nickname == "Explorer"
+
+
+# ---------------------------------------------------------------------------
+# 2. detection: agent_message identity and completion signals
+# ---------------------------------------------------------------------------
+
+
+def test_agent_message_recipients_identifies_requester() -> None:
+    input: list[ChatMessage] = [
+        _agent_message_user("/root", "/root/write_fizzbuzz"),
+        _agent_message_user(
+            "/root/write_fizzbuzz/implement_file", "/root/write_fizzbuzz"
+        ),
+    ]
+    assert agent_message_recipients(input) == {"/root/write_fizzbuzz"}
+
+
+def test_agent_message_recipients_empty_without_agent_messages() -> None:
+    assert agent_message_recipients([ChatMessageUser(content="plain task")]) == set()
+
+
+def test_final_answer_authors_detects_completion() -> None:
+    input: list[ChatMessage] = [
+        _agent_message_user("/root", "/root/write_primes"),
+        _agent_message_user(
+            "/root/write_primes", "/root", "FINAL_ANSWER", "primes written"
+        ),
+    ]
+    assert final_answer_authors(input) == {"/root/write_primes"}
+
+
+def test_final_answer_authors_ignores_plain_messages() -> None:
+    input: list[ChatMessage] = [
+        _agent_message_user("/root/write_primes", "/root", "MESSAGE")
+    ]
+    assert final_answer_authors(input) == set()
+
+
+# ---------------------------------------------------------------------------
+# 3. consumer: spans are named after V2 task_name
+# ---------------------------------------------------------------------------
+
+
+def test_consumer_names_v2_spans_after_task_name(monkeypatch: Any) -> None:
+    consumer, stub = _consumer(monkeypatch)
+    parent = _model_event(
+        [ChatMessageUser(content="spawn two agents")],
+        tool_calls=[
+            _v2_spawn_call("call_fb", "write_fizzbuzz"),
+            _v2_spawn_call("call_pr", "write_primes"),
+        ],
+    )
+    consumer.on_complete(parent)
+
+    names = [e.name for e in stub.span_begins()]
+    assert names == ["write_fizzbuzz", "write_primes"]
+
+
+# ---------------------------------------------------------------------------
+# 4. consumer: attribution by agent_message recipient
+# ---------------------------------------------------------------------------
+
+
+def test_consumer_attributes_subagent_call_by_recipient(monkeypatch: Any) -> None:
+    consumer, stub = _consumer(monkeypatch)
+
+    # parent spawns two agents (V2: encrypted prompts, so no substring match)
+    parent = _model_event(
+        [ChatMessageUser(content="spawn two agents")],
+        tool_calls=[
+            _v2_spawn_call("call_fb", "write_fizzbuzz"),
+            _v2_spawn_call("call_pr", "write_primes"),
+        ],
+    )
+    consumer.on_complete(parent)
+    fb_span, pr_span = (e.id for e in stub.span_begins())
+
+    # each sub-agent's first call carries its inbound spawn agent_message
+    fb_call = _model_event([_agent_message_user("/root", "/root/write_fizzbuzz")])
+    consumer.on_pending(fb_call)
+    assert fb_call.span_id == fb_span
+
+    pr_call = _model_event([_agent_message_user("/root", "/root/write_primes")])
+    consumer.on_pending(pr_call)
+    assert pr_call.span_id == pr_span
+
+    # the parent's own calls (inbound messages addressed to /root) stay outer
+    parent_call = _model_event(
+        [
+            ChatMessageUser(content="spawn two agents"),
+            _agent_message_user("/root/write_primes", "/root"),
+        ]
+    )
+    consumer.on_pending(parent_call)
+    assert parent_call.span_id not in (fb_span, pr_span)
+
+
+def test_consumer_nests_grandchild_span_under_child(monkeypatch: Any) -> None:
+    consumer, stub = _consumer(monkeypatch)
+
+    parent = _model_event(
+        [ChatMessageUser(content="go")],
+        tool_calls=[_v2_spawn_call("call_fb", "write_fizzbuzz")],
+    )
+    consumer.on_complete(parent)
+    fb_span = stub.span_begins()[0].id
+
+    # child call spawns its own sub-agent
+    child_call = _model_event(
+        [_agent_message_user("/root", "/root/write_fizzbuzz")],
+        tool_calls=[_v2_spawn_call("call_impl", "implement_file")],
+    )
+    consumer.on_pending(child_call)
+    consumer.on_complete(child_call)
+
+    impl_begin = stub.span_begins()[1]
+    assert impl_begin.name == "implement_file"
+    assert impl_begin.parent_id == fb_span
+
+
+# ---------------------------------------------------------------------------
+# 5. consumer: FINAL_ANSWER closes the child's span
+# ---------------------------------------------------------------------------
+
+
+def test_consumer_closes_span_on_final_answer(monkeypatch: Any) -> None:
+    consumer, stub = _consumer(monkeypatch)
+
+    parent = _model_event(
+        [ChatMessageUser(content="go")],
+        tool_calls=[_v2_spawn_call("call_pr", "write_primes")],
+    )
+    consumer.on_complete(parent)
+    pr_span = stub.span_begins()[0].id
+
+    # child identifies itself (binds /root/write_primes to the span) ...
+    child_call = _model_event([_agent_message_user("/root", "/root/write_primes")])
+    consumer.on_pending(child_call)
+    assert child_call.span_id == pr_span
+
+    # ... then the parent sees the child's FINAL_ANSWER -> span closes
+    parent_call = _model_event(
+        [
+            ChatMessageUser(content="go"),
+            _agent_message_user(
+                "/root/write_primes", "/root", "FINAL_ANSWER", "all primes written"
+            ),
+        ]
+    )
+    consumer.on_pending(parent_call)
+
+    assert [e.id for e in stub.span_ends()] == [pr_span]
+
+
+# ---------------------------------------------------------------------------
+# 6. consumer: V1 prompt-substring attribution still works
+# ---------------------------------------------------------------------------
+
+
+def test_consumer_v1_prompt_attribution_unchanged(monkeypatch: Any) -> None:
+    consumer, stub = _consumer(monkeypatch)
+
+    prompt = "write a fizzbuzz program and save it to /tmp/fizzbuzz.py"
+    parent = _model_event(
+        [ChatMessageUser(content="go")],
+        tool_calls=[_v1_spawn_call("call_1", prompt)],
+    )
+    consumer.on_complete(parent)
+    span = stub.span_begins()[0].id
+
+    # V1: codex re-sends the spawn prompt as the sub-agent's user message
+    child_call = _model_event([ChatMessageUser(content=prompt)])
+    consumer.on_pending(child_call)
+    assert child_call.span_id == span


### PR DESCRIPTION
Two fixes that together make Codex Multi-Agent V2 (codex >= 0.146, forced for gpt-5.6 models) work end to end. Both were verified against a live gpt-5.6-sol multi-agent eval (codex 0.147.0, docker sandbox).

## 1. Install the codex package archive with companion executables (350fa36)

### Problem

`codex_cli()` installs only the single `codex` binary. Codex releases since rust-v0.133.0 ship companion executables the CLI resolves at runtime — most critically `codex-code-mode-host`, which Code Mode runs in as a standalone host process (`features.code_mode_host` is stable and default-on in 0.147.0).

With codex >= 0.146 and gpt-5.6+ models, Code Mode is the execution path for Multi-Agent V2 sub-agents. Missing the host binary, Code Mode fails closed:

```
warning: Code Mode is unavailable because failed to spawn code-mode host
/var/tmp/.5c95f967ca830048/codex-code-mode-host: host executable was not found.
Code mode will fail closed; enable `features.code_mode_host` and install `codex-code-mode-host`.
```

Sub-agents then cannot execute anything ("the shared execution host is missing") and every multi-agent task fails.

### Fix

Install the `codex-package-<target>.tar.gz` release asset instead of the single binary. It is codex's canonical bundle:

```
bin/codex
bin/codex-code-mode-host
codex-path/rg
codex-resources/bwrap
codex-resources/zsh/...
```

- **Asset-presence fallback:** the package asset first shipped with rust-v0.133.0; when a pinned older release doesn't have it, resolution falls back to the single `codex-<target>.tar.gz` and the install path is unchanged.
- **Verbatim caching:** package archives are cached as downloaded, so the GitHub asset digest stays verifiable on cache reads (the single-binary path can't verify cached artifacts because `post_download` transforms them).
- **In-sandbox extraction:** the archive is written into the sandbox and extracted into a versioned directory (`$INSTALL_DIR/codex-<version>-<platform>/`), returning `bin/codex` as the agent binary. Running from the package layout is what lets codex's `CodexPackageLayout::from_exe` discover its bundled resources. A `test -x` short-circuit skips the write + extract when that version is already installed.
- Non-package agents (claude_code, etc.) are unchanged.
- Also: `cached_agent_binaries` name parsing handles the new artifact shape, and `-models.json` catalog caches are excluded from the codex binary-cache glob so cleanup can't count them against real binaries.

## 2. Reconstruct sub-agent spans under Multi-Agent V2 (d05d981)

### Problem

Multi-Agent V2 changed every signal the `CodexConsumer` used to build the agent-span tree, so sub-agent spans were named the generic "agent" and every model event landed flat on the outer `codex_cli` span (0 events attributed).

### Fix

- `spawn_agent` calls carry `task_name` (not `agent_type`) and an encrypted message, so prompt-substring attribution matched nothing → name spans after `task_name` and attribute calls by their inbound `agent_message` recipient path (preserved on `ContentText.internal` by the agent bridge in inspect_ai >= 0.3.253), with the V1 substring heuristic as fallback.
- `spawn_agent` results carry `{"task_name": "/root/<name>"}` → accept the absolute task path as the thread id.
- Completion arrives as a `FINAL_ANSWER` agent_message from the child (the `wait_agent` result no longer carries per-thread status) → close the author's span on `FINAL_ANSWER`.
- V1 behavior unchanged (regression-guarded in tests).

## Dependencies

Full gpt-5.6 multi-agent support also requires the inspect_ai agent bridge fix for `agent_message` items (UKGovernmentBEIS/inspect_ai#4787): without it the bridge rejects V2 requests outright, and span attribution by recipient (fix 2) degrades to the V1 fallback. This PR is safe to merge independently.

## Testing

- Package install: 8 unit tests — package-asset preference, single-binary fallback, verbatim caching + checksum-verified cache hits, in-sandbox extraction, already-installed skip, missing-entrypoint guard, catalog exclusion (`tests/test_agentbinary_install.py`, `tests/test_codex_agentbinary.py`).
- Spans: V2 reconstruction + V1 regression tests (`tests/test_codex_subagent_spans.py`).
- ruff + mypy clean; CI green.
- Verified end to end on a gpt-5.6-sol multi-agent eval that fails on main: with this branch the package extracts in-sandbox, no Code Mode warning, both spawned sub-agents execute and the task scores correct; spans are named `write_fizzbuzz`/`write_primes` with a nested grandchild, 89/113 model events attributed to sub-agent spans (previously 0), and all spans closed.

## Merge note

The branch intentionally carries two `fix:` commits — please use merge-commit or rebase (not squash) so Release Please records both changelog entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)