### PR TITLE
feat: claude_code reasoning effort option and bridged-MCP allowlist opt-out

### DIFF
--- a/src/inspect_swe/_claude_code/claude_code.py
+++ b/src/inspect_swe/_claude_code/claude_code.py
@@ -64,6 +64,7 @@ from .model import resolve_claude_code_models
 ClaudeCodePermissionMode = Literal[
     "acceptEdits", "auto", "bypassPermissions", "default", "dontAsk", "plan"
 ]
+ClaudeCodeEffort = Literal["low", "medium", "high", "xhigh", "max"]
 
 
 class ClaudeCodeDeprecatedArgs(TypedDict, total=False):
@@ -128,6 +129,7 @@ def claude_code(
     attempts: int | AgentAttempts = 1,
     model: str | None = None,
     model_config: str | None = None,
+    effort: ClaudeCodeEffort | None = None,
     model_aliases: dict[str, str | Model] | None = None,
     opus_model: str | None = None,
     sonnet_model: str | None = None,
@@ -185,6 +187,7 @@ def claude_code(
             bridged to the served Inspect model regardless. (Claude Code renders
             the genuine name/cutoff for recognized Anthropic ids and shows other
             ids verbatim.)
+        effort: Claude Code reasoning effort. ``None`` leaves the CLI default.
         model_aliases: Optional mapping of model names to Model instances or model name strings.
             Allows using custom Model implementations (e.g., wrapped Agents) instead of standard models.
             When a model name in the mapping is referenced, the corresponding Model/string is used.
@@ -317,11 +320,7 @@ def claude_code(
                 if effective_permission_mode is not None
                 else ["--dangerously-skip-permissions"]
             )
-            cmd = [
-                *permission_flag,
-                "--model",
-                models.presented,
-            ]
+            cmd = claude_code_command(permission_flag, models.presented, effort)
 
             # add interactive options if not running as centaur
             if centaur is False:
@@ -615,6 +614,18 @@ def _system_prompt_args(
         args.extend(["--append-system-prompt", "\n\n".join(system_texts)])
 
     return args
+
+
+def claude_code_effort_args(effort: ClaudeCodeEffort | None) -> list[str]:
+    if effort is None:
+        return []
+    return ["--effort", effort]
+
+
+def claude_code_command(
+    permission_flag: list[str], model: str, effort: ClaudeCodeEffort | None
+) -> list[str]:
+    return [*permission_flag, "--model", model, *claude_code_effort_args(effort)]
 
 
 async def _seed_claude_config(

--- a/src/inspect_swe/_claude_code/claude_code.py
+++ b/src/inspect_swe/_claude_code/claude_code.py
@@ -147,6 +147,7 @@ def claude_code(
     debug: bool | None = None,
     replace_system_prompt: str | None = None,
     allowlist_mcp_tools: bool = True,
+    allowlist_bridged_tools: bool = True,
     **deprecated_args: Unpack[ClaudeCodeDeprecatedArgs],
 ) -> Agent:
     """Claude Code agent.
@@ -223,8 +224,23 @@ def claude_code(
             mode except `"bypassPermissions"`: in unattended runs, excluded
             static tools are denied without prompting. Set `False` with
             `permission_mode="auto"` when Claude Code's first-party classifier
-            should adjudicate those tools. Bridged Inspect tools remain allowlisted
-            because an evaluation may depend on them being callable.
+            should adjudicate those tools. Bridged Inspect tools are governed
+            separately by `allowlist_bridged_tools`.
+        allowlist_bridged_tools: Whether to add bridged Inspect tools to
+            `--allowed-tools` (default `True`, preserving the behavior every
+            existing caller gets). Bridged tools are allowlisted by default
+            because an evaluation may depend on them being callable, and in
+            every mode except `"auto"` a tool left off `--allowed-tools` is
+            denied without prompting in an unattended run.
+
+            Set `False` ONLY with `permission_mode="auto"`, where an excluded
+            tool is adjudicated by the classifier rather than denied. This is
+            required for an evaluation that measures Claude Code's own auto-mode
+            classifier acting on bridged tools: an allow rule resolves at step 1
+            of the permission flow, BEFORE the classifier, so an allowlisted
+            bridged call is never reviewed. Left `True` under `"auto"`, a run
+            whose entire tool surface is bridged produces ZERO adjudications and
+            looks clean while being wholly unreviewed.
         **deprecated_args: Supports the deprecated `auto_mode` argument. Set
             `auto_mode=True` maps to `permission_mode="auto"`.
     """
@@ -350,6 +366,7 @@ def claude_code(
                         static_mcp_servers,
                         bridged_mcp_servers,
                         allowlist_mcp_tools,
+                        allowlist_bridged_tools,
                     )
                 )
 
@@ -679,13 +696,18 @@ def resolve_allowed_mcp_tools(
     static_mcp_servers: Sequence[MCPServerConfig],
     bridged_mcp_servers: Sequence[MCPServerConfig],
     allowlist_mcp_tools: bool,
+    allowlist_bridged_tools: bool = True,
 ) -> list[str]:
     static_allowed_tools = (
         resolve_mcp_server_allowed_tools(static_mcp_servers)
         if allowlist_mcp_tools
         else []
     )
-    bridged_allowed_tools = resolve_mcp_server_allowed_tools(bridged_mcp_servers)
+    bridged_allowed_tools = (
+        resolve_mcp_server_allowed_tools(bridged_mcp_servers)
+        if allowlist_bridged_tools
+        else []
+    )
     return [*static_allowed_tools, *bridged_allowed_tools]
 
 

--- a/src/inspect_swe/_claude_code/claude_code.py
+++ b/src/inspect_swe/_claude_code/claude_code.py
@@ -59,12 +59,11 @@ from .._util.sandbox import resolve_agent_cwd
 from .._util.trace import trace
 from .agentbinary import claude_code_binary_source
 from .env import claude_code_agent_env
-from .model import resolve_claude_code_models
+from .model import ClaudeCodeEffort, resolve_claude_code_models
 
 ClaudeCodePermissionMode = Literal[
     "acceptEdits", "auto", "bypassPermissions", "default", "dontAsk", "plan"
 ]
-ClaudeCodeEffort = Literal["low", "medium", "high", "xhigh", "max"]
 
 
 class ClaudeCodeDeprecatedArgs(TypedDict, total=False):
@@ -188,7 +187,13 @@ def claude_code(
             bridged to the served Inspect model regardless. (Claude Code renders
             the genuine name/cutoff for recognized Anthropic ids and shows other
             ids verbatim.)
-        effort: Claude Code reasoning effort. ``None`` leaves the CLI default.
+        effort: Reasoning effort for the served model. Sets
+            `GenerateConfig.reasoning_effort` on the model backing this agent
+            (see `resolve_claude_code_models`), not a Claude Code CLI flag: the
+            bridge drops request-level generation config from the inner agent
+            by default, so passing this through the CLI would have no effect
+            on the model actually serving the request. `None` leaves the
+            model's own default effort in place.
         model_aliases: Optional mapping of model names to Model instances or model name strings.
             Allows using custom Model implementations (e.g., wrapped Agents) instead of standard models.
             When a model name in the mapping is referenced, the corresponding Model/string is used.
@@ -263,6 +268,14 @@ def claude_code(
         cast(dict[str, Any], deprecated_args), permission_mode
     )
 
+    if allowlist_bridged_tools is False and effective_permission_mode != "auto":
+        raise ValueError(
+            "allowlist_bridged_tools=False requires permission_mode='auto'. In "
+            "every other mode, a bridged tool excluded from --allowed-tools is "
+            "denied without prompting instead of being adjudicated by Claude "
+            "Code's classifier, so the eval would complete toolless."
+        )
+
     # allocate session_id once per agent instance so that all calls to execute()
     # for the same sample share the same session. this enables --resume <id> to
     # replay the full conversation history through the bridge on continuation runs,
@@ -291,6 +304,7 @@ def claude_code(
         models = resolve_claude_code_models(
             model,
             model_config,
+            effort=effort,
             opus_model=opus_model,
             sonnet_model=sonnet_model,
             haiku_model=haiku_model,
@@ -336,7 +350,7 @@ def claude_code(
                 if effective_permission_mode is not None
                 else ["--dangerously-skip-permissions"]
             )
-            cmd = claude_code_command(permission_flag, models.presented, effort)
+            cmd = [*permission_flag, "--model", models.presented]
 
             # add interactive options if not running as centaur
             if centaur is False:
@@ -631,18 +645,6 @@ def _system_prompt_args(
         args.extend(["--append-system-prompt", "\n\n".join(system_texts)])
 
     return args
-
-
-def claude_code_effort_args(effort: ClaudeCodeEffort | None) -> list[str]:
-    if effort is None:
-        return []
-    return ["--effort", effort]
-
-
-def claude_code_command(
-    permission_flag: list[str], model: str, effort: ClaudeCodeEffort | None
-) -> list[str]:
-    return [*permission_flag, "--model", model, *claude_code_effort_args(effort)]
 
 
 async def _seed_claude_config(

--- a/src/inspect_swe/_claude_code/model.py
+++ b/src/inspect_swe/_claude_code/model.py
@@ -7,9 +7,13 @@ The real model is reached through the bridge. This module bundles that
 resolution so ``claude_code()`` stays readable.
 """
 
+from copy import copy
 from dataclasses import dataclass
+from typing import Literal
 
-from inspect_ai.model import Model, get_model
+from inspect_ai.model import GenerateConfig, Model, get_model
+
+ClaudeCodeEffort = Literal["low", "medium", "high", "xhigh", "max"]
 
 
 @dataclass(frozen=True)
@@ -37,6 +41,7 @@ def resolve_claude_code_models(
     model: str | None,
     model_config: str | None,
     *,
+    effort: ClaudeCodeEffort | None = None,
     opus_model: str | None = None,
     sonnet_model: str | None = None,
     haiku_model: str | None = None,
@@ -54,10 +59,29 @@ def resolve_claude_code_models(
     collapse them onto the main model). Caller-supplied ``model_aliases`` take
     precedence over the names we derive.
 
+    ``effort`` is set on every served model this function resolves (the primary
+    served model and any role that gets its own alias) by merging
+    ``GenerateConfig(reasoning_effort=effort)`` onto a copy of each model's
+    bound config, so it governs the model's own default whether or not the
+    bridge forwards the inner agent's request-level generation config (the
+    bridge drops those by default; see ``sandbox_agent_bridge``'s
+    ``forward_generation_config``). It is not applied to caller-supplied
+    ``model_aliases``, whose config is the caller's to control.
+
     Note: must be called at execution time — ``get_model()`` resolves the active
     model from the current eval/sample context.
     """
-    served_model = get_model(model)
+
+    def served(model_name: str | None) -> Model:
+        resolved = get_model(model_name)
+        if effort is not None:
+            resolved = copy(resolved)
+            resolved.config = resolved.config.merge(
+                GenerateConfig(reasoning_effort=effort)
+            )
+        return resolved
+
+    served_model = served(model)
     presented = model_config if model_config is not None else served_model.name
     aliases: dict[str, str | Model] = {presented: served_model}
 
@@ -67,7 +91,7 @@ def resolve_claude_code_models(
         # own model
         if role_model is None:
             return presented
-        role = get_model(role_model)
+        role = served(role_model)
         aliases[role.name] = role
         return role.name
 

--- a/tests/test_claude_code_effort.py
+++ b/tests/test_claude_code_effort.py
@@ -1,25 +1,51 @@
-from inspect_swe._claude_code.claude_code import (
-    claude_code_command,
-    claude_code_effort_args,
-)
+"""``effort`` is applied host-side, on the served model's ``GenerateConfig``.
+
+Passing it as a Claude Code CLI flag has no effect on the model actually
+serving the request: the bridge drops the inner agent's request-level
+generation config by default (``sandbox_agent_bridge``'s
+``forward_generation_config`` defaults to ``False``), and only the resolved
+Inspect model's own config governs. See ``resolve_claude_code_models``.
+"""
+
+from inspect_ai.model import Model
+from inspect_swe._claude_code.model import resolve_claude_code_models
 
 
-def test_effort_adds_cli_flag_when_configured() -> None:
-    assert claude_code_effort_args("max") == ["--effort", "max"]
+def test_effort_sets_reasoning_effort_on_served_model() -> None:
+    models = resolve_claude_code_models("mockllm/model", None, effort="max")
+    served_model = models.aliases[models.presented]
+    assert isinstance(served_model, Model)
+    assert served_model.config.reasoning_effort == "max"
 
 
-def test_effort_adds_no_cli_flag_when_unconfigured() -> None:
-    assert claude_code_effort_args(None) == []
+def test_unconfigured_effort_leaves_served_model_config_untouched() -> None:
+    models = resolve_claude_code_models("mockllm/model", None, effort=None)
+    served_model = models.aliases[models.presented]
+    assert isinstance(served_model, Model)
+    assert served_model.config.reasoning_effort is None
 
 
-def test_effort_is_present_in_claude_code_command_after_model() -> None:
-    assert claude_code_command(
-        ["--permission-mode", "auto"], "claude-opus-5", "max"
-    ) == [
-        "--permission-mode",
-        "auto",
-        "--model",
-        "claude-opus-5",
-        "--effort",
-        "max",
-    ]
+def test_effort_applies_to_every_role_this_function_resolves() -> None:
+    models = resolve_claude_code_models(
+        "mockllm/model",
+        None,
+        effort="low",
+        opus_model="mockllm/opus",
+    )
+    presented_model = models.aliases[models.presented]
+    opus_model = models.aliases[models.opus]
+    assert isinstance(presented_model, Model)
+    assert isinstance(opus_model, Model)
+    assert presented_model.config.reasoning_effort == "low"
+    assert opus_model.config.reasoning_effort == "low"
+
+
+def test_effort_does_not_override_caller_supplied_model_aliases() -> None:
+    models = resolve_claude_code_models(
+        "mockllm/model",
+        None,
+        effort="high",
+        model_aliases={"model": "mockllm/override"},
+    )
+    # the caller-supplied alias is a plain model spec string, untouched by effort
+    assert models.aliases["model"] == "mockllm/override"

--- a/tests/test_claude_code_effort.py
+++ b/tests/test_claude_code_effort.py
@@ -1,0 +1,25 @@
+from inspect_swe._claude_code.claude_code import (
+    claude_code_command,
+    claude_code_effort_args,
+)
+
+
+def test_effort_adds_cli_flag_when_configured() -> None:
+    assert claude_code_effort_args("max") == ["--effort", "max"]
+
+
+def test_effort_adds_no_cli_flag_when_unconfigured() -> None:
+    assert claude_code_effort_args(None) == []
+
+
+def test_effort_is_present_in_claude_code_command_after_model() -> None:
+    assert claude_code_command(
+        ["--permission-mode", "auto"], "claude-opus-5", "max"
+    ) == [
+        "--permission-mode",
+        "auto",
+        "--model",
+        "claude-opus-5",
+        "--effort",
+        "max",
+    ]

--- a/tests/test_claude_code_mcp_allowed_tools.py
+++ b/tests/test_claude_code_mcp_allowed_tools.py
@@ -56,6 +56,51 @@ def test_disabling_static_mcp_allowlist_preserves_bridged_allowlist() -> None:
     assert allowed_tools == ["mcp__inspect-tools__submit"]
 
 
+def test_disabling_bridged_allowlist_suppresses_bridged_allow_rules() -> None:
+    """``allowlist_bridged_tools=False`` is what sends bridged calls to the classifier.
+
+    An allow rule resolves at step 1 of the permission flow, before the
+    ``permission_mode="auto"`` classifier, so a bridged tool left on
+    ``--allowed-tools`` is never adjudicated. An evaluation whose whole tool
+    surface is bridged therefore records zero adjudications while appearing to
+    run under a reviewer.
+    """
+    bridged_server = MCPServerConfig(type="http", name="inspect-tools", tools="all")
+
+    allowed_tools = resolve_allowed_mcp_tools(
+        [], [bridged_server], allowlist_mcp_tools=False, allowlist_bridged_tools=False
+    )
+
+    assert allowed_tools == []
+
+
+def test_bridged_allowlist_defaults_to_enabled() -> None:
+    """Omitting the argument keeps every existing caller's behavior unchanged."""
+    bridged_server = MCPServerConfig(type="http", name="inspect-tools", tools="all")
+
+    assert resolve_allowed_mcp_tools(
+        [], [bridged_server], allowlist_mcp_tools=True
+    ) == ["mcp__inspect-tools__*"]
+
+
+def test_static_and_bridged_allowlists_are_independent() -> None:
+    static_server = MCPServerConfig(type="http", name="caller-tools", tools=["lookup"])
+    bridged_server = MCPServerConfig(
+        type="http", name="inspect-tools", tools=["submit"]
+    )
+
+    assert resolve_allowed_mcp_tools(
+        [static_server],
+        [bridged_server],
+        allowlist_mcp_tools=True,
+        allowlist_bridged_tools=False,
+    ) == ["mcp__caller-tools__lookup"]
+
+
+def test_claude_code_accepts_allowlist_bridged_tools() -> None:
+    claude_code(permission_mode="auto", allowlist_bridged_tools=False)
+
+
 def test_all_tools_wildcard_uses_double_underscore_before_glob() -> None:
     server = MCPServerConfig(type="http", name="taiga-mcp", tools="all")
 

--- a/tests/test_claude_code_mcp_allowed_tools.py
+++ b/tests/test_claude_code_mcp_allowed_tools.py
@@ -101,6 +101,20 @@ def test_claude_code_accepts_allowlist_bridged_tools() -> None:
     claude_code(permission_mode="auto", allowlist_bridged_tools=False)
 
 
+def test_allowlist_bridged_tools_false_requires_permission_mode_auto() -> None:
+    """Defaulting to `--dangerously-skip-permissions` denies bridged tools silently.
+
+    The eval would complete toolless without ever consulting the classifier.
+    """
+    with pytest.raises(ValueError, match="allowlist_bridged_tools"):
+        claude_code(allowlist_bridged_tools=False)
+
+
+def test_allowlist_bridged_tools_false_rejects_non_auto_permission_mode() -> None:
+    with pytest.raises(ValueError, match="allowlist_bridged_tools"):
+        claude_code(permission_mode="acceptEdits", allowlist_bridged_tools=False)
+
+
 def test_all_tools_wildcard_uses_double_underscore_before_glob() -> None:
     server = MCPServerConfig(type="http", name="taiga-mcp", tools="all")
 


### PR DESCRIPTION
Two small claude_code agent options, combined per our fork maintainer's request:

**Reasoning effort**: `claude_code()` gains an `effort` option (`"low"`/`"medium"`/`"high"`/`"xhigh"`/`"max"`) that sets `reasoning_effort` on the `GenerateConfig` of every served model the agent resolves, so evals can control the served model's thinking budget per agent. This is applied host-side rather than passed through as a Claude Code CLI flag: the bridge drops the inner agent's own request-level generation config by default, so a CLI-level flag would have no effect on the model actually serving the request. Covered by `tests/test_claude_code_effort.py`.

**Bridged-MCP allowlist opt-out**: `permission_mode="auto"` callers can suppress the bridged MCP allowlist (`--allowed-tools` restriction) that claude_code applies to bridged tools by default, via `allowlist_bridged_tools=False`. The default stays unchanged; the opt-out is for evaluations that specifically measure Claude Code's own auto-mode classifier acting on bridged tools. Construction raises `ValueError` if `allowlist_bridged_tools=False` is combined with any `permission_mode` other than `"auto"`, since every other mode denies an excluded bridged tool without prompting rather than adjudicating it. Covered by `tests/test_claude_code_mcp_allowed_tools.py`.

`make check` clean (ruff, mypy); targeted suites pass.

Agent involvement disclosure: branch assembled and PR opened by Claude on Sami Jawhar's behalf; reworked in response to review feedback from epatey (the effort mechanism moved from a CLI passthrough to a host-side GenerateConfig override after epatey verified the CLI flag had no effect on the served model, and the allowlist option gained a construction-time guard).
