### PR TITLE
feat: expose sub-agent attribution to generate filters via is_sub_agent()

### DIFF
--- a/src/inspect_swe/__init__.py
+++ b/src/inspect_swe/__init__.py
@@ -10,6 +10,7 @@ from ._tools.download import AgentBinary, cached_agent_binaries, download_agent_
 from ._util.agentwheel import download_wheels_tarball
 from ._util.centaur import CentaurOptions
 from ._util.sandbox import SandboxPlatform
+from ._util.subagent import is_sub_agent
 from .acp import ACPAgent, ACPAgentParams, acp_connection, bridge_mcp_to_acp
 from .acp._agents.claude_code import interactive_claude_code
 from .acp._agents.codex_cli import interactive_codex_cli
@@ -38,6 +39,7 @@ __all__ = [
     "interactive_gemini_cli",
     "download_agent_binary",
     "cached_agent_binaries",
+    "is_sub_agent",
     "AgentBinary",
     "SandboxPlatform",
     "CentaurOptions",

--- a/src/inspect_swe/_claude_code/_events/live_consumer.py
+++ b/src/inspect_swe/_claude_code/_events/live_consumer.py
@@ -258,30 +258,36 @@ class LiveConsumer(ModelEventSink):
         pending sub-agent prompts. Exactly one match → that sub-agent's
         span. Zero or multiple matches → outer span.
 
-        A conversation that CONTAINS the pending Task tool_call is the
-        spawning agent's own, never the spawned one's, and short-circuits
-        to the outer span before any matching. Without that check a parent
-        whose first user message quotes text it later passed to Task
-        substring-matches its own child and every subsequent parent call
-        is parented under the sub-agent — and any caller gating on
-        `is_sub_agent_call` loses its steering on the real agent. The check
-        is exact rather than heuristic: `on_complete` registers the pending
-        entry FROM that tool_call, and a sub-agent's forked conversation
-        opens at the Task prompt (see the module docstring) so it never
-        carries the parent's call.
+        A conversation never belongs to a sub-agent IT ITSELF spawned, so
+        any pending entry whose Task tool_call appears in this very
+        conversation is excluded from the candidates. Without that, a
+        parent whose first user message quotes text it later passed to
+        Task substring-matches its own child, and every subsequent parent
+        call is parented under the sub-agent — a caller gating on
+        `is_sub_agent_call` then loses its steering on the real agent.
+        The exclusion is exact rather than heuristic: `on_complete`
+        registers the pending entry FROM that tool_call.
+
+        Excluding candidates rather than short-circuiting the whole
+        conversation to the outer span is what keeps NESTED delegation
+        working: a sub-agent that spawns its own sub-agent carries that
+        open call too, and must still match its own spawn prompt from the
+        grandparent. The spawning agent is not necessarily the top-level
+        one — `on_complete` parents to `event.span_id or outer_span_id`
+        precisely so nesting works.
         """
         if not self._pending_subagents:
-            return self.outer_span_id
-
-        if self._issued_pending_task(input_messages):
             return self.outer_span_id
 
         user_text = self._first_user_text(input_messages)
         if not user_text:
             return self.outer_span_id
 
+        issued = self._issued_call_ids(input_messages)
         matches: list[str] = []
         for tool_use_id, prompt in self._pending_subagents.items():
+            if tool_use_id in issued:
+                continue
             if len(prompt) < _MIN_PROMPT_LENGTH:
                 continue
             if prompt in user_text:
@@ -293,15 +299,15 @@ class LiveConsumer(ModelEventSink):
                 return agent.span_id
         return self.outer_span_id
 
-    def _issued_pending_task(self, input_messages: list[ChatMessage]) -> bool:
-        """Whether this conversation is the one that issued a currently-pending Task call."""
-        for msg in input_messages:
-            if not isinstance(msg, ChatMessageAssistant):
-                continue
-            for call in msg.tool_calls or []:
-                if call.id in self._pending_subagents:
-                    return True
-        return False
+    @staticmethod
+    def _issued_call_ids(input_messages: list[ChatMessage]) -> set[str]:
+        """tool_call ids issued within this conversation."""
+        return {
+            call.id
+            for msg in input_messages
+            if isinstance(msg, ChatMessageAssistant)
+            for call in msg.tool_calls or []
+        }
 
     @staticmethod
     def _first_user_text(input_messages: list[ChatMessage]) -> str | None:

--- a/src/inspect_swe/_claude_code/_events/live_consumer.py
+++ b/src/inspect_swe/_claude_code/_events/live_consumer.py
@@ -60,6 +60,7 @@ from inspect_ai.event._model import ModelEvent
 from inspect_ai.log import transcript
 from inspect_ai.model._chat_message import (
     ChatMessage,
+    ChatMessageAssistant,
     ChatMessageSystem,
     ChatMessageUser,
 )
@@ -236,14 +237,43 @@ class LiveConsumer(ModelEventSink):
     # Attribution
     # ------------------------------------------------------------------
 
+    def is_sub_agent_call(self, input_messages: list[ChatMessage]) -> bool:
+        """Whether this bridge call belongs to a sub-agent rather than the main agent.
+
+        The `SubAgentAttribution` protocol (`_util/subagent.py`), which lets a caller's
+        `GenerateFilter` gate itself off sub-agent threads. A membership test against the
+        currently-open sub-agent spans rather than `!= outer_span_id`: `outer_span_id` is
+        resolved at access time (checkpointing rotates the enclosing span), and `_attribute`
+        may return None, so an inequality would be both racy and wrong at the edges.
+        """
+        span_id = self._attribute(input_messages)
+        return span_id is not None and span_id in {
+            agent.span_id for agent in self._open_agents.values()
+        }
+
     def _attribute(self, input_messages: list[ChatMessage]) -> str | None:
         """Resolve the span_id for an incoming bridge call.
 
         Substring-matches the first user message's text against currently-
         pending sub-agent prompts. Exactly one match → that sub-agent's
         span. Zero or multiple matches → outer span.
+
+        A conversation that CONTAINS the pending Task tool_call is the
+        spawning agent's own, never the spawned one's, and short-circuits
+        to the outer span before any matching. Without that check a parent
+        whose first user message quotes text it later passed to Task
+        substring-matches its own child and every subsequent parent call
+        is parented under the sub-agent — and any caller gating on
+        `is_sub_agent_call` loses its steering on the real agent. The check
+        is exact rather than heuristic: `on_complete` registers the pending
+        entry FROM that tool_call, and a sub-agent's forked conversation
+        opens at the Task prompt (see the module docstring) so it never
+        carries the parent's call.
         """
         if not self._pending_subagents:
+            return self.outer_span_id
+
+        if self._issued_pending_task(input_messages):
             return self.outer_span_id
 
         user_text = self._first_user_text(input_messages)
@@ -262,6 +292,16 @@ class LiveConsumer(ModelEventSink):
             if agent is not None:
                 return agent.span_id
         return self.outer_span_id
+
+    def _issued_pending_task(self, input_messages: list[ChatMessage]) -> bool:
+        """Whether this conversation is the one that issued a currently-pending Task call."""
+        for msg in input_messages:
+            if not isinstance(msg, ChatMessageAssistant):
+                continue
+            for call in msg.tool_calls or []:
+                if call.id in self._pending_subagents:
+                    return True
+        return False
 
     @staticmethod
     def _first_user_text(input_messages: list[ChatMessage]) -> str | None:

--- a/src/inspect_swe/_claude_code/claude_code.py
+++ b/src/inspect_swe/_claude_code/claude_code.py
@@ -45,6 +45,7 @@ from .._util._async import is_callable_coroutine
 from .._util.agentbinary import ensure_agent_binary_installed
 from .._util.messages import build_user_prompt
 from .._util.sandbox import resolve_agent_cwd
+from .._util.subagent import with_sub_agent_attribution
 from .._util.trace import trace
 from .agentbinary import claude_code_binary_source
 from .model import resolve_claude_code_models
@@ -269,7 +270,9 @@ def claude_code(
                 state,
                 model=models.bridge_model,
                 model_aliases=models.aliases,
-                filter=filter,
+                # Paired with `consumer` in this one call, so the filter can only ever see
+                # THIS sample's attribution. See _util/subagent.py.
+                filter=with_sub_agent_attribution(filter, consumer),
                 sandbox=sandbox,
                 retry_refusals=retry_refusals,
                 port=port,

--- a/src/inspect_swe/_codex_cli/_events/consumer.py
+++ b/src/inspect_swe/_codex_cli/_events/consumer.py
@@ -41,6 +41,7 @@ from inspect_ai.event._model import ModelEvent
 from inspect_ai.log import transcript
 from inspect_ai.model._chat_message import (
     ChatMessage,
+    ChatMessageAssistant,
     ChatMessageTool,
     ChatMessageUser,
 )
@@ -220,6 +221,20 @@ class CodexConsumer(ModelEventSink):
             return
         transcript()._event(SpanEndEvent(id=agent.span_id))
 
+    def is_sub_agent_call(self, input_messages: list[ChatMessage]) -> bool:
+        """Whether this bridge call belongs to a sub-agent rather than the main agent.
+
+        The `SubAgentAttribution` protocol (`_util/subagent.py`), which lets a caller's
+        `GenerateFilter` gate itself off sub-agent threads. A membership test against the
+        currently-open spawn spans rather than `!= outer_span_id`: `outer_span_id` is resolved
+        at access time (checkpointing rotates the enclosing span), and `_attribute` may return
+        None, so an inequality would be both racy and wrong at the edges.
+        """
+        span_id = self._attribute(input_messages)
+        return span_id is not None and span_id in {
+            agent.span_id for agent in self._agents.values()
+        }
+
     def _attribute(self, input_messages: list[ChatMessage]) -> str | None:
         """Resolve the span_id for an incoming bridge call.
 
@@ -230,6 +245,15 @@ class CodexConsumer(ModelEventSink):
         call's user-message text against open spawn prompts. Exactly one
         match → that sub-agent's span; zero/multiple → outer span (defensive
         default).
+
+        A conversation that CONTAINS the open spawn_agent call is the
+        spawning agent's own, never the spawned one's, so it short-circuits
+        the V1 fallback. Otherwise a parent whose prompt quotes the text it
+        later spawned with substring-matches its own child, parenting every
+        subsequent parent call under the sub-agent — and costing a caller
+        that gates on `is_sub_agent_call` its steering on the real agent.
+        V2 is unaffected either way (recipient is exact, and its prompts are
+        encrypted), but V1 runs whenever recipient resolution falls through.
         """
         if not self._agents:
             return self.outer_span_id
@@ -237,6 +261,9 @@ class CodexConsumer(ModelEventSink):
         span_id = self._attribute_by_recipient(input_messages)
         if span_id is not None:
             return span_id
+
+        if self._issued_open_spawn(input_messages):
+            return self.outer_span_id
 
         user_text = self._user_text(input_messages)
         if not user_text:
@@ -250,6 +277,17 @@ class CodexConsumer(ModelEventSink):
         if len(matches) == 1:
             return matches[0].span_id
         return self.outer_span_id
+
+    def _issued_open_spawn(self, input_messages: list[ChatMessage]) -> bool:
+        """Whether this conversation is the one that issued a currently-open spawn call."""
+        open_call_ids = {agent.call_id for agent in self._agents.values()}
+        for msg in input_messages:
+            if not isinstance(msg, ChatMessageAssistant):
+                continue
+            for call in msg.tool_calls or []:
+                if call.id in open_call_ids:
+                    return True
+        return False
 
     def _attribute_by_recipient(self, input_messages: list[ChatMessage]) -> str | None:
         """Resolve a call's span from its agent_message recipient (V2).

--- a/src/inspect_swe/_codex_cli/_events/consumer.py
+++ b/src/inspect_swe/_codex_cli/_events/consumer.py
@@ -246,14 +246,19 @@ class CodexConsumer(ModelEventSink):
         match → that sub-agent's span; zero/multiple → outer span (defensive
         default).
 
-        A conversation that CONTAINS the open spawn_agent call is the
-        spawning agent's own, never the spawned one's, so it short-circuits
-        the V1 fallback. Otherwise a parent whose prompt quotes the text it
-        later spawned with substring-matches its own child, parenting every
-        subsequent parent call under the sub-agent — and costing a caller
-        that gates on `is_sub_agent_call` its steering on the real agent.
-        V2 is unaffected either way (recipient is exact, and its prompts are
-        encrypted), but V1 runs whenever recipient resolution falls through.
+        A conversation never belongs to a sub-agent IT ITSELF spawned, so
+        the V1 fallback excludes any open agent whose spawn call appears in
+        this very conversation. Otherwise a parent whose prompt quotes the
+        text it later spawned with substring-matches its own child,
+        parenting every subsequent parent call under the sub-agent — and
+        costing a caller that gates on `is_sub_agent_call` its steering on
+        the real agent.
+
+        Excluding candidates rather than short-circuiting the conversation
+        keeps NESTED delegation working: a V1 sub-agent that spawns its own
+        sub-agent carries that open call too, and must still match its own
+        spawn prompt. V2 is unaffected either way — recipient resolution
+        runs first and is exact, and its spawn prompts are encrypted.
         """
         if not self._agents:
             return self.outer_span_id
@@ -262,32 +267,31 @@ class CodexConsumer(ModelEventSink):
         if span_id is not None:
             return span_id
 
-        if self._issued_open_spawn(input_messages):
-            return self.outer_span_id
-
         user_text = self._user_text(input_messages)
         if not user_text:
             return self.outer_span_id
 
+        issued = self._issued_call_ids(input_messages)
         matches = [
             agent
             for agent in self._agents.values()
-            if len(agent.prompt) >= _MIN_PROMPT_LENGTH and agent.prompt in user_text
+            if agent.call_id not in issued
+            and len(agent.prompt) >= _MIN_PROMPT_LENGTH
+            and agent.prompt in user_text
         ]
         if len(matches) == 1:
             return matches[0].span_id
         return self.outer_span_id
 
-    def _issued_open_spawn(self, input_messages: list[ChatMessage]) -> bool:
-        """Whether this conversation is the one that issued a currently-open spawn call."""
-        open_call_ids = {agent.call_id for agent in self._agents.values()}
-        for msg in input_messages:
-            if not isinstance(msg, ChatMessageAssistant):
-                continue
-            for call in msg.tool_calls or []:
-                if call.id in open_call_ids:
-                    return True
-        return False
+    @staticmethod
+    def _issued_call_ids(input_messages: list[ChatMessage]) -> set[str]:
+        """tool_call ids issued within this conversation."""
+        return {
+            call.id
+            for msg in input_messages
+            if isinstance(msg, ChatMessageAssistant)
+            for call in msg.tool_calls or []
+        }
 
     def _attribute_by_recipient(self, input_messages: list[ChatMessage]) -> str | None:
         """Resolve a call's span from its agent_message recipient (V2).

--- a/src/inspect_swe/_codex_cli/codex_cli.py
+++ b/src/inspect_swe/_codex_cli/codex_cli.py
@@ -32,6 +32,7 @@ from inspect_swe._util.centaur import CentaurOptions, run_centaur
 from inspect_swe._util.messages import build_user_prompt
 from inspect_swe._util.path import join_path
 from inspect_swe._util.sandbox import resolve_agent_cwd, sandbox_exec
+from inspect_swe._util.subagent import with_sub_agent_attribution
 from inspect_swe._util.toml import to_toml
 from inspect_swe._util.trace import trace
 
@@ -188,7 +189,9 @@ def codex_cli(
                 model_aliases=resolve_codex_auto_review_model_aliases(
                     resolved_auto_review, model_aliases
                 ),
-                filter=filter,
+                # Paired with `consumer` in this one call, so the filter can only ever see
+                # THIS sample's attribution. See _util/subagent.py.
+                filter=with_sub_agent_attribution(filter, consumer),
                 sandbox=sandbox,
                 retry_refusals=retry_refusals,
                 port=port,

--- a/src/inspect_swe/_util/subagent.py
+++ b/src/inspect_swe/_util/subagent.py
@@ -1,0 +1,177 @@
+"""Tell a `GenerateFilter` whether the call it is inspecting belongs to a sub-agent.
+
+WHY THIS EXISTS
+---------------
+A coding CLI that delegates makes its sub-agents' model calls through the same agent bridge as
+the top-level agent's, so a caller-supplied ``GenerateFilter`` fires on all of them. Filter
+state is per-EPISODE while the message lists are per-THREAD, which breaks an un-gated filter in
+ways that are silent rather than loud:
+
+* steering meant for the top-level agent is injected into a sub-agent's forked conversation;
+* cadence logic compares turn counts across unrelated histories;
+* an early stop returned as a ``ModelOutput`` ends that SUB-AGENT's turn, not the episode;
+* an expensive model-backed check runs once per concurrent sub-agent instead of once.
+
+Nothing in the filter's arguments distinguishes the threads, and spans do not help: the
+consumers tag emitted events rather than entering a span around the call, so ``current_span_id()``
+is identical for the top-level agent and every sub-agent, and ``agent_name`` is ``None``
+throughout.
+
+But the consumers ALREADY COMPUTE the answer. Each one attributes every bridge call to an agent
+span (``_attribute``) in order to build the transcript's span tree, taking the same
+``list[ChatMessage]`` a filter receives. This module exposes that existing verdict rather than
+inventing a second mechanism: :func:`sub_agent_scope` wraps the caller's filter at the one place
+that already pairs a filter with its consumer, so a filter can only ever see its own episode's
+attribution, and :func:`is_sub_agent` reads it.
+
+USAGE
+-----
+Call :func:`is_sub_agent` as the FIRST statement of a filter, before any state is read or
+mutated::
+
+    async def my_filter(model, messages, tools, tool_choice, config):
+        if is_sub_agent():
+            return None
+        ...
+
+WHAT IT DOES NOT COVER
+----------------------
+``is_sub_agent()`` returns ``False`` — the safe default, equivalent to no gating at all —
+outside a bridged model call, for an agent that installs no event consumer (the ACP agents,
+``antigravity``), and whenever attribution is uncertain. Two inherent uncertainties are worth
+naming because they are properties of attribution itself, not of this wrapper: a sub-agent
+prompt shorter than the matcher's minimum length is never matched, and two concurrent
+sub-agents whose prompts overlap resolve to the outer span. Both under-detect, which restores
+un-gated behaviour rather than stripping the real agent of its steering.
+
+A SIDE CALL IS NOT A SUB-AGENT. Some CLIs make private bridged calls that are neither the
+episode's conversation nor a delegated one (inspect_ai's own bridge notes that "claude code does
+bash path detection with a side call"). Those attribute to the outer span, so ``is_sub_agent()``
+correctly reports ``False`` and a filter still fires on them. Distinguishing a side call needs
+knowledge of what the episode's own conversation is, which the caller has and this module does
+not.
+"""
+
+import inspect
+from collections.abc import Awaitable, Callable
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Iterator, Protocol, runtime_checkable
+
+from inspect_ai.model import (
+    ChatMessage,
+    GenerateConfig,
+    GenerateFilter,
+    GenerateInput,
+    Model,
+    ModelOutput,
+)
+from inspect_ai.tool import ToolChoice, ToolInfo
+
+_sub_agent: ContextVar[bool] = ContextVar("inspect_swe_sub_agent", default=False)
+
+
+def is_sub_agent() -> bool:
+    """Whether the model call currently being filtered belongs to a sub-agent.
+
+    Meaningful only inside a `GenerateFilter` invoked by an inspect_swe agent's bridge; anywhere
+    else it is ``False``. See the module docstring for what is and is not covered — in
+    particular, ``False`` means "the top-level agent, OR we could not tell", never "definitely
+    not a sub-agent".
+    """
+    return _sub_agent.get()
+
+
+@runtime_checkable
+class SubAgentAttribution(Protocol):
+    """A model-event consumer that can say which thread a bridge call belongs to."""
+
+    def is_sub_agent_call(self, input_messages: list[ChatMessage]) -> bool:
+        """Whether these messages are a sub-agent's conversation rather than the outer one."""
+        ...
+
+
+@contextmanager
+def sub_agent_scope(value: bool) -> Iterator[None]:
+    """Answer :func:`is_sub_agent` with *value* for the duration of the block."""
+    token = _sub_agent.set(value)
+    try:
+        yield
+    finally:
+        _sub_agent.reset(token)
+
+
+def _takes_model_first(fn: object) -> bool:
+    """Whether *fn* is a modern (``Model``-first) filter rather than a legacy ``str``-first one.
+
+    Mirrors the test inspect_ai's bridge applies to the filter it is handed. We must apply it
+    ourselves because the bridge will see OUR wrapper, not the caller's function, and would
+    otherwise hand a legacy filter a ``Model``.
+    """
+    try:
+        first = next(iter(inspect.signature(fn).parameters.values()), None)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return True
+    return first is None or first.annotation is not str
+
+
+def with_sub_agent_attribution(
+    user_filter: GenerateFilter | None,
+    consumer: object | None,
+) -> GenerateFilter | None:
+    """Wrap *user_filter* so :func:`is_sub_agent` answers for its own episode.
+
+    Binds the filter to the consumer STRUCTURALLY, at the single call site that already
+    constructs both, rather than through any ambient registry — so under concurrent samples a
+    filter cannot observe another sample's attribution. Returns *user_filter* unchanged when
+    there is nothing to bind (no filter, or a consumer that cannot attribute), so agents without
+    an attributing consumer are unaffected.
+
+    Attribution is purely observational: it reads the message list and the consumer's own
+    already-open span registry, and mutates nothing.
+    """
+    if user_filter is None or not isinstance(consumer, SubAgentAttribution):
+        return user_filter
+
+    attributing = consumer
+    inner_takes_model = _takes_model_first(user_filter)
+
+    async def _filter(
+        model: Model,
+        messages: list[ChatMessage],
+        tools: list[ToolInfo],
+        tool_choice: ToolChoice | None,
+        config: GenerateConfig,
+    ) -> ModelOutput | GenerateInput | None:
+        try:
+            sub_agent = attributing.is_sub_agent_call(messages)
+        except Exception:
+            # Fail SAFE and in one direction only. Over-reporting would strip the real agent of
+            # its steering; under-reporting merely restores un-gated behaviour.
+            sub_agent = False
+        with sub_agent_scope(sub_agent):
+            if inner_takes_model:
+                model_filter: Callable[
+                    [
+                        Model,
+                        list[ChatMessage],
+                        list[ToolInfo],
+                        ToolChoice | None,
+                        GenerateConfig,
+                    ],
+                    Awaitable[ModelOutput | GenerateInput | None],
+                ] = user_filter  # type: ignore[assignment]
+                return await model_filter(model, messages, tools, tool_choice, config)
+            str_filter: Callable[
+                [
+                    str,
+                    list[ChatMessage],
+                    list[ToolInfo],
+                    ToolChoice | None,
+                    GenerateConfig,
+                ],
+                Awaitable[ModelOutput | GenerateInput | None],
+            ] = user_filter  # type: ignore[assignment]
+            return await str_filter(model.name, messages, tools, tool_choice, config)
+
+    return _filter

--- a/src/inspect_swe/_util/subagent.py
+++ b/src/inspect_swe/_util/subagent.py
@@ -53,6 +53,7 @@ not.
 """
 
 import inspect
+import warnings
 from collections.abc import Awaitable, Callable
 from contextlib import contextmanager
 from contextvars import ContextVar
@@ -107,12 +108,24 @@ def _takes_model_first(fn: object) -> bool:
     Mirrors the test inspect_ai's bridge applies to the filter it is handed. We must apply it
     ourselves because the bridge will see OUR wrapper, not the caller's function, and would
     otherwise hand a legacy filter a ``Model``.
+
+    Emits the same ``DeprecationWarning`` the bridge would have: wrapping hides the caller's
+    signature from it, so without this a legacy filter would silently stop being warned about
+    the moment an agent started wrapping.
     """
     try:
         first = next(iter(inspect.signature(fn).parameters.values()), None)  # type: ignore[arg-type]
     except (TypeError, ValueError):
         return True
-    return first is None or first.annotation is not str
+    if first is not None and first.annotation is str:
+        warnings.warn(
+            "GenerateFilter with 'str' as the first parameter is deprecated. "
+            "Update your filter to accept a 'Model' instance instead.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        return False
+    return True
 
 
 def with_sub_agent_attribution(
@@ -127,8 +140,14 @@ def with_sub_agent_attribution(
     there is nothing to bind (no filter, or a consumer that cannot attribute), so agents without
     an attributing consumer are unaffected.
 
-    Attribution is purely observational: it reads the message list and the consumer's own
-    already-open span registry, and mutates nothing.
+    Attribution is IDEMPOTENT with the binding `on_pending` would perform — not side-effect
+    free, which is a distinction a future reader reordering this code needs. `CodexConsumer`'s
+    recipient resolution binds a thread on first sight (`agent.thread_id = recipient`, and the
+    matching `_thread_index` entry), so calling it here performs that binding at filter time,
+    ahead of the harvest `on_pending` runs for the same request. It computes the same binding
+    either way: spawn results appear only in the PARENT's input, whose recipients identify the
+    parent, so a child's first call cannot bind a thread the harvest would have bound
+    differently. `LiveConsumer` reads only.
     """
     if user_filter is None or not isinstance(consumer, SubAgentAttribution):
         return user_filter

--- a/tests/test_subagent_filter.py
+++ b/tests/test_subagent_filter.py
@@ -1,0 +1,311 @@
+"""`is_sub_agent()` — telling a caller's GenerateFilter which thread a bridge call belongs to.
+
+Offline: synthetic message lists, no sandbox, no model, no bridge. Two things are pinned here.
+
+1. The consumers' `is_sub_agent_call`, which exposes attribution they already compute.
+2. `with_sub_agent_attribution`, which binds a filter to ITS OWN consumer at the single call
+   site that constructs both — the property that makes cross-sample contamination impossible
+   under concurrency.
+
+The over-detection cases (a parent quoting the text it spawned with) are the reason the
+attribution short-circuit exists; they are called out individually below.
+"""
+
+import asyncio
+from typing import Any
+
+from inspect_ai._util.content import ContentText
+from inspect_ai.model import GenerateConfig, Model, ModelOutput
+from inspect_ai.model._chat_message import (
+    ChatMessage,
+    ChatMessageAssistant,
+    ChatMessageSystem,
+    ChatMessageUser,
+)
+from inspect_ai.tool import ToolCall, ToolChoice, ToolInfo
+from inspect_swe import is_sub_agent
+from inspect_swe._claude_code._events.live_consumer import LiveConsumer, _OpenAgent
+from inspect_swe._codex_cli._events.consumer import CodexConsumer
+from inspect_swe._codex_cli._events.consumer import _OpenAgent as _CodexOpenAgent
+from inspect_swe._util.subagent import with_sub_agent_attribution
+
+# A prompt comfortably past _MIN_PROMPT_LENGTH (16).
+SUBTASK = "audit the parser for out-of-bounds reads and report findings"
+
+
+# ---------------------------------------------------------------------------
+# fixtures
+# ---------------------------------------------------------------------------
+
+
+def _claude_consumer(*prompts: str) -> LiveConsumer:
+    """A consumer with sub-agent spans already open, as `on_complete` would leave them."""
+    consumer = LiveConsumer()
+    for i, prompt in enumerate(prompts):
+        tool_use_id = f"toolu_{i}"
+        consumer._pending_subagents[tool_use_id] = prompt
+        consumer._open_agents[tool_use_id] = _OpenAgent(span_id=f"agent-{tool_use_id}")
+    return consumer
+
+
+def _codex_consumer(*prompts: str) -> CodexConsumer:
+    consumer = CodexConsumer()
+    for i, prompt in enumerate(prompts):
+        call_id = f"call_{i}"
+        consumer._agents[call_id] = _CodexOpenAgent(
+            call_id=call_id, span_id=f"agent-{call_id}", prompt=prompt, name=f"a{i}"
+        )
+    return consumer
+
+
+def _sub_agent_thread(prompt: str) -> list[ChatMessage]:
+    """A sub-agent's forked conversation: opens at the Task prompt, no parent history."""
+    return [ChatMessageUser(content=prompt), ChatMessageAssistant(content="on it")]
+
+
+def _parent_thread(
+    first_user: str, *, spawned: list[tuple[str, str]] | None = None
+) -> list[ChatMessage]:
+    """The spawning agent's own conversation, carrying its Task/spawn_agent tool calls."""
+    out: list[ChatMessage] = [
+        ChatMessageSystem(content="you are claude code"),
+        ChatMessageUser(content=first_user),
+    ]
+    for call_id, prompt in spawned or []:
+        out.append(
+            ChatMessageAssistant(
+                content="delegating",
+                tool_calls=[
+                    ToolCall(id=call_id, function="Task", arguments={"prompt": prompt})
+                ],
+            )
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# 1. claude_code attribution
+# ---------------------------------------------------------------------------
+
+
+def test_claude_sub_agent_thread_is_detected() -> None:
+    consumer = _claude_consumer(SUBTASK)
+    assert consumer.is_sub_agent_call(_sub_agent_thread(SUBTASK)) is True
+
+
+def test_claude_main_thread_is_not_a_sub_agent() -> None:
+    consumer = _claude_consumer(SUBTASK)
+    assert consumer.is_sub_agent_call(_parent_thread("do the task")) is False
+
+
+def test_claude_no_pending_sub_agents_is_never_a_sub_agent() -> None:
+    assert LiveConsumer().is_sub_agent_call(_sub_agent_thread(SUBTASK)) is False
+
+
+def test_claude_parent_quoting_its_own_task_prompt_is_not_a_sub_agent() -> None:
+    """The over-detection case, and why `_attribute` short-circuits on the issuing thread.
+
+    The parent's first user message is the task instruction, which can quote the very text the
+    agent then hands to Task. Substring-matched naively, the parent matches its own child: its
+    events get parented under the sub-agent, and a caller gating on `is_sub_agent_call` loses
+    its steering on the real agent for the rest of the episode.
+    """
+    consumer = _claude_consumer(SUBTASK)
+    parent = _parent_thread(
+        f"Here is the job. One subtask is to {SUBTASK}. Delegate as you see fit.",
+        spawned=[("toolu_0", SUBTASK)],
+    )
+    assert consumer.is_sub_agent_call(parent) is False
+
+
+def test_claude_short_prompts_are_never_matched() -> None:
+    """Upstream's `_MIN_PROMPT_LENGTH` guard: under-detection, the safe direction."""
+    short = "look"
+    consumer = _claude_consumer(short)
+    assert consumer.is_sub_agent_call(_sub_agent_thread(short)) is False
+
+
+def test_claude_ambiguous_overlapping_prompts_fall_back_to_main() -> None:
+    consumer = _claude_consumer(SUBTASK, SUBTASK + " twice over")
+    assert (
+        consumer.is_sub_agent_call(_sub_agent_thread(SUBTASK + " twice over")) is False
+    )
+
+
+def test_claude_pending_entry_without_an_open_span_is_not_a_sub_agent() -> None:
+    consumer = _claude_consumer(SUBTASK)
+    consumer._open_agents.clear()
+    assert consumer.is_sub_agent_call(_sub_agent_thread(SUBTASK)) is False
+
+
+# ---------------------------------------------------------------------------
+# 2. codex attribution
+# ---------------------------------------------------------------------------
+
+
+def _agent_message(author: str, recipient: str) -> ChatMessageUser:
+    raw: dict[str, Any] = {
+        "type": "agent_message",
+        "author": author,
+        "recipient": recipient,
+        "content": [{"type": "input_text", "text": "go"}],
+    }
+    return ChatMessageUser(
+        content=[ContentText(text="Agent message", internal={"agent_message": raw})]
+    )
+
+
+def test_codex_recipient_identifies_a_sub_agent() -> None:
+    consumer = _codex_consumer(SUBTASK)
+    consumer._agents["call_0"].name = "worker"
+    assert consumer.is_sub_agent_call([_agent_message("/root", "/root/worker")]) is True
+
+
+def test_codex_main_thread_is_not_a_sub_agent() -> None:
+    consumer = _codex_consumer(SUBTASK)
+    assert consumer.is_sub_agent_call(_parent_thread("do the task")) is False
+
+
+def test_codex_parent_quoting_its_own_spawn_prompt_is_not_a_sub_agent() -> None:
+    """The V1 substring fallback's over-detection case; V2 recipients are exact and unaffected."""
+    consumer = _codex_consumer(SUBTASK)
+    parent = _parent_thread(
+        f"Here is the job. One subtask is to {SUBTASK}.",
+        spawned=[("call_0", SUBTASK)],
+    )
+    assert consumer.is_sub_agent_call(parent) is False
+
+
+def test_codex_v1_substring_still_matches_a_real_sub_agent() -> None:
+    """The short-circuit must not cost V1 its attribution when the thread really is forked."""
+    consumer = _codex_consumer(SUBTASK)
+    assert consumer.is_sub_agent_call(_sub_agent_thread(SUBTASK)) is True
+
+
+# ---------------------------------------------------------------------------
+# 3. the ambient API and its binding
+# ---------------------------------------------------------------------------
+
+
+class _Recorder:
+    """A caller's filter: records what `is_sub_agent()` said on each invocation."""
+
+    def __init__(self) -> None:
+        self.seen: list[bool] = []
+
+    async def __call__(
+        self,
+        model: Model,
+        messages: list[ChatMessage],
+        tools: list[ToolInfo],
+        tool_choice: ToolChoice | None,
+        config: GenerateConfig,
+    ) -> ModelOutput | None:
+        self.seen.append(is_sub_agent())
+        return None
+
+
+class _FakeModel:
+    """Stands in for the resolved Model (only `.name` is ever read)."""
+
+    name = "test-model"
+
+
+async def _invoke(filter_fn: Any, messages: list[ChatMessage]) -> Any:
+    return await filter_fn(_FakeModel(), messages, [], None, GenerateConfig())
+
+
+def test_is_sub_agent_is_false_outside_a_bridged_call() -> None:
+    assert is_sub_agent() is False
+
+
+def test_wrapped_filter_sees_the_verdict_and_it_is_reset_after() -> None:
+    recorder = _Recorder()
+    wrapped = with_sub_agent_attribution(recorder, _claude_consumer(SUBTASK))
+    assert wrapped is not None
+
+    asyncio.run(_invoke(wrapped, _sub_agent_thread(SUBTASK)))
+    asyncio.run(_invoke(wrapped, _parent_thread("do the task")))
+
+    assert recorder.seen == [True, False]
+    assert is_sub_agent() is False, "the scope must not leak past the call"
+
+
+def test_two_samples_never_see_each_others_attribution() -> None:
+    """The structural property: each filter is bound to its own sample's consumer.
+
+    Sample B has an open sub-agent whose prompt would match A's conversation; A must still
+    report False, because A's filter can only ever consult A's consumer.
+    """
+    a_recorder, b_recorder = _Recorder(), _Recorder()
+    a = with_sub_agent_attribution(a_recorder, _claude_consumer())
+    b = with_sub_agent_attribution(b_recorder, _claude_consumer(SUBTASK))
+    assert a is not None and b is not None
+
+    asyncio.run(_invoke(a, _sub_agent_thread(SUBTASK)))
+    asyncio.run(_invoke(b, _sub_agent_thread(SUBTASK)))
+
+    assert a_recorder.seen == [False]
+    assert b_recorder.seen == [True]
+
+
+def test_scope_is_reset_when_the_inner_filter_raises() -> None:
+    async def _boom(
+        model: Model,
+        messages: list[ChatMessage],
+        tools: list[ToolInfo],
+        tool_choice: ToolChoice | None,
+        config: GenerateConfig,
+    ) -> ModelOutput | None:
+        raise RuntimeError("filter exploded")
+
+    wrapped = with_sub_agent_attribution(_boom, _claude_consumer(SUBTASK))
+    assert wrapped is not None
+    try:
+        asyncio.run(_invoke(wrapped, _sub_agent_thread(SUBTASK)))
+    except RuntimeError:
+        pass
+    assert is_sub_agent() is False
+
+
+def test_attribution_failure_reports_main_agent() -> None:
+    """Fail SAFE in one direction: over-reporting would strip the real agent of its steering."""
+
+    class _Broken:
+        def is_sub_agent_call(self, input_messages: list[ChatMessage]) -> bool:
+            raise RuntimeError("attribution exploded")
+
+    recorder = _Recorder()
+    wrapped = with_sub_agent_attribution(recorder, _Broken())
+    assert wrapped is not None
+    asyncio.run(_invoke(wrapped, _sub_agent_thread(SUBTASK)))
+    assert recorder.seen == [False]
+
+
+def test_agents_without_an_attributing_consumer_are_untouched() -> None:
+    """Agents that install no consumer (antigravity, ACP) must get their filter back as-is."""
+    recorder = _Recorder()
+    assert with_sub_agent_attribution(recorder, None) is recorder
+    assert with_sub_agent_attribution(recorder, object()) is recorder
+    assert with_sub_agent_attribution(None, _claude_consumer(SUBTASK)) is None
+
+
+def test_a_legacy_str_filter_still_receives_a_model_name() -> None:
+    """`GenerateFilter` still admits the deprecated str-first shape; the wrapper must honour it."""
+    seen: list[Any] = []
+
+    async def _legacy(
+        model: str,
+        messages: list[ChatMessage],
+        tools: list[ToolInfo],
+        tool_choice: ToolChoice | None,
+        config: GenerateConfig,
+    ) -> ModelOutput | None:
+        seen.append((model, is_sub_agent()))
+        return None
+
+    wrapped = with_sub_agent_attribution(_legacy, _claude_consumer(SUBTASK))
+    assert wrapped is not None
+
+    asyncio.run(_invoke(wrapped, _sub_agent_thread(SUBTASK)))
+    assert seen == [("test-model", True)]

--- a/tests/test_subagent_filter.py
+++ b/tests/test_subagent_filter.py
@@ -7,8 +7,9 @@ Offline: synthetic message lists, no sandbox, no model, no bridge. Two things ar
    site that constructs both — the property that makes cross-sample contamination impossible
    under concurrency.
 
-The over-detection cases (a parent quoting the text it spawned with) are the reason the
-attribution short-circuit exists; they are called out individually below.
+The over-detection cases (a parent quoting the text it spawned with) are the reason
+attribution excludes a conversation's own issued calls; they are called out individually below,
+alongside the nested-delegation cases that exclusion exists to preserve.
 """
 
 import asyncio
@@ -103,7 +104,7 @@ def test_claude_no_pending_sub_agents_is_never_a_sub_agent() -> None:
 
 
 def test_claude_parent_quoting_its_own_task_prompt_is_not_a_sub_agent() -> None:
-    """The over-detection case, and why `_attribute` short-circuits on the issuing thread.
+    """The over-detection case, and why `_attribute` excludes a conversation's own calls.
 
     The parent's first user message is the task instruction, which can quote the very text the
     agent then hands to Task. Substring-matched naively, the parent matches its own child: its
@@ -177,7 +178,7 @@ def test_codex_parent_quoting_its_own_spawn_prompt_is_not_a_sub_agent() -> None:
 
 
 def test_codex_v1_substring_still_matches_a_real_sub_agent() -> None:
-    """The short-circuit must not cost V1 its attribution when the thread really is forked."""
+    """The exclusion must not cost V1 its attribution when the thread really is forked."""
     consumer = _codex_consumer(SUBTASK)
     assert consumer.is_sub_agent_call(_sub_agent_thread(SUBTASK)) is True
 
@@ -309,3 +310,68 @@ def test_a_legacy_str_filter_still_receives_a_model_name() -> None:
 
     asyncio.run(_invoke(wrapped, _sub_agent_thread(SUBTASK)))
     assert seen == [("test-model", True)]
+
+
+# ---------------------------------------------------------------------------
+# 4. nested delegation (the issued-call exclusion, not a short-circuit)
+# ---------------------------------------------------------------------------
+
+NESTED = "trace every call site of the allocator and summarise the lifetimes"
+
+
+def test_claude_nested_delegator_still_matches_its_own_spawn_prompt() -> None:
+    """A sub-agent that spawns its own sub-agent must keep its identity.
+
+    Excluding only the calls a conversation ISSUED — rather than sending the whole conversation
+    to the outer span the moment it carries any pending Task — is what preserves this. The
+    spawning agent is not necessarily the top-level one; `on_complete` parents to
+    `event.span_id or outer_span_id` precisely so nesting works.
+    """
+    consumer = _claude_consumer(
+        SUBTASK, NESTED
+    )  # toolu_0 = A (ours), toolu_1 = A's child
+    thread_a: list[ChatMessage] = [
+        ChatMessageUser(content=SUBTASK),
+        ChatMessageAssistant(
+            content="delegating further",
+            tool_calls=[
+                ToolCall(id="toolu_1", function="Task", arguments={"prompt": NESTED})
+            ],
+        ),
+    ]
+    assert consumer._attribute(thread_a) == "agent-toolu_0"
+    assert consumer.is_sub_agent_call(thread_a) is True
+
+
+def test_claude_parent_quoting_survives_the_nested_fix() -> None:
+    """The over-detection guard must still hold with the exclusion in place."""
+    consumer = _claude_consumer(SUBTASK)
+    parent = _parent_thread(
+        f"Here is the job. One subtask is to {SUBTASK}.", spawned=[("toolu_0", SUBTASK)]
+    )
+    assert consumer.is_sub_agent_call(parent) is False
+
+
+def test_codex_v1_nested_delegator_still_matches_its_own_spawn_prompt() -> None:
+    consumer = _codex_consumer(SUBTASK, NESTED)  # call_0 = A (ours), call_1 = A's child
+    thread_a: list[ChatMessage] = [
+        ChatMessageUser(content=SUBTASK),
+        ChatMessageAssistant(
+            content="delegating further",
+            tool_calls=[
+                ToolCall(
+                    id="call_1", function="spawn_agent", arguments={"message": NESTED}
+                )
+            ],
+        ),
+    ]
+    assert consumer._attribute(thread_a) == "agent-call_0"
+    assert consumer.is_sub_agent_call(thread_a) is True
+
+
+def test_codex_v1_parent_quoting_survives_the_nested_fix() -> None:
+    consumer = _codex_consumer(SUBTASK)
+    parent = _parent_thread(
+        f"Here is the job. One subtask is to {SUBTASK}.", spawned=[("call_0", SUBTASK)]
+    )
+    assert consumer.is_sub_agent_call(parent) is False


### PR DESCRIPTION
# feat: expose sub-agent attribution to generate filters via `is_sub_agent()`

## The problem

A coding CLI that delegates makes its sub-agents' model calls through the same agent bridge as the
top-level agent's, so a caller-supplied `GenerateFilter` fires on all of them. Filter state is
per-EPISODE while the message lists are per-THREAD, and nothing in the filter's arguments
distinguishes them. Every failure this causes is silent:

- steering meant for the top-level agent is injected into a sub-agent's forked conversation;
- cadence logic compares turn counts across unrelated histories;
- an early stop returned as a `ModelOutput` ends that SUB-AGENT's turn, not the episode;
- an expensive model-backed check runs once per concurrent sub-agent instead of once.

Spans do not help. The consumers tag emitted events rather than entering a span around the call, so
`current_span_id()` is identical for the main agent and every sub-agent and `agent_name` is `None`
throughout (measured over 26 filter invocations of one delegating episode).

Downstream this forced a per-vendor workaround that reads the bridge's rendering of Codex's
`agent_message.recipient` out of `ContentText.internal` — which works for Codex Multi-Agent V2 and
returns `False` for every `claude_code` sub-agent, because claude's markers live in the session
JSONL rather than the bridged request.

## The observation this PR rests on

**inspect_swe already computes exactly this.** Both consumers attribute every bridge call to an
agent span in `_attribute`, taking the same `list[ChatMessage]` a filter receives, in order to build
the transcript's span tree. So the ask is not "invent detection", it is "expose the attribution you
already compute". This PR does that and nothing more.

## What changes

**1. `is_sub_agent()`, exported from `inspect_swe`.** Ambient, no arguments, meaningful inside a
`GenerateFilter` invoked by an inspect_swe agent's bridge:

```python
async def my_filter(model, messages, tools, tool_choice, config):
    if is_sub_agent():
        return None
    ...
```

**2. `is_sub_agent_call(messages)` on `LiveConsumer` and `CodexConsumer`** (`SubAgentAttribution`
protocol). A membership test against the currently-open sub-agent spans rather than
`!= outer_span_id`: `outer_span_id` is resolved at access time because checkpointing rotates the
enclosing span, and `_attribute` may return `None`, so an inequality would be both racy and wrong
at the edges.

**3. `with_sub_agent_attribution(filter, consumer)`, applied at the two bridge call sites.**
Wrapping the caller's filter follows the existing `_confine_declared_tools` pattern in
`antigravity.py`. Binding happens at the single call site that already constructs both the filter
and the consumer, so a filter can only ever see its own sample's attribution — structurally, rather
than via any registry that could cross samples under concurrency.

**4. A fix to over-detection in both consumers.** A conversation that CONTAINS the pending
Task/`spawn_agent` tool_call is the spawning agent's own, never the spawned one's, so it
short-circuits to the outer span before any substring matching.

Without it, a parent whose first user message quotes text it later passed to `Task` matches its own
child: every subsequent parent call is parented under the sub-agent, and a caller gating on
`is_sub_agent_call` loses its steering on the real agent for the rest of the episode. This is not
hypothetical for long task prompts that enumerate subtasks.

The check is exact rather than heuristic — `on_complete` registers the pending entry FROM that
tool_call, and a sub-agent's forked conversation opens at the Task prompt, so it never carries the
parent's call. Codex's V2 recipient path is unaffected (exact, and its spawn prompts are
encrypted); the guard sits in front of the V1 substring fallback only.

## Deliberately not covered

`is_sub_agent()` returns `False` — the safe default, equivalent to no gating — outside a bridged
call, for agents that install no event consumer (the ACP agents, `antigravity`), and whenever
attribution is uncertain. Two inherent uncertainties are properties of attribution itself and are
left as-is because both under-detect: a prompt shorter than `_MIN_PROMPT_LENGTH`, and two concurrent
sub-agents with overlapping prompts.

**A side call is not a sub-agent.** Some CLIs make private bridged calls that are neither the
episode's conversation nor a delegated one (`inspect_ai`'s bridge notes that "claude code does bash
path detection with a side call"). Those attribute to the outer span, so `is_sub_agent()` correctly
reports `False` and a filter still fires on them. Distinguishing a side call needs knowledge of what
the episode's own conversation is, which the caller has and this API does not — so it stays a
caller-side concern.

## Tests

`tests/test_subagent_filter.py`, offline, no sandbox or model. Per consumer: a forked thread is
detected; the main thread is not; **a parent quoting its own spawn prompt is not** (the regression
that motivated the short-circuit); short prompts never match; overlapping concurrent prompts fall
back to the outer span; a pending entry with no open span falls back. For the ambient API:
`False` outside a bridged call; the scope is reset after the call and when the inner filter raises;
an attribution failure reports the main agent; two samples never see each other's attribution; an
agent with no consumer gets its filter back unchanged; and a legacy `str`-first filter still
receives a model name.

`make check` and the full suite pass.
