### PR TITLE
fix(codex_cli): require inspect_ai>=0.3.253 for Multi-Agent V2 delegation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ requires-python = ">=3.10"
 license = { text = "MIT License" }
 dependencies = [
     "httpx",
-    "inspect_ai>=0.3.251",
+    "inspect_ai>=0.3.253",
     "nest_asyncio",
     "platformdirs",
     "pydantic>=2.13.0",

--- a/uv.lock
+++ b/uv.lock
@@ -12,14 +12,14 @@ resolution-markers = [
 
 [[package]]
 name = "agent-client-protocol"
-version = "0.11.0"
+version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6c/93/396d02c91b387b2678f23081869ca47bd495fc6c78789022c683180cf5f1/agent_client_protocol-0.11.0.tar.gz", hash = "sha256:8920a3b27bdcc852fd7c73066f47ab53257dbfbe57b505e20a40c69f80a5391c", size = 87402, upload-time = "2026-07-05T17:07:56.803Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/50/65bfb4e3e13f350a52c368cbfc4bc36a1b3b3f34a6b3f5a2e3551e1bd63b/agent_client_protocol-0.12.0.tar.gz", hash = "sha256:4d42ac680388556b038cb6dd58dbbbd1561f9e545a334c1a352cc055f98b1c79", size = 135037, upload-time = "2026-08-01T15:58:22.35Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/48/a1367dded7765f5489f9840389949d5aeac53a73aeb1b4e6c0ab61e1617a/agent_client_protocol-0.11.0-py3-none-any.whl", hash = "sha256:2d8570cd4911f8af9fbab4808f7b05f09204a756f346c7409ecdcae3f37cdb2f", size = 68089, upload-time = "2026-07-05T17:07:55.518Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/c7/b84b8698879464bd8f869551bac31454bed14a3a22910f65d9693f3701bd/agent_client_protocol-0.12.0-py3-none-any.whl", hash = "sha256:233626748034896214de118f5cf5a319484ad2186705fd595219afee92237ccc", size = 92992, upload-time = "2026-08-01T15:58:21.216Z" },
 ]
 
 [[package]]
@@ -1205,7 +1205,7 @@ wheels = [
 
 [[package]]
 name = "inspect-ai"
-version = "0.3.251"
+version = "0.3.253"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "agent-client-protocol" },
@@ -1250,9 +1250,9 @@ dependencies = [
     { name = "zipp" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/70/31/e1c5ae271f7ceac8446f6a39bdf916d76fa024ec63b7febe0d22b94061f1/inspect_ai-0.3.251.tar.gz", hash = "sha256:0dc938ac5ea816ce3bacd112def02840952161f82fca02c49425eefb5bef5772", size = 50175614, upload-time = "2026-07-29T15:02:51.489Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/bd/531d946d7ab45c2781700148fe266483a9fa7b058b24b99cbc60230efaba/inspect_ai-0.3.253.tar.gz", hash = "sha256:d93509900b456cd34774927f036ced40e1009aeebd25078993bc2ebff4277042", size = 35617305, upload-time = "2026-08-08T11:04:15.327Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/65/d78c2c921ce457fcca76425b7a401337dda0456bada0bcaf7c21be3badbd/inspect_ai-0.3.251-py3-none-any.whl", hash = "sha256:6f18df2f14dd0646db78eaffe0db6d7735334450fdd4e03ec8f45b42a669b0fe", size = 37585651, upload-time = "2026-07-29T15:02:38.447Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/b1/4902d02e40e75036c12bd3aa3e2218a564c897fbc423b9a481b856f8b984/inspect_ai-0.3.253-py3-none-any.whl", hash = "sha256:94c54290ecc5496f926bf78d5b005d02ad02afb394758485c7fceae33a5f411f", size = 34788572, upload-time = "2026-08-08T11:04:09.076Z" },
 ]
 
 [[package]]
@@ -1345,7 +1345,7 @@ requires-dist = [
     { name = "griffe", marker = "extra == 'dev'", specifier = ">=2" },
     { name = "griffe", marker = "extra == 'doc'", specifier = ">=2" },
     { name = "httpx" },
-    { name = "inspect-ai", specifier = ">=0.3.251" },
+    { name = "inspect-ai", specifier = ">=0.3.253" },
     { name = "inspect-evals", marker = "extra == 'dev'" },
     { name = "inspect-k8s-sandbox", marker = "extra == 'dev'" },
     { name = "ipython", marker = "extra == 'dev'" },


### PR DESCRIPTION
Follow-up to #107. The Multi-Agent V2 support merged there relies on the inspect_ai agent bridge handling `agent_message` input items, which landed in inspect_ai 0.3.253 (UKGovernmentBEIS/inspect_ai#4787). This bumps the dependency floor from 0.3.251 so users installing inspect_swe get an inspect_ai where bridged Codex agents can spawn subagents instead of failing the sample with `Type agent_message is not supported by the agent bridge`.

### Agent review
- No review pass was run — single-line dependency floor bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)