### PR TITLE
fix(claude_code): async Task subagents lose their spans (events orphaned to root)

### DIFF
--- a/src/inspect_swe/_claude_code/_events/live_consumer.py
+++ b/src/inspect_swe/_claude_code/_events/live_consumer.py
@@ -42,13 +42,32 @@ Three responsibilities, all driven from the same `LiveConsumer` instance:
    Claude Code re-sends the sub-agent's full conversation history on
    each request, with the original Task prompt always at `input[0]`.
    `_pending_subagents` and the open span are cleared in `_handle_user`
-   when the matching `tool_result` arrives.
+   when the matching `tool_result` arrives — for a *synchronous* Task.
+
+   **Async/background Task agents (`Task(..., async=True)` or
+   equivalent) are different**: the `tool_result` that arrives ~0.5s
+   after spawn is only a launch acknowledgment (its text starts
+   "Async agent launched successfully", verified live against CC
+   2.1.220 in `~/Development/test_evals/logs/agent-context/claude_code`)
+   — the sub-agent's real bridged calls arrive seconds later. If we
+   closed the span and cleared `_pending_subagents` on that ack (as a
+   sync Task's real `tool_result` would warrant), every later call would
+   find the registry empty and fall through to the outer span. So for an
+   async ack, `_handle_user` marks the `_OpenAgent` as `launched_async`
+   and leaves the span open / prompt registered; the span only closes
+   when the genuine completion signal arrives — a synthetic `user`
+   message whose text contains a `<task-notification>` block carrying
+   `<tool-use-id>`, which is (live-verified, same log) the *original*
+   Task tool_use_id verbatim, so it correlates directly to the
+   `_open_agents` entry without needing the CC-internal `<task-id>`.
 
 2. **JSONL consumer** — `process_jsonl_line` reads each line printed by
    Claude Code's `--output-format stream-json` and emits agent
-   `SpanEndEvent` (on `tool_result` for Task/Agent), and emits
-   `CompactionEvent` for `compact_boundary` system events. Span
-   *opening* is no longer driven from JSONL — see callback (1) above.
+   `SpanEndEvent` — on `tool_result` for a synchronous Task/Agent, or on
+   the correlated `<task-notification>` completion signal for an async
+   one — and emits `CompactionEvent` for `compact_boundary` system
+   events. Span *opening* is no longer driven from JSONL — see callback
+   (1) above.
 
 3. **`AgentContextClassifier`** — `classify()` is installed on the bridge
    filter (via `agentcontext.classify_filter`, see `claude_code.py`) so
@@ -62,6 +81,7 @@ Three responsibilities, all driven from the same `LiveConsumer` instance:
    presented slug. See `classify`'s docstring for the full truth table.
 """
 
+import re
 from dataclasses import dataclass
 from logging import getLogger
 from typing import Any
@@ -99,12 +119,39 @@ _MIN_PROMPT_LENGTH = 16
 # `_check_subagent_slug_drift`).
 _SUBAGENT_SLUG_DRIFT_WARN_THRESHOLD = 5
 
+# Prefix of an async/background Task's launch-acknowledgment tool_result text
+# (as opposed to a synchronous Task's real-result tool_result text).
+# Live-verified against CC 2.1.220 in
+# ~/Development/test_evals/logs/agent-context/claude_code/*.eval (msg[3]/
+# msg[4] of the recorded sample: two Task tool_results, both starting with
+# this exact string, arriving ~0.5s after the spawning assistant turn --
+# long before either sub-agent's real work could have finished).
+_ASYNC_LAUNCH_ACK_PREFIX = "Async agent launched successfully"
+
+# An async Task's genuine completion signal: a synthetic "user" turn (message
+# content is a plain string per Claude Code's synthetic-injection shape, not
+# a tool_result block) containing a <task-notification> block. Same recorded
+# sample, msg[6]/msg[8]: each notification carries a <tool-use-id> equal
+# (verbatim) to the *original* Task tool_use_id -- not the CC-internal
+# <task-id> also present in the block -- which is what lets us correlate the
+# notification back to the specific `_open_agents` entry without guessing.
+_TASK_NOTIFICATION_MARKER = "<task-notification>"
+_TASK_NOTIFICATION_TOOL_USE_ID_RE = re.compile(
+    r"<tool-use-id>\s*([^<\s]+)\s*</tool-use-id>"
+)
+
 
 @dataclass
 class _OpenAgent:
     """An agent span currently open (Task tool_use seen, no tool_result yet)."""
 
     span_id: str
+
+    # Set once we observe this agent's tool_result as an async launch
+    # acknowledgment (rather than a synchronous real result). Only
+    # async-launched agents close on a correlated <task-notification>;
+    # everything else keeps closing on tool_result as before.
+    launched_async: bool = False
 
 
 class LiveConsumer(ModelEventSink):
@@ -289,12 +336,29 @@ class LiveConsumer(ModelEventSink):
         Delegates the substring match to `_match_pending_prompt` (shared with
         `classify`) and resolves the matched sub-agent's span, falling back
         to the outer span whenever there's no unambiguous match.
+
+        Safety net for async Task agents: if the prompt-match fails but the
+        request is structurally known to be sub-agent traffic (its slug is
+        `models.subagent` -- see `classify`'s truth table) and there is
+        exactly one async-launched agent currently open, attribute to it --
+        unambiguous by construction. Zero or multiple open async agents fall
+        back to the outer span like any other unmatched call; this only
+        covers the single-async-agent case, not concurrent async agents.
         """
         tool_use_id = self._match_pending_prompt(input_messages)
         if tool_use_id is not None:
             agent = self._open_agents.get(tool_use_id)
             if agent is not None:
                 return agent.span_id
+
+        request = current_bridge_request()
+        if request is not None and request.model == self._models.subagent:
+            async_agents = [
+                agent for agent in self._open_agents.values() if agent.launched_async
+            ]
+            if len(async_agents) == 1:
+                return async_agents[0].span_id
+
         return self.outer_span_id
 
     def _match_pending_prompt(self, input_messages: list[ChatMessage]) -> str | None:
@@ -432,34 +496,126 @@ class LiveConsumer(ModelEventSink):
     # ------------------------------------------------------------------
 
     def _handle_user(self, raw: dict[str, Any]) -> None:
-        """Close agent spans and clear pending-sub-agent entries for tool_result blocks."""
+        """Route a "user" JSONL line to tool_result / task-notification handling.
+
+        Two shapes matter here (see the module-level marker constants for
+        live-verified provenance):
+
+        - `message.content` a list containing a `tool_result` block: a
+          Task/Agent tool_result. Synchronous Task -> close now, as always.
+          Async Task -> the block is only a launch acknowledgment; mark
+          launched-async and leave the span open (`_handle_tool_result`).
+        - `message.content` a plain string (or a list of `text` blocks,
+          tolerated the same way `extraction.py`'s offline extractor does)
+          containing a `<task-notification>` block: an async Task's genuine
+          completion signal, correlated by `<tool-use-id>`
+          (`_handle_task_notification`).
+        """
         message = raw.get("message", {})
         content = message.get("content", [])
+
+        if isinstance(content, str):
+            self._handle_task_notification(content)
+            return
         if not isinstance(content, list):
             return
 
+        text_blocks: list[str] = []
         for block in content:
             if not isinstance(block, dict):
                 continue
-            if block.get("type") != "tool_result":
-                continue
-            tool_use_id = block.get("tool_use_id")
-            if not tool_use_id:
-                continue
-            # Clear pending-subagent entry (no-op for non-Task tool_results).
-            self._pending_subagents.pop(tool_use_id, None)
-            agent = self._open_agents.pop(tool_use_id, None)
-            if agent is None:
-                continue
-            transcript()._event(SpanEndEvent(id=agent.span_id))
+            block_type = block.get("type")
+            if block_type == "tool_result":
+                self._handle_tool_result(block)
+            elif block_type == "text":
+                text = block.get("text")
+                if isinstance(text, str):
+                    text_blocks.append(text)
+
+        if text_blocks:
+            self._handle_task_notification("\n".join(text_blocks))
+
+    def _handle_tool_result(self, block: dict[str, Any]) -> None:
+        """Handle one `tool_result` content block from a "user" JSONL line."""
+        tool_use_id = block.get("tool_use_id")
+        if not tool_use_id:
+            return
+
+        agent = self._open_agents.get(tool_use_id)
+        if agent is not None and self._is_async_launch_ack(block):
+            # Async Task: this tool_result is only the launch acknowledgment,
+            # not completion. Keep the span open and the prompt registered
+            # (`_pending_subagents` untouched) so `_attribute` keeps routing
+            # this sub-agent's later bridge calls correctly; the span closes
+            # later on the correlated <task-notification>
+            # (`_handle_task_notification`), or at worst on `reset()`.
+            agent.launched_async = True
+            return
+
+        # Sync Task (or any non-Task tool_result): unchanged behavior --
+        # clear the pending entry and close the span now.
+        self._pending_subagents.pop(tool_use_id, None)
+        agent = self._open_agents.pop(tool_use_id, None)
+        if agent is None:
+            return
+        transcript()._event(SpanEndEvent(id=agent.span_id))
+
+    @staticmethod
+    def _is_async_launch_ack(block: dict[str, Any]) -> bool:
+        """Whether a tool_result block's text is an async-launch acknowledgment.
+
+        See `_ASYNC_LAUNCH_ACK_PREFIX` for provenance.
+        """
+        result_content = block.get("content")
+        text = ""
+        if isinstance(result_content, str):
+            text = result_content
+        elif isinstance(result_content, list):
+            for item in result_content:
+                if isinstance(item, dict) and item.get("type") == "text":
+                    text = str(item.get("text", ""))
+                    break
+        return text.startswith(_ASYNC_LAUNCH_ACK_PREFIX)
+
+    def _handle_task_notification(self, text: str) -> None:
+        """Close an async Task's span on its genuine completion signal.
+
+        See `_TASK_NOTIFICATION_MARKER` / `_TASK_NOTIFICATION_TOOL_USE_ID_RE`
+        for provenance. Only closes agents already marked `launched_async`
+        (sync Tasks already closed on their real tool_result); if the
+        `<tool-use-id>` can't be parsed out, or names an agent we don't have
+        open, this is a no-op -- conservative by design, per the module docs:
+        an un-correlated async agent's span just stays open until `reset()`
+        closes it (innermost-first) rather than guessing which one finished.
+        """
+        if _TASK_NOTIFICATION_MARKER not in text:
+            return
+
+        match = _TASK_NOTIFICATION_TOOL_USE_ID_RE.search(text)
+        if match is None:
+            return
+        tool_use_id = match.group(1)
+
+        agent = self._open_agents.get(tool_use_id)
+        if agent is None or not agent.launched_async:
+            return
+
+        self._pending_subagents.pop(tool_use_id, None)
+        self._open_agents.pop(tool_use_id, None)
+        transcript()._event(SpanEndEvent(id=agent.span_id))
 
     def _handle_system(self, raw: dict[str, Any]) -> None:
         """Handle system events (only compaction boundaries today).
 
-        Sub-agent lifecycle (`task_started`/`task_notification`) intentionally
-        ignored: registration happens in `on_complete` (synchronous with the
-        parent's bridge call, ahead of any race), and cleanup happens in
-        `_handle_user` on the matching tool_result.
+        Sub-agent lifecycle is driven elsewhere, not from a `system`-typed
+        JSONL line: registration happens in `on_complete` (synchronous with
+        the parent's bridge call, ahead of any race), sync-Task cleanup
+        happens in `_handle_tool_result` on the matching `tool_result`, and
+        async-Task cleanup happens in `_handle_task_notification` on the
+        correlated `<task-notification>` completion signal -- which,
+        live-verified against CC 2.1.220, arrives as a `user`-typed JSONL
+        line (plain-string `message.content`), not a `system` one, despite
+        the "notification" in its name.
         """
         subtype = raw.get("subtype")
         if subtype == "compact_boundary":

--- a/src/inspect_swe/_claude_code/_events/live_consumer.py
+++ b/src/inspect_swe/_claude_code/_events/live_consumer.py
@@ -202,6 +202,13 @@ class LiveConsumer(ModelEventSink):
         self._requests_since_first_subagent_span = 0
         self._subagent_slug_drift_warned = False
 
+        # Drift canary for the async-launch-ack signal (see
+        # `_warn_unresolvable_task_notification`): whether we've already
+        # warned that a `<task-notification>` named a tool_use_id that
+        # isn't a currently-open launched-async agent -- warn once per
+        # consumer instance, not once per notification.
+        self._task_notification_drift_warned = False
+
     @property
     def last_stop_reason(self) -> StopReason | None:
         """Stop reason of the last completed model event this attempt."""
@@ -226,12 +233,13 @@ class LiveConsumer(ModelEventSink):
         balanced even if Claude Code crashed before its tool_result blocks
         were written.
 
-        Deliberately does NOT clear the subagent-slug drift canary fields
+        Deliberately does NOT clear the drift canary fields
         (`_subagent_slug_seen`, `_first_subagent_span_seen`,
-        `_subagent_slug_drift_warned`, `_requests_since_first_subagent_span`)
-        -- they track this consumer instance's lifetime, not any single
-        attempt, so a slug sighting (or a warning already issued) from
-        before a retry must still suppress/count against later attempts.
+        `_subagent_slug_drift_warned`, `_requests_since_first_subagent_span`,
+        `_task_notification_drift_warned`) -- they track this consumer
+        instance's lifetime, not any single attempt, so a slug sighting (or
+        a warning already issued) from before a retry must still
+        suppress/count against later attempts.
         """
         for tool_use_id in reversed(list(self._open_agents.keys())):
             agent = self._open_agents.pop(tool_use_id)
@@ -339,11 +347,37 @@ class LiveConsumer(ModelEventSink):
 
         Safety net for async Task agents: if the prompt-match fails but the
         request is structurally known to be sub-agent traffic (its slug is
-        `models.subagent` -- see `classify`'s truth table) and there is
-        exactly one async-launched agent currently open, attribute to it --
-        unambiguous by construction. Zero or multiple open async agents fall
-        back to the outer span like any other unmatched call; this only
-        covers the single-async-agent case, not concurrent async agents.
+        `models.subagent` -- see `classify`'s truth table), there is exactly
+        one async-launched agent currently open, AND it is the *only* open
+        agent of any kind (no concurrently-open sync agent it could be
+        confused with), attribute to it. Requiring sole occupancy of
+        `_open_agents` -- not just sole occupancy among async agents -- is
+        what makes this unambiguous: a concurrently-open sync agent with an
+        unmatchable prompt (below `_MIN_PROMPT_LENGTH`, or substring-
+        overlapping another) would otherwise let this net misattribute that
+        sync agent's own traffic to the async one. Any other combination
+        (zero async agents open, multiple open agents of any kind) falls
+        back to the outer span like any other unmatched call.
+
+        Known limitation (deferred, not implemented): Claude Code lets a
+        user resume a *completed* async agent via SendMessage (the
+        launch-ack text includes "Use SendMessage with to: '<agentId>' ...
+        to continue this agent", and a `<task-notification>`'s own
+        `<note>` says "the same task-id may notify more than once"). If a
+        resumed agent's continuation calls arrive after its span already
+        closed on `<task-notification>`, and some other async agent
+        happens to be the sole open agent at that moment, this safety net
+        would attribute the resumed agent's traffic to that *other* open
+        agent -- wrong-sibling attribution again, just via a different
+        path than the bug this net was added to guard against. Fixing this
+        would need a "tombstone": retaining a closed async agent's
+        span_id (keyed by its tool_use_id/agentId) for some bounded window
+        after close, so a later resume can still correlate to its own
+        (closed, but reopenable) span rather than falling through to the
+        net. Judged out of scope here -- the resume flow isn't exercised
+        by the recorded log this fix is based on, and a tombstone adds
+        real state (eviction policy, reopen-vs-new-span semantics) for a
+        case that hasn't been observed live yet.
         """
         tool_use_id = self._match_pending_prompt(input_messages)
         if tool_use_id is not None:
@@ -352,12 +386,14 @@ class LiveConsumer(ModelEventSink):
                 return agent.span_id
 
         request = current_bridge_request()
-        if request is not None and request.model == self._models.subagent:
-            async_agents = [
-                agent for agent in self._open_agents.values() if agent.launched_async
-            ]
-            if len(async_agents) == 1:
-                return async_agents[0].span_id
+        if (
+            request is not None
+            and request.model == self._models.subagent
+            and len(self._open_agents) == 1
+        ):
+            (only_agent,) = self._open_agents.values()
+            if only_agent.launched_async:
+                return only_agent.span_id
 
         return self.outer_span_id
 
@@ -578,31 +614,65 @@ class LiveConsumer(ModelEventSink):
         return text.startswith(_ASYNC_LAUNCH_ACK_PREFIX)
 
     def _handle_task_notification(self, text: str) -> None:
-        """Close an async Task's span on its genuine completion signal.
+        """Close async Tasks' spans on their genuine completion signal.
 
         See `_TASK_NOTIFICATION_MARKER` / `_TASK_NOTIFICATION_TOOL_USE_ID_RE`
-        for provenance. Only closes agents already marked `launched_async`
-        (sync Tasks already closed on their real tool_result); if the
-        `<tool-use-id>` can't be parsed out, or names an agent we don't have
-        open, this is a no-op -- conservative by design, per the module docs:
-        an un-correlated async agent's span just stays open until `reset()`
-        closes it (innermost-first) rather than guessing which one finished.
+        for provenance. Scans for *every* `<tool-use-id>` in the text (not
+        just the first) since a batched turn can carry more than one
+        `<task-notification>` block -- e.g. two background agents finishing
+        close together and both notifications landing in the same JSONL
+        "user" line. Only closes agents already marked `launched_async`
+        (sync Tasks already closed on their real tool_result); if a
+        `<tool-use-id>` names an agent we don't have open (or don't have
+        marked launched-async), that one notification is a no-op --
+        conservative by design, per the module docs: an un-correlated async
+        agent's span just stays open until `reset()` closes it (innermost-
+        first) rather than guessing which one finished. That no-op is also
+        the live signature of `_is_async_launch_ack`'s prefix match having
+        gone stale (see `_warn_unresolvable_task_notification`).
         """
         if _TASK_NOTIFICATION_MARKER not in text:
             return
 
-        match = _TASK_NOTIFICATION_TOOL_USE_ID_RE.search(text)
-        if match is None:
-            return
-        tool_use_id = match.group(1)
-
-        agent = self._open_agents.get(tool_use_id)
-        if agent is None or not agent.launched_async:
+        matches = list(_TASK_NOTIFICATION_TOOL_USE_ID_RE.finditer(text))
+        if not matches:
             return
 
-        self._pending_subagents.pop(tool_use_id, None)
-        self._open_agents.pop(tool_use_id, None)
-        transcript()._event(SpanEndEvent(id=agent.span_id))
+        for match in matches:
+            tool_use_id = match.group(1)
+            agent = self._open_agents.get(tool_use_id)
+            if agent is None or not agent.launched_async:
+                self._warn_unresolvable_task_notification(tool_use_id)
+                continue
+
+            self._pending_subagents.pop(tool_use_id, None)
+            self._open_agents.pop(tool_use_id, None)
+            transcript()._event(SpanEndEvent(id=agent.span_id))
+
+    def _warn_unresolvable_task_notification(self, tool_use_id: str) -> None:
+        """Warn (once, per consumer instance) of an unresolvable notification.
+
+        A `<task-notification>` naming a `tool_use_id` that isn't a
+        currently-open launched-async agent is the free-standing signature
+        of `_is_async_launch_ack`'s prefix match having gone stale (CC
+        reworded the launch-ack text, so `_handle_tool_result` never marked
+        the agent `launched_async` in the first place) -- the same failure
+        mode `_check_subagent_slug_drift` guards for the subagent-slug
+        signal. Silently no-op'ing forever would let async spans quietly
+        stop closing on notification (falling back to `reset()` only) with
+        nothing surfaced; this warns once instead.
+        """
+        if self._task_notification_drift_warned:
+            return
+        self._task_notification_drift_warned = True
+        logger.warning(
+            "claude code <task-notification> named tool_use_id %r that "
+            "isn't a currently-open launched-async agent -- async-launch-ack "
+            "detection may have gone stale (CC changed the launch-ack "
+            "text), or the notification arrived after the agent's span "
+            "already closed",
+            tool_use_id,
+        )
 
     def _handle_system(self, raw: dict[str, Any]) -> None:
         """Handle system events (only compaction boundaries today).

--- a/tests/test_claude_code_agent_context.py
+++ b/tests/test_claude_code_agent_context.py
@@ -369,21 +369,18 @@ def _sync_task_result_jsonl(
     return _tool_result_jsonl(tool_use_id, result_text)
 
 
-def _task_notification_jsonl(
+def _task_notification_text(
     tool_use_id: str, task_id: str = "a56bbf04021ac8018"
-) -> dict[str, Any]:
-    """An async Task's genuine completion signal.
+) -> str:
+    """Text of one `<task-notification>` block.
 
-    Shape verified live against CC 2.1.220 (recorded log msg[6]/msg[8]):
-    `message.content` is a plain string (not a tool_result block), and
+    An async Task's genuine completion signal. Shape verified live against
+    CC 2.1.220 (recorded log msg[6]/msg[8]):
     correlates to the *original* Task tool_use_id via `<tool-use-id>` --
     not the CC-internal `<task-id>` also present in the block -- see
     `live_consumer._TASK_NOTIFICATION_TOOL_USE_ID_RE`.
     """
-    text = (
-        "[SYSTEM NOTIFICATION - NOT USER INPUT]\n"
-        "This is an automated background-task event, NOT a message from "
-        "the user.\n\n"
+    return (
         "<task-notification>\n"
         f"<task-id>{task_id}</task-id>\n"
         f"<tool-use-id>{tool_use_id}</tool-use-id>\n"
@@ -391,6 +388,21 @@ def _task_notification_jsonl(
         "<summary>Agent finished</summary>\n"
         "<result>the result text</result>\n"
         "</task-notification>"
+    )
+
+
+def _task_notification_jsonl(
+    tool_use_id: str, task_id: str = "a56bbf04021ac8018"
+) -> dict[str, Any]:
+    """A raw "user" JSONL line wrapping one `<task-notification>` block.
+
+    `message.content` is a plain string (not a tool_result block) -- see
+    `_task_notification_text`.
+    """
+    text = (
+        "[SYSTEM NOTIFICATION - NOT USER INPUT]\n"
+        "This is an automated background-task event, NOT a message from "
+        "the user.\n\n" + _task_notification_text(tool_use_id, task_id)
     )
     return {"type": "user", "message": {"content": text}}
 
@@ -576,3 +588,80 @@ def test_attribute_safety_net_no_op_with_multiple_async_agents(
     with bridged_request_scope(consumer._models.subagent):
         resolved = consumer._attribute(messages)
     assert resolved == consumer.outer_span_id
+
+
+def test_attribute_safety_net_requires_sole_open_agent(monkeypatch: Any) -> None:
+    """A concurrently-open agent of ANY kind must block the safety net.
+
+    Exactly one async agent is open (call_1), which alone would satisfy the
+    old (too-loose) check -- but a second, still-open sync Task (call_2,
+    no tool_result yet) is also open, with a prompt that won't substring-
+    match this call's text. The safety net must require the async agent be
+    the *sole* open agent (of any kind), not just the sole *async* one --
+    otherwise call_2's own unmatchable traffic could get misattributed to
+    call_1. Must fall back to the outer span.
+    """
+    consumer = _consumer(monkeypatch)
+    _spawn_pending(consumer, "call_1", _TASK_PROMPT)
+    consumer.process_jsonl_line(_async_launch_ack_jsonl("call_1"))
+    # call_2: a second, still-open (synchronous) Task -- no tool_result yet,
+    # so it's open but not launched_async.
+    _spawn_pending(consumer, "call_2", _TASK_PROMPT_2)
+
+    messages: list[ChatMessage] = [
+        ChatMessageUser(content="totally unrelated text, no prompt substring")
+    ]
+    with bridged_request_scope(consumer._models.subagent):
+        resolved = consumer._attribute(messages)
+    assert resolved == consumer.outer_span_id
+
+
+def test_task_notification_batched_closes_both_spans(monkeypatch: Any) -> None:
+    """A batched turn can carry two <task-notification> blocks at once.
+
+    E.g. two background agents finishing close together. Both spans must
+    close, not just the first match.
+    """
+    consumer, stub = _consumer_with_transcript(monkeypatch)
+    _spawn_pending(consumer, "call_1", _TASK_PROMPT)
+    _spawn_pending(consumer, "call_2", _TASK_PROMPT_2)
+    consumer.process_jsonl_line(_async_launch_ack_jsonl("call_1", agent_id="agent-1"))
+    consumer.process_jsonl_line(_async_launch_ack_jsonl("call_2", agent_id="agent-2"))
+    span_1 = consumer._open_agents["call_1"].span_id
+    span_2 = consumer._open_agents["call_2"].span_id
+
+    batched_text = (
+        "[SYSTEM NOTIFICATION - NOT USER INPUT]\n"
+        + _task_notification_text("call_1", task_id="agent-1")
+        + "\n"
+        + _task_notification_text("call_2", task_id="agent-2")
+    )
+    consumer.process_jsonl_line({"type": "user", "message": {"content": batched_text}})
+
+    assert "call_1" not in consumer._open_agents
+    assert "call_2" not in consumer._open_agents
+    span_ends = _span_events(stub, SpanEndEvent)
+    assert len(span_ends) == 2
+    assert {e.id for e in span_ends} == {span_1, span_2}
+
+
+def test_unresolvable_task_notification_warns_once(
+    monkeypatch: Any, caplog: Any
+) -> None:
+    """An unresolvable notification warns once per consumer instance.
+
+    A <task-notification> naming no open launched-async agent is the free
+    drift signal that `_is_async_launch_ack`'s prefix match may have gone
+    stale.
+    """
+    consumer, _ = _consumer_with_transcript(monkeypatch)
+
+    with caplog.at_level(
+        "WARNING", logger="inspect_swe._claude_code._events.live_consumer"
+    ):
+        consumer.process_jsonl_line(_task_notification_jsonl("does-not-exist"))
+        consumer.process_jsonl_line(_task_notification_jsonl("also-does-not-exist"))
+
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert len(warnings) == 1
+    assert "does-not-exist" in warnings[0].message

--- a/tests/test_claude_code_agent_context.py
+++ b/tests/test_claude_code_agent_context.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from inspect_ai.agent import AgentBridgeContext
 from inspect_ai.agent._bridge.context import bridged_request_scope
+from inspect_ai.event import SpanBeginEvent, SpanEndEvent
 from inspect_ai.event._model import ModelEvent
 from inspect_ai.model import GenerateConfig, ModelOutput, get_model
 from inspect_ai.model._chat_message import (
@@ -27,6 +28,10 @@ from inspect_swe._claude_code.model import resolve_claude_code_models
 
 # Long enough to clear _MIN_PROMPT_LENGTH's substring-match guard.
 _TASK_PROMPT = "Investigate the failing integration test and report the root cause."
+
+# Second prompt for the two-subagent async replay (mirrors the real recorded
+# log's two concurrent Task spawns).
+_TASK_PROMPT_2 = "Run the second background command and report its output."
 
 
 class _TranscriptStub:
@@ -46,6 +51,23 @@ def _consumer(monkeypatch: Any, **model_kwargs: Any) -> LiveConsumer:
     monkeypatch.setattr(live_consumer_module, "transcript", lambda: _TranscriptStub())
     models = resolve_claude_code_models("mockllm/model", None, **model_kwargs)
     return LiveConsumer(models)
+
+
+def _consumer_with_transcript(
+    monkeypatch: Any, **model_kwargs: Any
+) -> tuple[LiveConsumer, _TranscriptStub]:
+    """Like `_consumer`, but returns the *same* stub instance every call.
+
+    `_consumer`'s `lambda: _TranscriptStub()` hands back a fresh (and
+    therefore immediately-discarded) stub on every `transcript()` call --
+    fine for tests that only assert on consumer state, but the async-replay
+    tests below need to see the actual sequence of SpanBeginEvent /
+    SpanEndEvent traffic emitted across multiple calls.
+    """
+    stub = _TranscriptStub()
+    monkeypatch.setattr(live_consumer_module, "transcript", lambda: stub)
+    models = resolve_claude_code_models("mockllm/model", None, **model_kwargs)
+    return LiveConsumer(models), stub
 
 
 def _task_call_event(tool_call_id: str, prompt: str) -> ModelEvent:
@@ -280,3 +302,277 @@ def test_subagent_slug_drift_requires_a_first_span(
 
     warnings = [r for r in caplog.records if r.levelname == "WARNING"]
     assert len(warnings) == 0
+
+
+# ---------------------------------------------------------------------------
+# async Task span lifecycle
+# ---------------------------------------------------------------------------
+#
+# Shapes below are replayed verbatim (structurally) from a real recorded CC
+# 2.1.220 log -- two concurrent background Task spawns -- at
+# ~/Development/test_evals/logs/agent-context/claude_code/*.eval. See
+# `live_consumer._ASYNC_LAUNCH_ACK_PREFIX` / `_TASK_NOTIFICATION_MARKER` /
+# `_TASK_NOTIFICATION_TOOL_USE_ID_RE` for the provenance notes on each shape.
+#
+# The bug this covers: `_handle_user` used to treat *any* tool_result on a
+# pending Task tool_use_id as completion, closing the span and clearing the
+# registry. For an async/background Task, that tool_result is only the
+# launch acknowledgment -- the real work (and real bridged model calls)
+# arrives seconds later, by which point the registry was already empty, so
+# every subsequent subagent event fell through to the outer span (the
+# "utility agents" / "tail-only messages" viewer artifacts).
+
+
+def _span_events(stub: "_TranscriptStub", event_type: type) -> list[Any]:
+    return [e for e in stub.events if isinstance(e, event_type)]
+
+
+def _tool_result_jsonl(tool_use_id: str, text: str) -> dict[str, Any]:
+    """A raw "user" JSONL line carrying one tool_result content block."""
+    return {
+        "type": "user",
+        "message": {
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": tool_use_id,
+                    "content": [{"type": "text", "text": text}],
+                }
+            ]
+        },
+    }
+
+
+def _async_launch_ack_jsonl(
+    tool_use_id: str, agent_id: str = "a56bbf04021ac8018"
+) -> dict[str, Any]:
+    """An async Task's launch-acknowledgment tool_result.
+
+    Text prefix verified live against CC 2.1.220 (recorded log msg[3]/
+    msg[4]) -- see `live_consumer._ASYNC_LAUNCH_ACK_PREFIX`.
+    """
+    text = (
+        "Async agent launched successfully. (This tool result is internal "
+        "metadata — never quote or paste any part of it, including the "
+        f"agentId below, into a user-facing reply.)\nagentId: {agent_id} "
+        "(internal ID - do not mention to user. Use SendMessage to "
+        "continue this agent.)\nThe agent is working in the background. "
+        "You will be notified automatically when it completes."
+    )
+    return _tool_result_jsonl(tool_use_id, text)
+
+
+def _sync_task_result_jsonl(
+    tool_use_id: str, result_text: str = "the command finished; here is the output"
+) -> dict[str, Any]:
+    """A synchronous Task's real-result tool_result (no async-ack prefix)."""
+    return _tool_result_jsonl(tool_use_id, result_text)
+
+
+def _task_notification_jsonl(
+    tool_use_id: str, task_id: str = "a56bbf04021ac8018"
+) -> dict[str, Any]:
+    """An async Task's genuine completion signal.
+
+    Shape verified live against CC 2.1.220 (recorded log msg[6]/msg[8]):
+    `message.content` is a plain string (not a tool_result block), and
+    correlates to the *original* Task tool_use_id via `<tool-use-id>` --
+    not the CC-internal `<task-id>` also present in the block -- see
+    `live_consumer._TASK_NOTIFICATION_TOOL_USE_ID_RE`.
+    """
+    text = (
+        "[SYSTEM NOTIFICATION - NOT USER INPUT]\n"
+        "This is an automated background-task event, NOT a message from "
+        "the user.\n\n"
+        "<task-notification>\n"
+        f"<task-id>{task_id}</task-id>\n"
+        f"<tool-use-id>{tool_use_id}</tool-use-id>\n"
+        "<status>completed</status>\n"
+        "<summary>Agent finished</summary>\n"
+        "<result>the result text</result>\n"
+        "</task-notification>"
+    )
+    return {"type": "user", "message": {"content": text}}
+
+
+def _subagent_bridge_event(prompt: str) -> ModelEvent:
+    """An in-flight ModelEvent from a sub-agent's own bridge call.
+
+    Re-sends the sub-agent's full history with the original Task prompt at
+    `input[0]` -- see `LiveConsumer`'s class docstring for why that's what
+    drives substring-match attribution.
+    """
+    return ModelEvent(
+        model="m",
+        input=[ChatMessageUser(content=f"<task>\n{prompt}\n</task>")],
+        tools=[],
+        tool_choice="none",
+        config=GenerateConfig(),
+        output=ModelOutput.from_content("m", "working on it"),
+    )
+
+
+def test_async_task_full_replay(monkeypatch: Any) -> None:
+    """Full async Task lifecycle, replayed from the real recorded log's shapes.
+
+    spawn -> launch-ack (span stays OPEN, prompt still registered) ->
+    subagent model events (attributed to the agent span) -> completion
+    notification (span closes) -> reset() closes any stragglers.
+    """
+    consumer, stub = _consumer_with_transcript(monkeypatch)
+
+    # 1. spawn: on_complete with two concurrent Task tool_calls (mirrors the
+    #    real log's two background Task spawns).
+    message = ChatMessageAssistant(
+        content="Spawning two background agents.",
+        tool_calls=[
+            ToolCall(id="call_1", function="Task", arguments={"prompt": _TASK_PROMPT}),
+            ToolCall(
+                id="call_2", function="Task", arguments={"prompt": _TASK_PROMPT_2}
+            ),
+        ],
+    )
+    consumer.on_complete(
+        ModelEvent(
+            model="m",
+            input=[],
+            tools=[],
+            tool_choice="none",
+            config=GenerateConfig(),
+            output=ModelOutput.from_message(message),
+        )
+    )
+    span_1 = consumer._open_agents["call_1"].span_id
+    span_2 = consumer._open_agents["call_2"].span_id
+    assert len(_span_events(stub, SpanBeginEvent)) == 2
+
+    # 2. launch-ack tool_results for both -- spans must stay OPEN, prompts
+    #    still registered. This is the bug: previously this closed the span
+    #    and cleared the registry, orphaning every later subagent event onto
+    #    the outer span.
+    consumer.process_jsonl_line(_async_launch_ack_jsonl("call_1"))
+    consumer.process_jsonl_line(_async_launch_ack_jsonl("call_2"))
+    assert "call_1" in consumer._open_agents
+    assert "call_2" in consumer._open_agents
+    assert "call_1" in consumer._pending_subagents
+    assert "call_2" in consumer._pending_subagents
+    assert consumer._open_agents["call_1"].launched_async is True
+    assert consumer._open_agents["call_2"].launched_async is True
+    assert _span_events(stub, SpanEndEvent) == []  # nothing closed yet
+
+    # 3. subagent model events -- attributed to their own agent span, not
+    #    dumped on the outer span.
+    event_1 = _subagent_bridge_event(_TASK_PROMPT)
+    consumer.on_pending(event_1)
+    assert event_1.span_id == span_1
+
+    event_2 = _subagent_bridge_event(_TASK_PROMPT_2)
+    consumer.on_pending(event_2)
+    assert event_2.span_id == span_2
+
+    # 4. completion notification for agent 1 only -- its span closes; agent
+    #    2 stays open (not yet notified).
+    consumer.process_jsonl_line(_task_notification_jsonl("call_1"))
+    assert "call_1" not in consumer._open_agents
+    assert "call_1" not in consumer._pending_subagents
+    assert "call_2" in consumer._open_agents
+    span_ends = _span_events(stub, SpanEndEvent)
+    assert len(span_ends) == 1
+    assert span_ends[0].id == span_1
+
+    # 5. reset() closes any stragglers (agent 2, never notified).
+    consumer.reset()
+    assert consumer._open_agents == {}
+    span_ends = _span_events(stub, SpanEndEvent)
+    assert len(span_ends) == 2
+    assert {e.id for e in span_ends} == {span_1, span_2}
+
+
+def test_sync_task_result_closes_span_immediately(monkeypatch: Any) -> None:
+    """Regression check: sync Task lifecycle is unchanged by this fix.
+
+    A synchronous Task's tool_result (no async-ack shape) still closes the
+    span and clears the registry right away.
+    """
+    consumer, stub = _consumer_with_transcript(monkeypatch)
+    _spawn_pending(consumer, "call_1", _TASK_PROMPT)
+    span_id = consumer._open_agents["call_1"].span_id
+
+    consumer.process_jsonl_line(_sync_task_result_jsonl("call_1"))
+
+    assert "call_1" not in consumer._open_agents
+    assert "call_1" not in consumer._pending_subagents
+    span_ends = _span_events(stub, SpanEndEvent)
+    assert len(span_ends) == 1
+    assert span_ends[0].id == span_id
+
+
+def test_task_notification_unresolvable_id_is_noop(monkeypatch: Any) -> None:
+    """An unresolvable notification is a no-op, not a guess.
+
+    A notification whose <tool-use-id> names no open agent leaves the span
+    open until `reset()` -- conservative by design.
+    """
+    consumer, stub = _consumer_with_transcript(monkeypatch)
+    _spawn_pending(consumer, "call_1", _TASK_PROMPT)
+    consumer.process_jsonl_line(_async_launch_ack_jsonl("call_1"))
+
+    consumer.process_jsonl_line(_task_notification_jsonl("does-not-exist"))
+
+    assert "call_1" in consumer._open_agents
+    assert _span_events(stub, SpanEndEvent) == []
+
+
+def test_plain_user_text_without_notification_is_noop(monkeypatch: Any) -> None:
+    """Only the <task-notification> marker triggers a lookup.
+
+    An ordinary string-content user turn without it must not close
+    anything.
+    """
+    consumer, stub = _consumer_with_transcript(monkeypatch)
+    _spawn_pending(consumer, "call_1", _TASK_PROMPT)
+    consumer.process_jsonl_line(_async_launch_ack_jsonl("call_1"))
+
+    consumer.process_jsonl_line(
+        {"type": "user", "message": {"content": "hello, unrelated user text"}}
+    )
+
+    assert "call_1" in consumer._open_agents
+    assert _span_events(stub, SpanEndEvent) == []
+
+
+def test_attribute_safety_net_single_async_agent_by_slug(monkeypatch: Any) -> None:
+    """Safety net: slug + a single open async agent resolves unambiguously.
+
+    Prompt-match fails, but the slug is the subagent slug and exactly one
+    async agent is open, so attribution falls back to it.
+    """
+    consumer = _consumer(monkeypatch)
+    _spawn_pending(consumer, "call_1", _TASK_PROMPT)
+    consumer.process_jsonl_line(_async_launch_ack_jsonl("call_1"))
+    span_id = consumer._open_agents["call_1"].span_id
+
+    messages: list[ChatMessage] = [
+        ChatMessageUser(content="totally unrelated text, no prompt substring")
+    ]
+    with bridged_request_scope(consumer._models.subagent):
+        resolved = consumer._attribute(messages)
+    assert resolved == span_id
+
+
+def test_attribute_safety_net_no_op_with_multiple_async_agents(
+    monkeypatch: Any,
+) -> None:
+    """Two async agents open -- ambiguous, safety net must not guess."""
+    consumer = _consumer(monkeypatch)
+    _spawn_pending(consumer, "call_1", _TASK_PROMPT)
+    _spawn_pending(consumer, "call_2", _TASK_PROMPT_2)
+    consumer.process_jsonl_line(_async_launch_ack_jsonl("call_1"))
+    consumer.process_jsonl_line(_async_launch_ack_jsonl("call_2"))
+
+    messages: list[ChatMessage] = [
+        ChatMessageUser(content="totally unrelated text, no prompt substring")
+    ]
+    with bridged_request_scope(consumer._models.subagent):
+        resolved = consumer._attribute(messages)
+    assert resolved == consumer.outer_span_id


### PR DESCRIPTION
## Bug

Part of #131 (multi-agent delegation across bridged CLIs). In the transcript viewer, a Claude Code run that spawns background sub-agents shows no sub-agents at all: their work appears mislabeled as "utility" agents, and the main conversation's message flow becomes an unreadable interleaving of three threads.

Underneath: Claude Code's async/background Task subagents (`Task(..., run_in_background=true)` or equivalent) get their agent spans closed at launch time instead of at completion, orphaning every one of their real bridged model events onto the outer (root) span.

## Mechanism

`_handle_user` in `src/inspect_swe/_claude_code/_events/live_consumer.py` closed an agent span and cleared `_pending_subagents` as soon as it saw *any* `tool_result` for a pending Task/Agent `tool_use_id`. For a synchronous Task that's correct -- the `tool_result` *is* the real result. For an async/background Task, that `tool_result` is only a launch acknowledgment (text starts `"Async agent launched successfully..."`), arriving ~0.5s after spawn -- seconds before the subagent's real bridged calls. By the time those calls arrive, `_pending_subagents` is already empty, so `_attribute` falls through to the outer span.

Two live artifacts this produces, both verified in the real recorded log at `~/Development/test_evals/logs/agent-context/claude_code/2026-08-09T01-56-03-00-00_claude-code-task_5WszyPu2Vdh9NGWPcvANyW.eval`:

- The two real Task spans end up empty and get dropped by the transcript's timeline heuristics; two spurious `utility`-typed spans appear instead, each holding one orphaned subagent event.
- The root/main span's model events interleave with the orphaned subagent ones, so its `n_input` sequence goes non-monotonic (`[2, 5, 2, 2, 4, 4, 7, 9]` in the buggy log) -- an unreadable message flow in the viewer.

## Fix

`_handle_user` now routes `tool_result` blocks through `_handle_tool_result`, which detects the async-launch-ack shape (`_ASYNC_LAUNCH_ACK_PREFIX = "Async agent launched successfully"`, live-verified against CC 2.1.220) and, for those, marks the `_OpenAgent` `launched_async` instead of closing the span / clearing the registry -- sync Task lifecycle is byte-for-byte unchanged.

The real completion signal for an async Task is a synthetic `user`-typed JSONL line whose `message.content` is a plain string containing a `<task-notification>` block. Critically, that block carries `<tool-use-id>` equal *verbatim* to the original Task's `tool_use_id` (not the CC-internal `<task-id>` also present) -- so correlation back to the specific `_open_agents` entry is exact, no guessing needed. `_handle_task_notification` closes the span there. If the id can't be parsed or names an agent we don't have open, it's a no-op by design -- the span just stays open until `reset()` (already closes stragglers innermost-first).

Small safety net added to `_attribute`: if prompt-match fails but the request's slug is the subagent slug and exactly one async agent is open, attribute to it (zero-or-multiple still fall back to the outer span, unchanged).

This also resolves the "utility agents" and "tail-only messages" viewer artifacts noted in the harness README, and doesn't touch `classify()`'s truth table or the subagent-slug drift canary (those tests still pass unmodified).

## Tests

`tests/test_claude_code_agent_context.py` gets:
- `test_async_task_full_replay` -- the full async lifecycle replayed from the real log's shapes: spawn (`on_complete`, 2 concurrent Task tool_calls) → launch-ack tool_results (spans stay OPEN, prompts still registered) → subagent bridge events (asserts `event.span_id` resolves to each agent's own span) → completion notification for one agent (its span closes, the other stays open) → `reset()` closes the straggler.
- `test_sync_task_result_closes_span_immediately` -- regression: a non-async-ack `tool_result` still closes immediately.
- `test_task_notification_unresolvable_id_is_noop`, `test_plain_user_text_without_notification_is_noop` -- conservative no-op edge cases.
- `test_attribute_safety_net_single_async_agent_by_slug`, `test_attribute_safety_net_no_op_with_multiple_async_agents` -- the new attribution safety net.

```
uv run --no-sync pytest tests/test_claude_code_agent_context.py tests/test_claude_code_exit.py tests/test_claude_code_model.py tests/test_agent_context_util.py -q
42 passed
```

ruff check / ruff format / mypy all clean on both touched files.

## Live validation

Re-ran the claude_code agent-context harness task with a fresh log dir (`logs/agent-context/claude_code-fixed/`), same two-subagent delegating prompt, same model (`anthropic/claude-sonnet-4-5`):

| | agent spans | model events per agent span | utility=True spans | root `n_input` sequence |
|---|---|---|---|---|
| **Before** (original diagnostic log) | main + 2 spurious `utility` spans | main: 6, utility: 1, utility: 1 | 2 | `[2, 5, 2, 2, 4, 4, 7, 9]` (non-monotonic) |
| **After** (this fix) | main + 2 real `agent`/Task spans | main: 4, agent: 2, agent: 2 | 0 | `[2, 5, 7, 9]` (monotonic) |

Confirmed via `inspect_ai.event._timeline.timeline_build` on both logs (same diagnostic method used to find the bug): 2 surviving agent spans, correct model-event counts on each, zero utility=True spans, monotonic root n_input.

## Claude Code attribution

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
