### PR TITLE
feat: Codex rollout events

### DIFF
--- a/src/inspect_swe/_claude_code/_events/extraction.py
+++ b/src/inspect_swe/_claude_code/_events/extraction.py
@@ -378,4 +378,3 @@ def get_first_timestamp(events: list[BaseEvent]) -> str | None:
     # Sort and return earliest
     timestamps.sort()
     return timestamps[0]
-

--- a/src/inspect_swe/_claude_code/_events/extraction.py
+++ b/src/inspect_swe/_claude_code/_events/extraction.py
@@ -7,7 +7,6 @@ information from Claude Code events.
 from logging import getLogger
 from typing import Any
 
-from inspect_ai.event import Event, ModelEvent
 from inspect_ai.model import (
     Content,
     ContentImage,
@@ -20,6 +19,9 @@ from inspect_ai.model._chat_message import (
 )
 from inspect_ai.tool import ToolCall
 
+# Re-exported here because scout's claude-code importer sums tokens alongside
+# the other extraction helpers (single implementation in _util.events).
+from ..._util.events import sum_scout_tokens as sum_scout_tokens
 from .detection import (
     get_timestamp,
 )
@@ -377,21 +379,3 @@ def get_first_timestamp(events: list[BaseEvent]) -> str | None:
     timestamps.sort()
     return timestamps[0]
 
-
-def sum_scout_tokens(events: list[Event]) -> int:
-    """Sum total tokens from converted Scout ModelEvent objects.
-
-    Unlike sum_tokens() which only counts main-session BaseEvent tokens,
-    this counts tokens from all ModelEvents including loaded subagent events.
-
-    Args:
-        events: List of Inspect AI events
-
-    Returns:
-        Total token count across all ModelEvents
-    """
-    total = 0
-    for event in events:
-        if isinstance(event, ModelEvent) and event.output and event.output.usage:
-            total += event.output.usage.total_tokens
-    return total

--- a/src/inspect_swe/_codex_cli/_events/rollout.py
+++ b/src/inspect_swe/_codex_cli/_events/rollout.py
@@ -562,8 +562,11 @@ class _RolloutProcessor:
         return [compaction]
 
     def process_token_count(self, event: TokenCountEvent) -> None:
-        """Track the cumulative total (per-response usage is attached by the
-        flush-time lookahead in ``process_rollout_events``)."""
+        """Track the cumulative total.
+
+        Per-response usage is attached by the flush-time lookahead in
+        ``process_rollout_events``.
+        """
         if not event.info:
             return
         total = total_tokens_from_token_info(event.info)
@@ -752,8 +755,11 @@ async def process_rollout_events(
     proc = _RolloutProcessor(max_depth=max_depth, child_loader=child_loader)
 
     def lookahead_usage(start: int) -> ModelUsage | None:
-        """Usage for the response being flushed: the first usage-bearing
-        token_count at/after ``start``, before the next model response."""
+        """Usage for the response being flushed.
+
+        The first usage-bearing token_count at/after ``start``, before the
+        next model response.
+        """
         for ahead in events[start:]:
             if proc.is_assistant_side(ahead):
                 return None

--- a/src/inspect_swe/_codex_cli/_events/rollout.py
+++ b/src/inspect_swe/_codex_cli/_events/rollout.py
@@ -539,7 +539,9 @@ class _RolloutProcessor:
         if event.replacement_history is not None:
             self.accumulated_messages = history_to_messages(event.replacement_history)
         elif event.message:
-            self.accumulated_messages = [ChatMessageAssistant(content=event.message)]
+            # Codex re-injects the summary as a user-role bridge message
+            # (codex-rs build_compacted_history), so mirror that role.
+            self.accumulated_messages = [ChatMessageUser(content=event.message)]
         else:
             self.accumulated_messages = []
         self.user_turn_starts = []

--- a/src/inspect_swe/_codex_cli/_events/rollout.py
+++ b/src/inspect_swe/_codex_cli/_events/rollout.py
@@ -79,6 +79,7 @@ from .rollout_models import (
     ReviewModeEvent,
     RolloutEvent,
     SessionMetaEvent,
+    SubAgentActivityEvent,
     ThreadRolledBackEvent,
     TokenCountEvent,
     TurnAbortedEvent,
@@ -117,6 +118,9 @@ class _PendingCall:
     timestamp: datetime
     is_spawn: bool = False
     spawn_agent_type: str | None = None
+    spawn_task_name: str | None = None
+    spawn_thread_id: str | None = None
+    spawn_agent_path: str | None = None
 
 
 def _spawn_result_thread_id(result: str) -> tuple[str | None, str | None]:
@@ -237,6 +241,11 @@ class _RolloutProcessor:
                     spawn_agent_type=(
                         str(arguments.get("agent_type"))
                         if item.name == SPAWN_AGENT and arguments.get("agent_type")
+                        else None
+                    ),
+                    spawn_task_name=(
+                        str(arguments.get("task_name"))
+                        if item.name == SPAWN_AGENT and arguments.get("task_name")
                         else None
                     ),
                 )
@@ -408,6 +417,17 @@ class _RolloutProcessor:
         )
         return events
 
+    def process_sub_agent_activity(self, event: SubAgentActivityEvent) -> None:
+        """Bind a modern sub-agent activity event to its pending spawn call."""
+        pending = self.pending_calls.get(event.event_id)
+        if pending is None or not pending.is_spawn:
+            logger.debug(
+                f"Sub-agent activity with no matching spawn call: {event.event_id}"
+            )
+            return
+        pending.spawn_thread_id = event.agent_thread_id
+        pending.spawn_agent_path = event.agent_path
+
     async def _spawn_agent_span_events(
         self,
         pending: _PendingCall,
@@ -418,8 +438,15 @@ class _RolloutProcessor:
         """Create the agent span for a spawn_agent call (child events nested)."""
         agent_span_id = f"agent-{pending.call_id}"
         result_text = result if isinstance(result, str) else ""
-        thread_id, nickname = _spawn_result_thread_id(result_text)
-        agent_name = nickname or pending.spawn_agent_type or "agent"
+        result_thread_id, nickname = _spawn_result_thread_id(result_text)
+        thread_id = pending.spawn_thread_id or result_thread_id
+        agent_name = (
+            nickname
+            or pending.spawn_task_name
+            or pending.spawn_agent_type
+            or (pending.spawn_agent_path or "").rsplit("/", maxsplit=1)[-1]
+            or "agent"
+        )
 
         events: list[Event] = [
             _span_begin(
@@ -429,7 +456,9 @@ class _RolloutProcessor:
                 timestamp=pending.timestamp,
                 metadata={
                     "agent_type": pending.spawn_agent_type,
+                    "task_name": pending.spawn_task_name,
                     "thread_id": thread_id,
+                    "agent_path": pending.spawn_agent_path,
                 },
             )
         ]
@@ -700,6 +729,8 @@ async def process_rollout_events(
                 yield evt
         elif isinstance(event, TokenCountEvent):
             proc.process_token_count(event)
+        elif isinstance(event, SubAgentActivityEvent):
+            proc.process_sub_agent_activity(event)
         elif isinstance(event, CompactedEvent):
             for evt in proc.process_compacted(event, timestamp):
                 yield evt

--- a/src/inspect_swe/_codex_cli/_events/rollout.py
+++ b/src/inspect_swe/_codex_cli/_events/rollout.py
@@ -1,0 +1,744 @@
+"""Conversion of Codex CLI rollout files to Scout/Inspect events.
+
+Mirrors ``_claude_code/_events/events.py``: a ``_RolloutProcessor`` walks the
+parsed rollout lines in file order, reconstructing what the model saw
+(``accumulated_messages``) and emitting Inspect events:
+
+- assistant-side response items (reasoning / assistant message / tool calls)
+  are buffered and flushed into a single ``ModelEvent`` per model response
+- ``function_call`` / ``function_call_output`` pairs (matched by ``call_id``)
+  become tool spans: SpanBegin(type="tool") → ToolEvent → SpanEnd
+- ``spawn_agent`` calls become agent spans with the child thread's events
+  nested inside (loaded via a ``ChildThreadLoader`` callback — file-based in
+  inspect_scout)
+- ``compacted`` items become ``CompactionEvent``s; accumulated messages are
+  reset to the item's ``replacement_history`` (the exact post-compaction
+  context)
+- ``thread_rolled_back`` (undo) truncates accumulated messages so subsequent
+  ``ModelEvent.input`` reflects what the model actually saw; already-emitted
+  events stay in the timeline with an InfoEvent marking the boundary
+- ``token_count`` events attach usage to the most recent ModelEvent
+
+Unlike Claude Code there is no uuid/parentUuid tree (rollouts are
+append-ordered) and no shared-id consolidation (one model response is a run
+of consecutive assistant-side items).
+"""
+
+import json
+from collections.abc import AsyncIterator, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from logging import getLogger
+from typing import Any, Literal, Protocol
+
+from inspect_ai.event import (
+    CompactionEvent,
+    Event,
+    InfoEvent,
+    ModelEvent,
+    SpanBeginEvent,
+    SpanEndEvent,
+    ToolEvent,
+)
+from inspect_ai.model import Content, ContentText, ModelOutput
+from inspect_ai.model._chat_message import (
+    ChatMessage,
+    ChatMessageAssistant,
+    ChatMessageSystem,
+    ChatMessageTool,
+    ChatMessageUser,
+)
+from inspect_ai.model._generate_config import GenerateConfig
+from inspect_ai.model._model_output import ChatCompletionChoice
+from inspect_ai.tool._tool import ToolResult
+from inspect_ai.tool._tool_call import ToolCall, ToolCallError
+
+from .detection import SPAWN_AGENT
+from .rollout_extraction import (
+    content_items_to_content,
+    history_to_messages,
+    is_context_message,
+    output_to_result,
+    parse_arguments,
+    parse_timestamp,
+    reasoning_to_content,
+    total_tokens_from_token_info,
+    usage_from_token_info,
+)
+from .rollout_models import (
+    CompactedEvent,
+    ResponseCompaction,
+    ResponseCustomToolCall,
+    ResponseCustomToolCallOutput,
+    ResponseFunctionCall,
+    ResponseFunctionCallOutput,
+    ResponseLocalShellCall,
+    ResponseMessage,
+    ResponseReasoning,
+    ResponseWebSearchCall,
+    ReviewModeEvent,
+    RolloutEvent,
+    SessionMetaEvent,
+    ThreadRolledBackEvent,
+    TokenCountEvent,
+    TurnAbortedEvent,
+    TurnCompleteEvent,
+    TurnContextEvent,
+)
+from .toolview import tool_view
+
+logger = getLogger(__name__)
+
+CODEX_EVENT_SOURCE = "codex_cli"
+
+# Sentinel timestamp for events with unparseable timestamps.
+# Using epoch avoids extending timelines to the present day.
+_EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+
+class ChildThreadLoader(Protocol):
+    """Callback for loading a spawned child thread's events.
+
+    Implementations locate the child rollout file by thread id
+    (inspect_scout loads from ``$CODEX_HOME/sessions``) and return its
+    converted events for nesting under the parent's agent span.
+    """
+
+    async def __call__(self, thread_id: str, max_depth: int) -> list[Event]: ...
+
+
+@dataclass
+class _PendingCall:
+    """A tool call awaiting its output item."""
+
+    call_id: str
+    function: str
+    arguments: dict[str, Any]
+    timestamp: datetime
+    is_spawn: bool = False
+    spawn_agent_type: str | None = None
+
+
+def _spawn_result_thread_id(result: str) -> tuple[str | None, str | None]:
+    """Extract (thread_id, nickname) from a spawn_agent tool result."""
+    try:
+        data = json.loads(result)
+    except (json.JSONDecodeError, TypeError):
+        return None, None
+    if isinstance(data, dict):
+        agent_id = data.get("agent_id")
+        nickname = data.get("nickname")
+        if isinstance(agent_id, str) and agent_id:
+            return agent_id, nickname if isinstance(nickname, str) else None
+    return None, None
+
+
+class _RolloutProcessor:
+    """Stateful conversion of parsed rollout events to Inspect events."""
+
+    def __init__(
+        self,
+        max_depth: int = 5,
+        child_loader: ChildThreadLoader | None = None,
+    ) -> None:
+        self.max_depth = max_depth
+        self.child_loader = child_loader
+
+        self.accumulated_messages: list[ChatMessage] = []
+        # Index into accumulated_messages where each genuine user turn began
+        # (used to replay thread_rolled_back truncation).
+        self.user_turn_starts: list[int] = []
+        self.pending_calls: dict[str, _PendingCall] = {}
+        # Buffered assistant-side items awaiting flush into one ModelEvent
+        self.assistant_buffer: list[RolloutEvent] = []
+        self.buffer_timestamp: datetime | None = None
+        self.last_model_event: ModelEvent | None = None
+        self.current_model: str | None = None
+        self.last_total_tokens: int | None = None
+        self.last_timestamp: datetime = _EPOCH
+
+    def update_timestamp(self, event: RolloutEvent) -> datetime:
+        """Parse and track the latest timestamp, ensuring monotonic ordering."""
+        timestamp = parse_timestamp(event.timestamp) or self.last_timestamp
+        if timestamp <= self.last_timestamp:
+            timestamp = self.last_timestamp + timedelta(milliseconds=1)
+        self.last_timestamp = timestamp
+        return timestamp
+
+    # ── assistant-side buffering ─────────────────────────────────────────
+
+    def is_assistant_side(self, event: RolloutEvent) -> bool:
+        """Whether this item is part of a model response (buffered)."""
+        if isinstance(event, ResponseMessage):
+            return event.role == "assistant"
+        return isinstance(
+            event,
+            (
+                ResponseReasoning,
+                ResponseFunctionCall,
+                ResponseLocalShellCall,
+                ResponseCustomToolCall,
+                ResponseWebSearchCall,
+            ),
+        )
+
+    def buffer_assistant(self, event: RolloutEvent, timestamp: datetime) -> None:
+        """Buffer an assistant-side item for the next ModelEvent flush."""
+        if not self.assistant_buffer:
+            self.buffer_timestamp = timestamp
+        self.assistant_buffer.append(event)
+
+    def flush_model(self) -> list[Event]:
+        """Convert buffered assistant-side items into a ModelEvent.
+
+        Also emits self-contained spans for hosted ``web_search_call`` items
+        (which have no separate output item) and registers pending tool
+        calls for later matching by ``call_id``.
+        """
+        if not self.assistant_buffer:
+            return []
+
+        timestamp = self.buffer_timestamp or self.last_timestamp
+        content: list[Content] = []
+        tool_calls: list[ToolCall] = []
+        web_search_events: list[Event] = []
+        message_id: str | None = None
+
+        for item in self.assistant_buffer:
+            if isinstance(item, ResponseReasoning):
+                reasoning = reasoning_to_content(item)
+                if reasoning is not None:
+                    content.append(reasoning)
+            elif isinstance(item, ResponseMessage):
+                if message_id is None and item.id:
+                    message_id = item.id
+                converted = content_items_to_content(item.content)
+                if isinstance(converted, str):
+                    if converted:
+                        content.append(ContentText(text=converted))
+                else:
+                    content.extend(converted)
+            elif isinstance(item, ResponseFunctionCall):
+                arguments = parse_arguments(item.arguments)
+                tool_calls.append(
+                    ToolCall(
+                        id=item.call_id,
+                        function=item.name,
+                        arguments=arguments,
+                        view=tool_view(item.name, arguments),
+                    )
+                )
+                self.pending_calls[item.call_id] = _PendingCall(
+                    call_id=item.call_id,
+                    function=item.name,
+                    arguments=arguments,
+                    timestamp=timestamp,
+                    is_spawn=item.name == SPAWN_AGENT,
+                    spawn_agent_type=(
+                        str(arguments.get("agent_type"))
+                        if item.name == SPAWN_AGENT and arguments.get("agent_type")
+                        else None
+                    ),
+                )
+            elif isinstance(item, ResponseLocalShellCall):
+                call_id = item.call_id or item.id or ""
+                arguments = dict(item.action)
+                arguments.pop("type", None)
+                tool_calls.append(
+                    ToolCall(id=call_id, function="local_shell", arguments=arguments)
+                )
+                if call_id:
+                    self.pending_calls[call_id] = _PendingCall(
+                        call_id=call_id,
+                        function="local_shell",
+                        arguments=arguments,
+                        timestamp=timestamp,
+                    )
+            elif isinstance(item, ResponseCustomToolCall):
+                arguments = {"input": item.input}
+                tool_calls.append(
+                    ToolCall(
+                        id=item.call_id,
+                        function=item.name,
+                        arguments=arguments,
+                        view=tool_view(item.name, arguments),
+                        type="custom",
+                    )
+                )
+                self.pending_calls[item.call_id] = _PendingCall(
+                    call_id=item.call_id,
+                    function=item.name,
+                    arguments=arguments,
+                    timestamp=timestamp,
+                )
+            elif isinstance(item, ResponseWebSearchCall):
+                # Hosted tool: no output item, so emit a self-contained span.
+                action = item.action or {}
+                arguments = {k: v for k, v in action.items() if k != "type"}
+                call_id = item.id or f"web_search_{len(web_search_events)}"
+                tool_calls.append(
+                    ToolCall(
+                        id=call_id,
+                        function="web_search",
+                        arguments=arguments,
+                        view=tool_view("web_search", arguments),
+                    )
+                )
+                web_search_events.extend(
+                    _tool_span_events(
+                        call_id=call_id,
+                        function="web_search",
+                        arguments=arguments,
+                        result=item.status or "",
+                        error=None,
+                        timestamp=timestamp,
+                        completed=timestamp,
+                    )
+                )
+
+        self.assistant_buffer = []
+        self.buffer_timestamp = None
+
+        output_content: str | list[Content]
+        if len(content) == 1 and isinstance(content[0], ContentText):
+            output_content = content[0].text
+        else:
+            output_content = content if content else ""
+
+        output_message = ChatMessageAssistant(
+            id=message_id,
+            content=output_content,
+            tool_calls=tool_calls if tool_calls else None,
+        )
+
+        stop_reason: Literal["stop", "tool_calls"] = (
+            "tool_calls" if tool_calls else "stop"
+        )
+        model = self.current_model or "unknown"
+        model_event = ModelEvent(
+            model=model,
+            input=list(self.accumulated_messages),
+            tools=[],
+            tool_choice="auto",
+            config=GenerateConfig(),
+            output=ModelOutput(
+                model=model,
+                choices=[
+                    ChatCompletionChoice(
+                        message=output_message, stop_reason=stop_reason
+                    )
+                ],
+            ),
+            timestamp=timestamp,
+        )
+        self.accumulated_messages.append(output_message)
+        self.last_model_event = model_event
+
+        return [model_event, *web_search_events]
+
+    # ── boundary items ───────────────────────────────────────────────────
+
+    def process_user_message(self, event: ResponseMessage) -> None:
+        """Accumulate a user/developer message (no event emitted).
+
+        All model-visible messages are accumulated for ModelEvent.input
+        fidelity — including injected context blocks (user_instructions,
+        environment_context, ...), which are model context even though they
+        are not user speech. Genuine user turns are tracked for rollback.
+        """
+        converted = content_items_to_content(event.content)
+        if not converted:
+            return
+        if event.role in ("developer", "system"):
+            self.accumulated_messages.append(ChatMessageSystem(content=converted))
+        else:
+            text = converted if isinstance(converted, str) else ""
+            genuine = not (text and is_context_message(text))
+            if genuine:
+                self.user_turn_starts.append(len(self.accumulated_messages))
+            self.accumulated_messages.append(ChatMessageUser(content=converted))
+
+    async def process_call_output(
+        self,
+        call_id: str,
+        output: Any,
+        timestamp: datetime,
+    ) -> list[Event]:
+        """Match a tool output to its pending call and emit the tool span."""
+        pending = self.pending_calls.pop(call_id, None)
+        result, exit_code = output_to_result(output)
+        error: ToolCallError | None = None
+        if exit_code is not None and exit_code != 0:
+            error = ToolCallError(
+                type="unknown",
+                message=result if isinstance(result, str) else str(result),
+            )
+
+        if pending is None:
+            # Output with no matching call (e.g. prefix truncated by
+            # compaction replay or a malformed file) — record for fidelity.
+            logger.debug(f"Tool output with no matching call: {call_id}")
+            self.accumulated_messages.append(
+                ChatMessageTool(content=result, tool_call_id=call_id)
+            )
+            return []
+
+        events: list[Event] = []
+        if pending.is_spawn:
+            events = await self._spawn_agent_span_events(
+                pending, result, error, timestamp
+            )
+        else:
+            events = _tool_span_events(
+                call_id=pending.call_id,
+                function=pending.function,
+                arguments=pending.arguments,
+                result=result,
+                error=error,
+                timestamp=pending.timestamp,
+                completed=timestamp,
+            )
+
+        self.accumulated_messages.append(
+            ChatMessageTool(
+                content=result,
+                tool_call_id=pending.call_id,
+                function=pending.function,
+            )
+        )
+        return events
+
+    async def _spawn_agent_span_events(
+        self,
+        pending: _PendingCall,
+        result: str | list[Content],
+        error: ToolCallError | None,
+        timestamp: datetime,
+    ) -> list[Event]:
+        """Create the agent span for a spawn_agent call (child events nested)."""
+        agent_span_id = f"agent-{pending.call_id}"
+        result_text = result if isinstance(result, str) else ""
+        thread_id, nickname = _spawn_result_thread_id(result_text)
+        agent_name = nickname or pending.spawn_agent_type or "agent"
+
+        events: list[Event] = [
+            _span_begin(
+                span_id=agent_span_id,
+                name=agent_name,
+                span_type="agent",
+                timestamp=pending.timestamp,
+                metadata={
+                    "agent_type": pending.spawn_agent_type,
+                    "thread_id": thread_id,
+                },
+            )
+        ]
+
+        tool_event = _to_tool_event(
+            call_id=pending.call_id,
+            function=pending.function,
+            arguments=pending.arguments,
+            result=result,
+            error=error,
+            timestamp=pending.timestamp,
+            completed=timestamp,
+        )
+        tool_event.span_id = agent_span_id
+        tool_event.agent_span_id = agent_span_id
+        events.append(tool_event)
+
+        if thread_id and self.child_loader and self.max_depth > 0:
+            child_events = await self.child_loader(thread_id, self.max_depth - 1)
+            # Re-parent top-level items so event_tree() nests them under
+            # the agent span
+            for evt in child_events:
+                if isinstance(evt, SpanBeginEvent):
+                    if evt.parent_id is None:
+                        evt.parent_id = agent_span_id
+                elif not isinstance(evt, SpanEndEvent):
+                    if evt.span_id is None:
+                        evt.span_id = agent_span_id
+            events.extend(child_events)
+
+        events.append(SpanEndEvent(id=agent_span_id, timestamp=timestamp))
+        return events
+
+    def process_compacted(
+        self, event: CompactedEvent, timestamp: datetime
+    ) -> list[Event]:
+        """Handle a local compaction checkpoint."""
+        compaction = CompactionEvent(
+            source=CODEX_EVENT_SOURCE,
+            tokens_before=self.last_total_tokens,
+            metadata={"trigger": "local", "message": event.message},
+            timestamp=timestamp,
+        )
+        # replacement_history is the exact post-compaction context
+        if event.replacement_history is not None:
+            self.accumulated_messages = history_to_messages(event.replacement_history)
+        elif event.message:
+            self.accumulated_messages = [ChatMessageAssistant(content=event.message)]
+        else:
+            self.accumulated_messages = []
+        self.user_turn_starts = []
+        return [compaction]
+
+    def process_remote_compaction(
+        self, event: ResponseCompaction, timestamp: datetime
+    ) -> list[Event]:
+        """Handle a remote/server-side compaction artifact (encrypted)."""
+        compaction = CompactionEvent(
+            source=CODEX_EVENT_SOURCE,
+            tokens_before=self.last_total_tokens,
+            metadata={"trigger": "remote", "encrypted": True},
+            timestamp=timestamp,
+        )
+        self.accumulated_messages = []
+        self.user_turn_starts = []
+        return [compaction]
+
+    def process_token_count(self, event: TokenCountEvent) -> None:
+        """Attach usage to the most recent ModelEvent."""
+        if not event.info:
+            return
+        total = total_tokens_from_token_info(event.info)
+        if total is not None:
+            self.last_total_tokens = total
+        if self.last_model_event is not None:
+            usage = usage_from_token_info(event.info)
+            if usage is not None and self.last_model_event.output.usage is None:
+                self.last_model_event.output.usage = usage
+
+    def process_rolled_back(
+        self, event: ThreadRolledBackEvent, timestamp: datetime
+    ) -> list[Event]:
+        """Replay an undo: truncate accumulated messages by num_turns user turns.
+
+        Already-emitted events stay in the timeline (they really happened);
+        this only affects what subsequent ModelEvent.input reflects.
+        """
+        num_turns = event.num_turns
+        if num_turns > 0 and self.user_turn_starts:
+            num_turns = min(num_turns, len(self.user_turn_starts))
+            truncate_at = self.user_turn_starts[-num_turns]
+            del self.accumulated_messages[truncate_at:]
+            del self.user_turn_starts[-num_turns:]
+        return [
+            InfoEvent(
+                source=CODEX_EVENT_SOURCE,
+                data={"type": "thread_rolled_back", "num_turns": event.num_turns},
+                timestamp=timestamp,
+            )
+        ]
+
+    async def process_turn_aborted(
+        self, event: TurnAbortedEvent, timestamp: datetime
+    ) -> list[Event]:
+        """Handle an interrupt: flush dangling calls and mark the boundary."""
+        events = await self.flush_pending(
+            error=ToolCallError(
+                type="unknown", message=f"aborted: {event.reason or 'interrupted'}"
+            ),
+            completed=timestamp,
+        )
+        events.append(
+            InfoEvent(
+                source=CODEX_EVENT_SOURCE,
+                data={"type": "turn_aborted", "reason": event.reason},
+                timestamp=timestamp,
+            )
+        )
+        return events
+
+    async def flush_pending(
+        self,
+        error: ToolCallError | None = None,
+        completed: datetime | None = None,
+    ) -> list[Event]:
+        """Emit spans for tool calls that never received an output."""
+        events: list[Event] = []
+        for pending in self.pending_calls.values():
+            events.extend(
+                _tool_span_events(
+                    call_id=pending.call_id,
+                    function=pending.function,
+                    arguments=pending.arguments,
+                    result="",
+                    error=error,
+                    timestamp=pending.timestamp,
+                    completed=completed or pending.timestamp,
+                )
+            )
+        self.pending_calls.clear()
+        return events
+
+
+# ── event constructors ───────────────────────────────────────────────────
+
+
+def _span_begin(
+    span_id: str,
+    name: str,
+    span_type: str,
+    timestamp: datetime,
+    metadata: dict[str, Any] | None = None,
+) -> SpanBeginEvent:
+    from inspect_ai.util._span import current_span_id
+
+    return SpanBeginEvent(
+        id=span_id,
+        name=name,
+        type=span_type,
+        parent_id=current_span_id(),
+        timestamp=timestamp,
+        working_start=0.0,
+        metadata=metadata,
+    )
+
+
+def _to_tool_event(
+    call_id: str,
+    function: str,
+    arguments: dict[str, Any],
+    result: str | list[Content],
+    error: ToolCallError | None,
+    timestamp: datetime,
+    completed: datetime | None,
+) -> ToolEvent:
+    tool_result: ToolResult = result  # type: ignore[assignment]
+    return ToolEvent(
+        id=call_id,
+        type="function",
+        function=function,
+        arguments=arguments,
+        result=tool_result,
+        timestamp=timestamp,
+        completed=completed,
+        error=error,
+        view=tool_view(function, arguments),
+    )
+
+
+def _tool_span_events(
+    call_id: str,
+    function: str,
+    arguments: dict[str, Any],
+    result: str | list[Content],
+    error: ToolCallError | None,
+    timestamp: datetime,
+    completed: datetime | None,
+) -> list[Event]:
+    """Regular tool span: SpanBegin(type='tool') → ToolEvent → SpanEnd."""
+    tool_span_id = f"tool-{call_id}"
+    tool_event = _to_tool_event(
+        call_id=call_id,
+        function=function,
+        arguments=arguments,
+        result=result,
+        error=error,
+        timestamp=timestamp,
+        completed=completed,
+    )
+    tool_event.span_id = tool_span_id
+    return [
+        _span_begin(
+            span_id=tool_span_id,
+            name=function,
+            span_type="tool",
+            timestamp=timestamp,
+        ),
+        tool_event,
+        SpanEndEvent(id=tool_span_id, timestamp=completed or timestamp),
+    ]
+
+
+# ── public entry point ───────────────────────────────────────────────────
+
+
+async def process_rollout_events(
+    events: Sequence[RolloutEvent],
+    max_depth: int = 5,
+    child_loader: ChildThreadLoader | None = None,
+) -> AsyncIterator[Event]:
+    """Convert parsed Codex rollout events to Inspect events.
+
+    Args:
+        events: Rollout events in file order (from ``parse_rollout_events``).
+        max_depth: Maximum depth for loading spawned child threads
+            (0 = no loading).
+        child_loader: Callback for loading a child thread's events by
+            thread id (file-based in inspect_scout).
+
+    Yields:
+        Inspect Event objects (ModelEvent, ToolEvent, SpanBeginEvent,
+        CompactionEvent, InfoEvent, ...).
+    """
+    proc = _RolloutProcessor(max_depth=max_depth, child_loader=child_loader)
+
+    for event in events:
+        timestamp = proc.update_timestamp(event)
+
+        if proc.is_assistant_side(event):
+            proc.buffer_assistant(event, timestamp)
+            continue
+
+        # Boundary item: flush any buffered model response first
+        for evt in proc.flush_model():
+            yield evt
+
+        if isinstance(event, ResponseMessage):
+            proc.process_user_message(event)
+        elif isinstance(event, ResponseFunctionCallOutput):
+            for evt in await proc.process_call_output(
+                event.call_id, event.output, timestamp
+            ):
+                yield evt
+        elif isinstance(event, ResponseCustomToolCallOutput):
+            for evt in await proc.process_call_output(
+                event.call_id, event.output, timestamp
+            ):
+                yield evt
+        elif isinstance(event, TokenCountEvent):
+            proc.process_token_count(event)
+        elif isinstance(event, CompactedEvent):
+            for evt in proc.process_compacted(event, timestamp):
+                yield evt
+        elif isinstance(event, ResponseCompaction):
+            for evt in proc.process_remote_compaction(event, timestamp):
+                yield evt
+        elif isinstance(event, TurnContextEvent):
+            if event.model:
+                proc.current_model = event.model
+        elif isinstance(event, ThreadRolledBackEvent):
+            for evt in proc.process_rolled_back(event, timestamp):
+                yield evt
+        elif isinstance(event, TurnAbortedEvent):
+            for evt in await proc.process_turn_aborted(event, timestamp):
+                yield evt
+        elif isinstance(event, TurnCompleteEvent):
+            if event.error:
+                yield InfoEvent(
+                    source=CODEX_EVENT_SOURCE,
+                    data={"type": "turn_error", "error": event.error},
+                    timestamp=timestamp,
+                )
+        elif isinstance(event, ReviewModeEvent):
+            yield InfoEvent(
+                source=CODEX_EVENT_SOURCE,
+                data={
+                    "type": (
+                        "entered_review_mode" if event.entered else "exited_review_mode"
+                    ),
+                },
+                timestamp=timestamp,
+            )
+        elif isinstance(event, SessionMetaEvent):
+            # Mid-file session_meta lines occur in fork-copied files; the
+            # file's identity is the first meta (handled by the caller).
+            pass
+
+    # Flush any trailing model response and dangling tool calls
+    for evt in proc.flush_model():
+        yield evt
+    for evt in await proc.flush_pending():
+        yield evt

--- a/src/inspect_swe/_codex_cli/_events/rollout.py
+++ b/src/inspect_swe/_codex_cli/_events/rollout.py
@@ -174,6 +174,9 @@ class _RolloutProcessor:
         # Buffered assistant-side items awaiting flush into one ModelEvent
         self.assistant_buffer: list[RolloutEvent] = []
         self.buffer_timestamp: datetime | None = None
+        # Fallback ids issued for id-less web_search_call items (unique
+        # across the whole rollout, not just one flush).
+        self.web_search_count: int = 0
         self.current_model: str | None = None
         self.last_total_tokens: int | None = None
         self.last_timestamp: datetime = _EPOCH
@@ -301,7 +304,11 @@ class _RolloutProcessor:
                 # Hosted tool: no output item, so emit a self-contained span.
                 action = item.action or {}
                 arguments = {k: v for k, v in action.items() if k != "type"}
-                call_id = item.id or f"web_search_{len(web_search_events)}"
+                if item.id:
+                    call_id = item.id
+                else:
+                    call_id = f"web_search_{self.web_search_count}"
+                    self.web_search_count += 1
                 tool_calls.append(
                     ToolCall(
                         id=call_id,

--- a/src/inspect_swe/_codex_cli/_events/rollout.py
+++ b/src/inspect_swe/_codex_cli/_events/rollout.py
@@ -821,13 +821,16 @@ async def process_rollout_events(
                     timestamp=timestamp,
                 )
         elif isinstance(event, ReviewModeEvent):
+            review_data: dict[str, Any] = {
+                "type": (
+                    "entered_review_mode" if event.entered else "exited_review_mode"
+                ),
+            }
+            if event.review:
+                review_data["review"] = event.review
             yield InfoEvent(
                 source=CODEX_EVENT_SOURCE,
-                data={
-                    "type": (
-                        "entered_review_mode" if event.entered else "exited_review_mode"
-                    ),
-                },
+                data=review_data,
                 timestamp=timestamp,
             )
         elif isinstance(event, SessionMetaEvent):

--- a/src/inspect_swe/_codex_cli/_events/rollout.py
+++ b/src/inspect_swe/_codex_cli/_events/rollout.py
@@ -29,6 +29,7 @@ from collections.abc import AsyncIterator, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from logging import getLogger
+from pathlib import PurePosixPath
 from typing import Any, Literal, Protocol
 
 from inspect_ai.event import (
@@ -123,8 +124,21 @@ class _PendingCall:
     spawn_agent_path: str | None = None
 
 
+def _str_arg(arguments: dict[str, Any], key: str) -> str | None:
+    """A truthy tool-call argument as a string, else None."""
+    value = arguments.get(key)
+    return str(value) if value else None
+
+
 def _spawn_result_thread_id(result: str) -> tuple[str | None, str | None]:
-    """Extract (thread_id, nickname) from a spawn_agent tool result."""
+    """Extract (thread_id, nickname) from a spawn_agent tool result.
+
+    V1 results carry ``{"agent_id": <thread uuid>, "nickname": ...}``; V2
+    results carry ``{"task_name": "/root/<name>", "nickname": ...}`` with no
+    thread id at all — the thread id then comes from the ``sub_agent_activity``
+    event instead (the task path is not a rollout thread id, so unlike
+    ``detection.spawn_result`` it is not used as one here).
+    """
     try:
         data = json.loads(result)
     except (json.JSONDecodeError, TypeError):
@@ -132,8 +146,10 @@ def _spawn_result_thread_id(result: str) -> tuple[str | None, str | None]:
     if isinstance(data, dict):
         agent_id = data.get("agent_id")
         nickname = data.get("nickname")
-        if isinstance(agent_id, str) and agent_id:
-            return agent_id, nickname if isinstance(nickname, str) else None
+        return (
+            agent_id if isinstance(agent_id, str) and agent_id else None,
+            nickname if isinstance(nickname, str) and nickname else None,
+        )
     return None, None
 
 
@@ -232,21 +248,18 @@ class _RolloutProcessor:
                         view=tool_view(item.name, arguments),
                     )
                 )
+                is_spawn = item.name == SPAWN_AGENT
                 self.pending_calls[item.call_id] = _PendingCall(
                     call_id=item.call_id,
                     function=item.name,
                     arguments=arguments,
                     timestamp=timestamp,
-                    is_spawn=item.name == SPAWN_AGENT,
+                    is_spawn=is_spawn,
                     spawn_agent_type=(
-                        str(arguments.get("agent_type"))
-                        if item.name == SPAWN_AGENT and arguments.get("agent_type")
-                        else None
+                        _str_arg(arguments, "agent_type") if is_spawn else None
                     ),
                     spawn_task_name=(
-                        str(arguments.get("task_name"))
-                        if item.name == SPAWN_AGENT and arguments.get("task_name")
-                        else None
+                        _str_arg(arguments, "task_name") if is_spawn else None
                     ),
                 )
             elif isinstance(item, ResponseLocalShellCall):
@@ -426,7 +439,10 @@ class _RolloutProcessor:
             )
             return
         pending.spawn_thread_id = event.agent_thread_id
-        pending.spawn_agent_path = event.agent_path
+        # agent_path is optional on the wire; never erase a previously bound
+        # path with a later event that omits it.
+        if event.agent_path:
+            pending.spawn_agent_path = event.agent_path
 
     async def _spawn_agent_span_events(
         self,
@@ -440,13 +456,31 @@ class _RolloutProcessor:
         result_text = result if isinstance(result, str) else ""
         result_thread_id, nickname = _spawn_result_thread_id(result_text)
         thread_id = pending.spawn_thread_id or result_thread_id
+        path_name = (
+            PurePosixPath(pending.spawn_agent_path).name
+            if pending.spawn_agent_path
+            else None
+        )
         agent_name = (
             nickname
             or pending.spawn_task_name
             or pending.spawn_agent_type
-            or (pending.spawn_agent_path or "").rsplit("/", maxsplit=1)[-1]
+            or path_name
             or "agent"
         )
+
+        # Same shape as the live bridge (consumer.py): keys present only when
+        # known, so consumers need not distinguish absent from None.
+        metadata = {
+            key: value
+            for key, value in {
+                "agent_type": pending.spawn_agent_type,
+                "task_name": pending.spawn_task_name,
+                "thread_id": thread_id,
+                "agent_path": pending.spawn_agent_path,
+            }.items()
+            if value is not None
+        }
 
         events: list[Event] = [
             _span_begin(
@@ -454,12 +488,7 @@ class _RolloutProcessor:
                 name=agent_name,
                 span_type="agent",
                 timestamp=pending.timestamp,
-                metadata={
-                    "agent_type": pending.spawn_agent_type,
-                    "task_name": pending.spawn_task_name,
-                    "thread_id": thread_id,
-                    "agent_path": pending.spawn_agent_path,
-                },
+                metadata=metadata or None,
             )
         ]
 
@@ -584,20 +613,35 @@ class _RolloutProcessor:
         error: ToolCallError | None = None,
         completed: datetime | None = None,
     ) -> list[Event]:
-        """Emit spans for tool calls that never received an output."""
+        """Emit spans for tool calls that never received an output.
+
+        Dangling spawn_agent calls (aborted turn, truncated file) still get
+        their agent span — the child thread id may already be bound from a
+        ``sub_agent_activity`` event, so its events remain reachable.
+        """
         events: list[Event] = []
         for pending in self.pending_calls.values():
-            events.extend(
-                _tool_span_events(
-                    call_id=pending.call_id,
-                    function=pending.function,
-                    arguments=pending.arguments,
-                    result="",
-                    error=error,
-                    timestamp=pending.timestamp,
-                    completed=completed or pending.timestamp,
+            if pending.is_spawn:
+                events.extend(
+                    await self._spawn_agent_span_events(
+                        pending,
+                        result="",
+                        error=error,
+                        timestamp=completed or pending.timestamp,
+                    )
                 )
-            )
+            else:
+                events.extend(
+                    _tool_span_events(
+                        call_id=pending.call_id,
+                        function=pending.function,
+                        arguments=pending.arguments,
+                        result="",
+                        error=error,
+                        timestamp=pending.timestamp,
+                        completed=completed or pending.timestamp,
+                    )
+                )
         self.pending_calls.clear()
         return events
 

--- a/src/inspect_swe/_codex_cli/_events/rollout.py
+++ b/src/inspect_swe/_codex_cli/_events/rollout.py
@@ -17,7 +17,9 @@ parsed rollout lines in file order, reconstructing what the model saw
 - ``thread_rolled_back`` (undo) truncates accumulated messages so subsequent
   ``ModelEvent.input`` reflects what the model actually saw; already-emitted
   events stay in the timeline with an InfoEvent marking the boundary
-- ``token_count`` events attach usage to the most recent ModelEvent
+- ``token_count`` events supply each ModelEvent's usage; the usage is looked
+  ahead at flush time so events are complete when yielded (consumers may
+  serialize them as they stream)
 
 Unlike Claude Code there is no uuid/parentUuid tree (rollouts are
 append-ordered) and no shared-id consolidation (one model response is a run
@@ -41,7 +43,7 @@ from inspect_ai.event import (
     SpanEndEvent,
     ToolEvent,
 )
-from inspect_ai.model import Content, ContentText, ModelOutput
+from inspect_ai.model import Content, ContentText, ModelOutput, ModelUsage
 from inspect_ai.model._chat_message import (
     ChatMessage,
     ChatMessageAssistant,
@@ -172,7 +174,6 @@ class _RolloutProcessor:
         # Buffered assistant-side items awaiting flush into one ModelEvent
         self.assistant_buffer: list[RolloutEvent] = []
         self.buffer_timestamp: datetime | None = None
-        self.last_model_event: ModelEvent | None = None
         self.current_model: str | None = None
         self.last_total_tokens: int | None = None
         self.last_timestamp: datetime = _EPOCH
@@ -208,8 +209,11 @@ class _RolloutProcessor:
             self.buffer_timestamp = timestamp
         self.assistant_buffer.append(event)
 
-    def flush_model(self) -> list[Event]:
+    def flush_model(self, usage: ModelUsage | None = None) -> list[Event]:
         """Convert buffered assistant-side items into a ModelEvent.
+
+        ``usage`` comes from the caller's lookahead to the response's
+        ``token_count`` event, so the ModelEvent is complete when yielded.
 
         Also emits self-contained spans for hosted ``web_search_call`` items
         (which have no separate output item) and registers pending tool
@@ -345,6 +349,7 @@ class _RolloutProcessor:
             config=GenerateConfig(),
             output=ModelOutput(
                 model=model,
+                usage=usage,
                 choices=[
                     ChatCompletionChoice(
                         message=output_message, stop_reason=stop_reason
@@ -354,7 +359,6 @@ class _RolloutProcessor:
             timestamp=timestamp,
         )
         self.accumulated_messages.append(output_message)
-        self.last_model_event = model_event
 
         return [model_event, *web_search_events]
 
@@ -556,16 +560,13 @@ class _RolloutProcessor:
         return [compaction]
 
     def process_token_count(self, event: TokenCountEvent) -> None:
-        """Attach usage to the most recent ModelEvent."""
+        """Track the cumulative total (per-response usage is attached by the
+        flush-time lookahead in ``process_rollout_events``)."""
         if not event.info:
             return
         total = total_tokens_from_token_info(event.info)
         if total is not None:
             self.last_total_tokens = total
-        if self.last_model_event is not None:
-            usage = usage_from_token_info(event.info)
-            if usage is not None and self.last_model_event.output.usage is None:
-                self.last_model_event.output.usage = usage
 
     def process_rolled_back(
         self, event: ThreadRolledBackEvent, timestamp: datetime
@@ -748,16 +749,30 @@ async def process_rollout_events(
     """
     proc = _RolloutProcessor(max_depth=max_depth, child_loader=child_loader)
 
-    for event in events:
+    def lookahead_usage(start: int) -> ModelUsage | None:
+        """Usage for the response being flushed: the first usage-bearing
+        token_count at/after ``start``, before the next model response."""
+        for ahead in events[start:]:
+            if proc.is_assistant_side(ahead):
+                return None
+            if isinstance(ahead, TokenCountEvent) and ahead.info:
+                usage = usage_from_token_info(ahead.info)
+                if usage is not None:
+                    return usage
+        return None
+
+    for index, event in enumerate(events):
         timestamp = proc.update_timestamp(event)
 
         if proc.is_assistant_side(event):
             proc.buffer_assistant(event, timestamp)
             continue
 
-        # Boundary item: flush any buffered model response first
-        for evt in proc.flush_model():
-            yield evt
+        # Boundary item: flush any buffered model response first (with its
+        # usage looked ahead, so the ModelEvent is complete when yielded)
+        if proc.assistant_buffer:
+            for evt in proc.flush_model(usage=lookahead_usage(index)):
+                yield evt
 
         if isinstance(event, ResponseMessage):
             proc.process_user_message(event)

--- a/src/inspect_swe/_codex_cli/_events/rollout_extraction.py
+++ b/src/inspect_swe/_codex_cli/_events/rollout_extraction.py
@@ -176,18 +176,26 @@ def output_to_result(
     exit_code is only known for the legacy form.
     """
     if isinstance(output, str):
-        # Legacy form: JSON-encoded object with output + metadata
+        # Legacy form: JSON-encoded object with output + metadata. Require the
+        # exact legacy shape (string output, no extra keys) — a genuine tool
+        # output can itself be JSON text (e.g. `cat config.json`) and must
+        # pass through verbatim rather than being unwrapped.
         if output.startswith("{"):
             try:
                 parsed = json.loads(output)
             except json.JSONDecodeError:
                 parsed = None
-            if isinstance(parsed, dict) and "output" in parsed:
+            if (
+                isinstance(parsed, dict)
+                and isinstance(parsed.get("output"), str)
+                and set(parsed.keys()) <= {"output", "metadata"}
+                and isinstance(parsed.get("metadata"), (dict, type(None)))
+            ):
                 metadata = parsed.get("metadata")
                 exit_code = (
                     metadata.get("exit_code") if isinstance(metadata, dict) else None
                 )
-                return str(parsed["output"]), (
+                return parsed["output"], (
                     exit_code if isinstance(exit_code, int) else None
                 )
         return output, None

--- a/src/inspect_swe/_codex_cli/_events/rollout_extraction.py
+++ b/src/inspect_swe/_codex_cli/_events/rollout_extraction.py
@@ -5,7 +5,6 @@ from datetime import datetime, timezone
 from logging import getLogger
 from typing import Any
 
-from inspect_ai.event import Event, ModelEvent
 from inspect_ai.model import (
     Content,
     ContentImage,
@@ -20,6 +19,9 @@ from inspect_ai.model._chat_message import (
 )
 from inspect_ai.model._model_output import ModelUsage
 
+# Re-exported here because scout's codex importer sums tokens alongside the
+# other rollout extraction helpers (single implementation in _util.events).
+from ..._util.events import sum_scout_tokens as sum_scout_tokens
 from .rollout_models import ResponseReasoning
 
 logger = getLogger(__name__)
@@ -271,16 +273,6 @@ def total_tokens_from_token_info(info: dict[str, Any]) -> int | None:
         if isinstance(value, int):
             return value
     return None
-
-
-def sum_scout_tokens(events: list[Event]) -> int:
-    """Sum total tokens across all ModelEvents (including nested agents)."""
-    total = 0
-    for event in events:
-        if isinstance(event, ModelEvent):
-            if event.output and event.output.usage:
-                total += event.output.usage.total_tokens
-    return total
 
 
 # ── replacement history conversion ───────────────────────────────────────

--- a/src/inspect_swe/_codex_cli/_events/rollout_extraction.py
+++ b/src/inspect_swe/_codex_cli/_events/rollout_extraction.py
@@ -49,6 +49,7 @@ _CONTEXT_OPEN_TAGS = (
     "<apps_instructions>",
     "<skills_instructions>",
     "<plugins_instructions>",
+    "<recommended_plugins>",
     "<tools>",
     "<collaboration_mode>",
     "<multi_agent_mode>",
@@ -57,6 +58,8 @@ _CONTEXT_OPEN_TAGS = (
     "<context_window_guidance>",
     "<turn_context>",
 )
+
+_CONTEXT_TEXT_PREFIXES = ("# AGENTS.md instructions",)
 
 # Genuine user text bundled with context blocks is prefixed with this marker.
 USER_MESSAGE_BEGIN = "## My request for Codex:"
@@ -71,7 +74,7 @@ def is_context_message(text: str) -> bool:
     stripped = text.lstrip()
     if USER_MESSAGE_BEGIN in text:
         return False
-    return stripped.startswith(_CONTEXT_OPEN_TAGS)
+    return stripped.startswith((*_CONTEXT_OPEN_TAGS, *_CONTEXT_TEXT_PREFIXES))
 
 
 # ── content conversion ───────────────────────────────────────────────────

--- a/src/inspect_swe/_codex_cli/_events/rollout_extraction.py
+++ b/src/inspect_swe/_codex_cli/_events/rollout_extraction.py
@@ -1,0 +1,297 @@
+"""Content/usage extraction helpers for Codex rollout conversion."""
+
+import json
+from datetime import datetime, timezone
+from logging import getLogger
+from typing import Any
+
+from inspect_ai.event import Event, ModelEvent
+from inspect_ai.model import (
+    Content,
+    ContentImage,
+    ContentReasoning,
+    ContentText,
+)
+from inspect_ai.model._chat_message import (
+    ChatMessage,
+    ChatMessageAssistant,
+    ChatMessageSystem,
+    ChatMessageUser,
+)
+from inspect_ai.model._model_output import ModelUsage
+
+from .rollout_models import ResponseReasoning
+
+logger = getLogger(__name__)
+
+
+def parse_timestamp(timestamp_str: str | None) -> datetime | None:
+    """Parse an RFC3339 timestamp string to a timezone-aware datetime."""
+    if not timestamp_str:
+        return None
+    try:
+        parsed = datetime.fromisoformat(timestamp_str.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed
+    except (ValueError, AttributeError):
+        return None
+
+
+# ── pseudo-user message classification ───────────────────────────────────
+
+# Special context blocks codex injects as role="user" response items. See
+# the *_OPEN_TAG constants in codex-rs/protocol/src/protocol.rs.
+_CONTEXT_OPEN_TAGS = (
+    "<user_instructions>",
+    "<environment_context>",
+    "<environments_instructions>",
+    "<apps_instructions>",
+    "<skills_instructions>",
+    "<plugins_instructions>",
+    "<tools>",
+    "<collaboration_mode>",
+    "<multi_agent_mode>",
+    "<realtime_conversation>",
+    "<context_window>",
+    "<context_window_guidance>",
+    "<turn_context>",
+)
+
+# Genuine user text bundled with context blocks is prefixed with this marker.
+USER_MESSAGE_BEGIN = "## My request for Codex:"
+
+
+def is_context_message(text: str) -> bool:
+    """Whether a role=user message is an injected context block, not user speech.
+
+    Messages that contain the ``USER_MESSAGE_BEGIN`` marker carry genuine
+    user text after the context prefix, so they are user speech.
+    """
+    stripped = text.lstrip()
+    if USER_MESSAGE_BEGIN in text:
+        return False
+    return stripped.startswith(_CONTEXT_OPEN_TAGS)
+
+
+# ── content conversion ───────────────────────────────────────────────────
+
+
+def content_items_to_content(
+    content: list[dict[str, Any]] | str,
+) -> str | list[Content]:
+    """Convert Responses-API content items to inspect content.
+
+    Text-only content collapses to a plain string (matching the Claude Code
+    converter's behaviour); images preserve interleaving in a content list.
+    """
+    if isinstance(content, str):
+        return content
+
+    blocks: list[Content] = []
+    has_image = False
+    for item in content:
+        item_type = item.get("type")
+        if item_type in ("input_text", "output_text"):
+            text = item.get("text")
+            if isinstance(text, str) and text:
+                blocks.append(ContentText(text=text))
+        elif item_type == "input_image":
+            image_url = item.get("image_url")
+            if isinstance(image_url, str) and image_url:
+                blocks.append(ContentImage(image=image_url))
+                has_image = True
+            else:
+                logger.warning("Skipping input_image with no image_url")
+        # input_audio and unknown item types are dropped
+
+    if not has_image:
+        return "\n".join(
+            block.text for block in blocks if isinstance(block, ContentText)
+        )
+    return blocks
+
+
+def reasoning_to_content(item: ResponseReasoning) -> ContentReasoning | None:
+    """Convert a reasoning item to ContentReasoning.
+
+    Plaintext reasoning (``content``) is rare; usually only summaries plus an
+    opaque ``encrypted_content`` are available, in which case the summary text
+    is used and the block is marked redacted (the raw chain-of-thought is not
+    recoverable). The encrypted payload itself is not preserved.
+    """
+    summary_text = "\n\n".join(
+        text
+        for block in item.summary
+        if isinstance(text := block.get("text"), str) and text
+    )
+    plaintext = ""
+    if item.content:
+        plaintext = "\n\n".join(
+            text
+            for block in item.content
+            if block.get("type") in ("reasoning_text", "text")
+            and isinstance(text := block.get("text"), str)
+            and text
+        )
+
+    if plaintext:
+        return ContentReasoning(
+            reasoning=plaintext, summary=summary_text or None, redacted=False
+        )
+    elif summary_text:
+        return ContentReasoning(
+            reasoning=summary_text,
+            summary=summary_text,
+            redacted=item.encrypted_content is not None,
+        )
+    elif item.encrypted_content is not None:
+        return ContentReasoning(reasoning="", redacted=True)
+    else:
+        return None
+
+
+# ── tool output conversion ───────────────────────────────────────────────
+
+
+def output_to_result(
+    output: Any,
+) -> tuple[str | list[Content], int | None]:
+    """Convert a function_call_output payload to a tool result.
+
+    Handles the three wire forms: plain string, array of content items, and
+    the legacy JSON-encoded ``{"output": ..., "metadata": {"exit_code": ...}}``
+    string written by old codex versions. Returns (result, exit_code) where
+    exit_code is only known for the legacy form.
+    """
+    if isinstance(output, str):
+        # Legacy form: JSON-encoded object with output + metadata
+        if output.startswith("{"):
+            try:
+                parsed = json.loads(output)
+            except json.JSONDecodeError:
+                parsed = None
+            if isinstance(parsed, dict) and "output" in parsed:
+                metadata = parsed.get("metadata")
+                exit_code = (
+                    metadata.get("exit_code") if isinstance(metadata, dict) else None
+                )
+                return str(parsed["output"]), (
+                    exit_code if isinstance(exit_code, int) else None
+                )
+        return output, None
+    elif isinstance(output, list):
+        return content_items_to_content(output), None
+    elif isinstance(output, dict):
+        # FunctionCallOutputBody-style {"content": ...} wrapper
+        content = output.get("content")
+        if isinstance(content, (str, list)):
+            return output_to_result(content)
+        return json.dumps(output), None
+    elif output is None:
+        return "", None
+    else:
+        return str(output), None
+
+
+def parse_arguments(arguments: str) -> dict[str, Any]:
+    """Parse a function_call arguments JSON string, tolerating bad JSON."""
+    if not arguments:
+        return {}
+    try:
+        parsed = json.loads(arguments)
+    except json.JSONDecodeError:
+        return {"arguments": arguments}
+    if isinstance(parsed, dict):
+        return parsed
+    return {"arguments": parsed}
+
+
+# ── usage ────────────────────────────────────────────────────────────────
+
+
+def usage_from_token_info(info: dict[str, Any]) -> ModelUsage | None:
+    """Build ModelUsage from a token_count event's last_token_usage.
+
+    Codex reports input_tokens inclusive of cached tokens (Responses API
+    semantics); inspect's ModelUsage.input_tokens excludes them.
+    """
+    last = info.get("last_token_usage")
+    if not isinstance(last, dict):
+        return None
+
+    def _tokens(key: str) -> int:
+        value = last.get(key)
+        return value if isinstance(value, int) else 0
+
+    input_tokens = _tokens("input_tokens")
+    cached = _tokens("cached_input_tokens")
+    cache_write = _tokens("cache_write_input_tokens")
+    output_tokens = _tokens("output_tokens")
+    reasoning = _tokens("reasoning_output_tokens")
+    total = _tokens("total_tokens") or (input_tokens + output_tokens)
+
+    if total == 0 and input_tokens == 0 and output_tokens == 0:
+        return None
+
+    return ModelUsage(
+        input_tokens=max(0, input_tokens - cached),
+        output_tokens=output_tokens,
+        total_tokens=total,
+        input_tokens_cache_read=cached if cached else None,
+        input_tokens_cache_write=cache_write if cache_write else None,
+        reasoning_tokens=reasoning if reasoning else None,
+    )
+
+
+def total_tokens_from_token_info(info: dict[str, Any]) -> int | None:
+    """The cumulative total token count from a token_count event."""
+    total = info.get("total_token_usage")
+    if isinstance(total, dict):
+        value = total.get("total_tokens")
+        if isinstance(value, int):
+            return value
+    return None
+
+
+def sum_scout_tokens(events: list[Event]) -> int:
+    """Sum total tokens across all ModelEvents (including nested agents)."""
+    total = 0
+    for event in events:
+        if isinstance(event, ModelEvent):
+            if event.output and event.output.usage:
+                total += event.output.usage.total_tokens
+    return total
+
+
+# ── replacement history conversion ───────────────────────────────────────
+
+
+def history_to_messages(items: list[dict[str, Any]]) -> list[ChatMessage]:
+    """Convert a compacted item's replacement_history to chat messages.
+
+    Only message items are converted (function calls etc. may appear in
+    replacement history but have no natural chat-message form without their
+    outputs).
+    """
+    messages: list[ChatMessage] = []
+    for item in items:
+        if not isinstance(item, dict) or item.get("type") != "message":
+            continue
+        role = item.get("role")
+        raw_content = item.get("content")
+        content: list[dict[str, Any]] | str
+        if isinstance(raw_content, (list, str)):
+            content = raw_content
+        else:
+            continue
+        converted = content_items_to_content(content)
+        if not converted:
+            continue
+        if role == "assistant":
+            messages.append(ChatMessageAssistant(content=converted))
+        elif role == "developer" or role == "system":
+            messages.append(ChatMessageSystem(content=converted))
+        else:
+            messages.append(ChatMessageUser(content=converted))
+    return messages

--- a/src/inspect_swe/_codex_cli/_events/rollout_extraction.py
+++ b/src/inspect_swe/_codex_cli/_events/rollout_extraction.py
@@ -59,7 +59,13 @@ _CONTEXT_OPEN_TAGS = (
     "<turn_context>",
 )
 
-_CONTEXT_TEXT_PREFIXES = ("# AGENTS.md instructions",)
+# Injected AGENTS.md blocks are bare markdown: a "# AGENTS.md instructions"
+# heading followed by the file contents wrapped in <INSTRUCTIONS> markers.
+# Codex's own classifiers (codex-rs/memories/write/src/phase1.rs) require both
+# the heading and the closing marker, so we do too — a genuine user message
+# could plausibly start with the heading alone.
+_AGENTS_MD_PREFIX = "# AGENTS.md instructions"
+_AGENTS_MD_CLOSE = "</INSTRUCTIONS>"
 
 # Genuine user text bundled with context blocks is prefixed with this marker.
 USER_MESSAGE_BEGIN = "## My request for Codex:"
@@ -71,10 +77,12 @@ def is_context_message(text: str) -> bool:
     Messages that contain the ``USER_MESSAGE_BEGIN`` marker carry genuine
     user text after the context prefix, so they are user speech.
     """
-    stripped = text.lstrip()
     if USER_MESSAGE_BEGIN in text:
         return False
-    return stripped.startswith((*_CONTEXT_OPEN_TAGS, *_CONTEXT_TEXT_PREFIXES))
+    stripped = text.lstrip()
+    if stripped.startswith(_CONTEXT_OPEN_TAGS):
+        return True
+    return stripped.startswith(_AGENTS_MD_PREFIX) and _AGENTS_MD_CLOSE in stripped
 
 
 # ── content conversion ───────────────────────────────────────────────────

--- a/src/inspect_swe/_codex_cli/_events/rollout_models.py
+++ b/src/inspect_swe/_codex_cli/_events/rollout_models.py
@@ -73,7 +73,6 @@ class SessionMetaEvent(RolloutEvent):
     # "cli" | "vscode" | "exec" | "mcp" | {"custom": ...} | {"subagent": ...} | ...
     source: str | dict[str, Any] | None = None
     agent_nickname: str | None = None
-    agent_path: str | None = None
     agent_role: str | None = None
     model_provider: str | None = None
     # Modern field is base_instructions ({"text": ...}); very old files used

--- a/src/inspect_swe/_codex_cli/_events/rollout_models.py
+++ b/src/inspect_swe/_codex_cli/_events/rollout_models.py
@@ -73,6 +73,7 @@ class SessionMetaEvent(RolloutEvent):
     # "cli" | "vscode" | "exec" | "mcp" | {"custom": ...} | {"subagent": ...} | ...
     source: str | dict[str, Any] | None = None
     agent_nickname: str | None = None
+    agent_path: str | None = None
     agent_role: str | None = None
     model_provider: str | None = None
     # Modern field is base_instructions ({"text": ...}); very old files used
@@ -263,6 +264,15 @@ class ThreadRolledBackEvent(RolloutEvent):
     num_turns: int = 0
 
 
+class SubAgentActivityEvent(RolloutEvent):
+    """A sub-agent lifecycle event linking a spawn call to its child thread."""
+
+    event_id: str
+    agent_thread_id: str
+    agent_path: str | None = None
+    kind: str | None = None
+
+
 class ReviewModeEvent(RolloutEvent):
     """An ``entered_review_mode`` / ``exited_review_mode`` event."""
 
@@ -291,6 +301,7 @@ _EVENT_MSG_TYPES: dict[str, type[RolloutEvent]] = {
     "turn_aborted": TurnAbortedEvent,
     "turn_complete": TurnCompleteEvent,
     "thread_rolled_back": ThreadRolledBackEvent,
+    "sub_agent_activity": SubAgentActivityEvent,
 }
 
 

--- a/src/inspect_swe/_codex_cli/_events/rollout_models.py
+++ b/src/inspect_swe/_codex_cli/_events/rollout_models.py
@@ -265,12 +265,17 @@ class ThreadRolledBackEvent(RolloutEvent):
 
 
 class SubAgentActivityEvent(RolloutEvent):
-    """A sub-agent lifecycle event linking a spawn call to its child thread."""
+    """A sub-agent lifecycle event linking a spawn call to its child thread.
+
+    The wire payload also carries ``kind`` ("started" | "interacted" |
+    "interrupted"); it is not declared because nothing consumes it — only
+    "started" events reuse the spawn call's id, which is what the
+    ``event_id`` correlation relies on.
+    """
 
     event_id: str
     agent_thread_id: str
     agent_path: str | None = None
-    kind: str | None = None
 
 
 class ReviewModeEvent(RolloutEvent):

--- a/src/inspect_swe/_codex_cli/_events/rollout_models.py
+++ b/src/inspect_swe/_codex_cli/_events/rollout_models.py
@@ -1,0 +1,367 @@
+"""Pydantic models for the Codex CLI rollout JSONL format.
+
+Codex persists each thread as a rollout file
+(``$CODEX_HOME/sessions/YYYY/MM/DD/rollout-<ts>-<thread-id>.jsonl``) where
+every line is an envelope ``{"timestamp", "type", "payload"}`` (plus an
+optional ``ordinal`` for paginated threads). The ``type``/``payload`` pair is
+an adjacently-tagged ``RolloutItem``; ``response_item`` and ``event_msg``
+payloads are further discriminated on ``payload["type"]``.
+
+The rollout format is a moving target (there is no format-version field), so
+parsing is deliberately lenient: models use ``extra="ignore"``, unknown item
+and event types are silently dropped, and validation failures skip the line
+with a warning. Ground truth: ``codex-rs/protocol/src/protocol.rs`` and
+``codex-rs/protocol/src/models.rs`` in openai/codex.
+"""
+
+from logging import getLogger
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+logger = getLogger(__name__)
+
+
+class RolloutEvent(BaseModel):
+    """Base class for parsed rollout lines.
+
+    ``timestamp`` is taken from the line envelope (RFC3339 string).
+    """
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    timestamp: str | None = None
+
+
+# ── session_meta ─────────────────────────────────────────────────────────
+
+
+class GitInfo(BaseModel):
+    """Git metadata collected at session start."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    commit_hash: str | None = None
+    branch: str | None = None
+    repository_url: str | None = None
+
+
+class HistoryBase(BaseModel):
+    """Exclusive prefix of another rollout inherited by reference."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    thread_id: str
+    end_ordinal_exclusive: int
+    end_byte_offset: int | None = None
+
+
+class SessionMetaEvent(RolloutEvent):
+    """The ``session_meta`` line (first line of every rollout file).
+
+    Fork-copied files may contain a second ``session_meta`` mid-file (the
+    source thread's); readers treat the first as the file's identity.
+    """
+
+    id: str | None = None
+    session_id: str | None = None
+    forked_from_id: str | None = None
+    parent_thread_id: str | None = None
+    cwd: str | None = None
+    originator: str | None = None
+    cli_version: str | None = None
+    # "cli" | "vscode" | "exec" | "mcp" | {"custom": ...} | {"subagent": ...} | ...
+    source: str | dict[str, Any] | None = None
+    agent_nickname: str | None = None
+    agent_role: str | None = None
+    model_provider: str | None = None
+    # Modern field is base_instructions ({"text": ...}); very old files used
+    # a plain-string instructions field.
+    base_instructions: dict[str, Any] | None = None
+    instructions: str | None = None
+    history_mode: str = "legacy"
+    history_base: HistoryBase | None = None
+    git: GitInfo | None = None
+
+    @model_validator(mode="after")
+    def _backfill_ids(self) -> "SessionMetaEvent":
+        # Older files have only id; newer files carry both id and session_id.
+        if self.id is None:
+            self.id = self.session_id
+        if self.session_id is None:
+            self.session_id = self.id
+        return self
+
+    @property
+    def thread_id(self) -> str | None:
+        """The thread id (rollout identity)."""
+        return self.id
+
+    def subagent_source(self) -> str | dict[str, Any] | None:
+        """The subagent classification, if this is a subagent thread.
+
+        Returns e.g. ``"review"``, ``"compact"`` or ``{"thread_spawn": {...}}``.
+        """
+        if isinstance(self.source, dict):
+            subagent = self.source.get("subagent")
+            if isinstance(subagent, (str, dict)):
+                return subagent
+        return None
+
+
+# ── response_item variants ───────────────────────────────────────────────
+
+
+class ResponseMessage(RolloutEvent):
+    """A ``message`` response item (user / assistant / developer)."""
+
+    id: str | None = None
+    role: str = "user"
+    content: list[dict[str, Any]] | str = Field(default_factory=list)
+    phase: str | None = None  # assistant only: "commentary" | "final_answer"
+
+
+class ResponseReasoning(RolloutEvent):
+    """A ``reasoning`` response item.
+
+    ``summary`` holds readable summaries; ``content`` holds plaintext
+    reasoning (rare — only some providers); ``encrypted_content`` is opaque.
+    """
+
+    id: str | None = None
+    summary: list[dict[str, Any]] = Field(default_factory=list)
+    content: list[dict[str, Any]] | None = None
+    encrypted_content: str | None = None
+
+
+class ResponseFunctionCall(RolloutEvent):
+    """A ``function_call`` response item (shell, update_plan, MCP, ...)."""
+
+    id: str | None = None
+    name: str = ""
+    namespace: str | None = None
+    arguments: str = ""  # JSON-encoded string
+    call_id: str = ""
+
+
+class ResponseFunctionCallOutput(RolloutEvent):
+    """A ``function_call_output`` response item.
+
+    ``output`` is polymorphic on the wire: a plain string, an array of
+    content items, or (in very old files) a JSON-encoded string of
+    ``{"output": ..., "metadata": {"exit_code": ...}}``.
+    """
+
+    id: str | None = None
+    call_id: str = ""
+    output: Any = None
+
+
+class ResponseLocalShellCall(RolloutEvent):
+    """A ``local_shell_call`` item (models with the hosted local-shell tool)."""
+
+    id: str | None = None
+    call_id: str | None = None
+    status: str | None = None
+    action: dict[str, Any] = Field(default_factory=dict)
+
+
+class ResponseCustomToolCall(RolloutEvent):
+    """A ``custom_tool_call`` item (freeform tools, e.g. apply_patch)."""
+
+    id: str | None = None
+    call_id: str = ""
+    name: str = ""
+    input: str = ""
+
+
+class ResponseCustomToolCallOutput(RolloutEvent):
+    """A ``custom_tool_call_output`` item."""
+
+    id: str | None = None
+    call_id: str = ""
+    name: str | None = None
+    output: Any = None
+
+
+class ResponseWebSearchCall(RolloutEvent):
+    """A ``web_search_call`` hosted-tool item (no separate output item)."""
+
+    id: str | None = None
+    status: str | None = None
+    action: dict[str, Any] | None = None
+
+
+class ResponseCompaction(RolloutEvent):
+    """A remote/server-side compaction artifact.
+
+    Covers ``compaction`` (alias ``compaction_summary``) and
+    ``context_compaction`` items — both carry only encrypted content.
+    """
+
+    id: str | None = None
+    encrypted_content: str | None = None
+
+
+# ── other rollout item variants ──────────────────────────────────────────
+
+
+class CompactedEvent(RolloutEvent):
+    """A ``compacted`` item (local compaction checkpoint).
+
+    ``message`` is the plaintext summary; ``replacement_history`` is the
+    complete post-compaction in-context history (raw response items).
+    """
+
+    message: str = ""
+    replacement_history: list[dict[str, Any]] | None = None
+
+
+class TurnContextEvent(RolloutEvent):
+    """A ``turn_context`` item — the model/cwd/policies in effect for a turn."""
+
+    turn_id: str | None = None
+    cwd: str | None = None
+    approval_policy: str | dict[str, Any] | None = None
+    sandbox_policy: str | dict[str, Any] | None = None
+    model: str | None = None
+    effort: str | None = None
+
+
+# ── persisted event_msg variants we consume ──────────────────────────────
+
+
+class TokenCountEvent(RolloutEvent):
+    """A ``token_count`` event — cumulative and last-turn usage."""
+
+    info: dict[str, Any] | None = None
+    rate_limits: dict[str, Any] | None = None
+
+
+class TurnAbortedEvent(RolloutEvent):
+    """A ``turn_aborted`` event (interrupt, replacement, budget, ...)."""
+
+    turn_id: str | None = None
+    reason: str | None = None
+
+
+class TurnCompleteEvent(RolloutEvent):
+    """A ``turn_complete`` event — carries terminal turn errors."""
+
+    turn_id: str | None = None
+    last_agent_message: str | None = None
+    error: str | dict[str, Any] | None = None
+
+
+class ThreadRolledBackEvent(RolloutEvent):
+    """A ``thread_rolled_back`` event — the user undid ``num_turns`` turns.
+
+    Rollout files are append-only, so rolled-back lines remain in the file
+    before this marker.
+    """
+
+    num_turns: int = 0
+
+
+class ReviewModeEvent(RolloutEvent):
+    """An ``entered_review_mode`` / ``exited_review_mode`` event."""
+
+    entered: bool = True
+    review: dict[str, Any] | None = None
+
+
+# ── parsing ──────────────────────────────────────────────────────────────
+
+_RESPONSE_ITEM_TYPES: dict[str, type[RolloutEvent]] = {
+    "message": ResponseMessage,
+    "reasoning": ResponseReasoning,
+    "function_call": ResponseFunctionCall,
+    "function_call_output": ResponseFunctionCallOutput,
+    "local_shell_call": ResponseLocalShellCall,
+    "custom_tool_call": ResponseCustomToolCall,
+    "custom_tool_call_output": ResponseCustomToolCallOutput,
+    "web_search_call": ResponseWebSearchCall,
+    "compaction": ResponseCompaction,
+    "compaction_summary": ResponseCompaction,
+    "context_compaction": ResponseCompaction,
+}
+
+_EVENT_MSG_TYPES: dict[str, type[RolloutEvent]] = {
+    "token_count": TokenCountEvent,
+    "turn_aborted": TurnAbortedEvent,
+    "turn_complete": TurnCompleteEvent,
+    "thread_rolled_back": ThreadRolledBackEvent,
+}
+
+
+def parse_rollout_event(raw: dict[str, Any]) -> RolloutEvent | None:
+    """Parse a single raw rollout line into a typed model.
+
+    Returns None for unknown/unpersisted item types (deliberate — the format
+    adds new types over time) and for lines that fail validation.
+    """
+    payload = raw.get("payload")
+    if not isinstance(payload, dict):
+        return None
+    line_type = raw.get("type")
+
+    model_cls: type[RolloutEvent] | None = None
+    if line_type == "session_meta":
+        model_cls = SessionMetaEvent
+    elif line_type == "response_item":
+        payload_type = payload.get("type")
+        if isinstance(payload_type, str):
+            model_cls = _RESPONSE_ITEM_TYPES.get(payload_type)
+    elif line_type == "compacted":
+        model_cls = CompactedEvent
+    elif line_type == "turn_context":
+        model_cls = TurnContextEvent
+    elif line_type == "event_msg":
+        payload_type = payload.get("type")
+        if payload_type == "entered_review_mode":
+            return ReviewModeEvent(
+                entered=True,
+                review=payload if payload else None,
+                timestamp=_envelope_timestamp(raw),
+            )
+        elif payload_type == "exited_review_mode":
+            return ReviewModeEvent(
+                entered=False,
+                review=payload if payload else None,
+                timestamp=_envelope_timestamp(raw),
+            )
+        elif isinstance(payload_type, str):
+            model_cls = _EVENT_MSG_TYPES.get(payload_type)
+
+    if model_cls is None:
+        return None
+
+    try:
+        event = model_cls.model_validate(payload)
+    except ValidationError as ex:
+        logger.warning(f"Failed to parse rollout {line_type} payload: {ex}")
+        return None
+
+    # Envelope timestamp wins when present (session_meta payloads carry their
+    # own timestamp field which serves as a fallback).
+    envelope_ts = _envelope_timestamp(raw)
+    if envelope_ts is not None:
+        event.timestamp = envelope_ts
+    elif event.timestamp is None and isinstance(payload.get("timestamp"), str):
+        event.timestamp = payload["timestamp"]
+    return event
+
+
+def _envelope_timestamp(raw: dict[str, Any]) -> str | None:
+    ts = raw.get("timestamp")
+    return ts if isinstance(ts, str) else None
+
+
+def parse_rollout_events(raw_lines: list[dict[str, Any]]) -> list[RolloutEvent]:
+    """Parse raw rollout lines to typed models, dropping unknown types."""
+    events: list[RolloutEvent] = []
+    for raw in raw_lines:
+        event = parse_rollout_event(raw)
+        if event is not None:
+            events.append(event)
+    return events

--- a/src/inspect_swe/_codex_cli/_events/rollout_models.py
+++ b/src/inspect_swe/_codex_cli/_events/rollout_models.py
@@ -278,7 +278,11 @@ class SubAgentActivityEvent(RolloutEvent):
 
 
 class ReviewModeEvent(RolloutEvent):
-    """An ``entered_review_mode`` / ``exited_review_mode`` event."""
+    """An ``entered_review_mode`` / ``exited_review_mode`` event.
+
+    ``review`` is the event payload (the review request, or the review
+    output on exit), surfaced on the converted InfoEvent.
+    """
 
     entered: bool = True
     review: dict[str, Any] | None = None
@@ -333,16 +337,14 @@ def parse_rollout_event(raw: dict[str, Any]) -> RolloutEvent | None:
         model_cls = TurnContextEvent
     elif line_type == "event_msg":
         payload_type = payload.get("type")
-        if payload_type == "entered_review_mode":
+        if payload_type in ("entered_review_mode", "exited_review_mode"):
+            # The payload (minus the discriminator) is the review request /
+            # review output — surfaced on the InfoEvent for transcript
+            # consumers.
+            review = {k: v for k, v in payload.items() if k != "type"}
             return ReviewModeEvent(
-                entered=True,
-                review=payload if payload else None,
-                timestamp=_envelope_timestamp(raw),
-            )
-        elif payload_type == "exited_review_mode":
-            return ReviewModeEvent(
-                entered=False,
-                review=payload if payload else None,
+                entered=payload_type == "entered_review_mode",
+                review=review or None,
                 timestamp=_envelope_timestamp(raw),
             )
         elif isinstance(payload_type, str):
@@ -357,13 +359,11 @@ def parse_rollout_event(raw: dict[str, Any]) -> RolloutEvent | None:
         logger.warning(f"Failed to parse rollout {line_type} payload: {ex}")
         return None
 
-    # Envelope timestamp wins when present (session_meta payloads carry their
-    # own timestamp field which serves as a fallback).
+    # Envelope timestamp wins when present (a payload-level timestamp — e.g.
+    # session_meta's — is already populated by model_validate as a fallback).
     envelope_ts = _envelope_timestamp(raw)
     if envelope_ts is not None:
         event.timestamp = envelope_ts
-    elif event.timestamp is None and isinstance(payload.get("timestamp"), str):
-        event.timestamp = payload["timestamp"]
     return event
 
 

--- a/src/inspect_swe/_util/events.py
+++ b/src/inspect_swe/_util/events.py
@@ -1,0 +1,21 @@
+"""Helpers shared by the Scout event converters."""
+
+from inspect_ai.event import Event, ModelEvent
+
+
+def sum_scout_tokens(events: list[Event]) -> int:
+    """Sum total tokens from converted Scout ModelEvent objects.
+
+    Counts tokens from all ModelEvents, including loaded subagent events.
+
+    Args:
+        events: List of Inspect AI events
+
+    Returns:
+        Total token count across all ModelEvents
+    """
+    total = 0
+    for event in events:
+        if isinstance(event, ModelEvent) and event.output and event.output.usage:
+            total += event.output.usage.total_tokens
+    return total

--- a/tests/test_codex_rollout_conversion.py
+++ b/tests/test_codex_rollout_conversion.py
@@ -1,0 +1,577 @@
+"""Unit tests for codex rollout → scout event conversion."""
+
+import asyncio
+from datetime import datetime, timezone
+from typing import Any
+
+from inspect_ai.event import (
+    CompactionEvent,
+    Event,
+    InfoEvent,
+    ModelEvent,
+    SpanBeginEvent,
+    SpanEndEvent,
+    ToolEvent,
+)
+from inspect_ai.model import ContentImage, ContentReasoning, ContentText
+from inspect_ai.model._chat_message import ChatMessageUser
+from inspect_ai.model._generate_config import GenerateConfig
+from inspect_ai.model._model_output import ModelOutput
+from inspect_swe._codex_cli._events.rollout import process_rollout_events
+from inspect_swe._codex_cli._events.rollout_extraction import (
+    is_context_message,
+    output_to_result,
+    parse_arguments,
+    reasoning_to_content,
+    usage_from_token_info,
+)
+from inspect_swe._codex_cli._events.rollout_models import (
+    ResponseReasoning,
+    parse_rollout_events,
+)
+
+
+def _line(
+    type_: str, payload: dict[str, Any], ts: str = "2026-08-01T10:00:00Z"
+) -> dict[str, Any]:
+    return {"timestamp": ts, "type": type_, "payload": payload}
+
+
+def _user(text: str) -> dict[str, Any]:
+    return _line(
+        "response_item",
+        {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": text}],
+        },
+    )
+
+
+def _assistant(text: str) -> dict[str, Any]:
+    return _line(
+        "response_item",
+        {
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": text}],
+        },
+    )
+
+
+def _function_call(name: str, arguments: str, call_id: str) -> dict[str, Any]:
+    return _line(
+        "response_item",
+        {
+            "type": "function_call",
+            "name": name,
+            "arguments": arguments,
+            "call_id": call_id,
+        },
+    )
+
+
+def _call_output(call_id: str, output: Any) -> dict[str, Any]:
+    return _line(
+        "response_item",
+        {"type": "function_call_output", "call_id": call_id, "output": output},
+    )
+
+
+def _turn_context(model: str = "gpt-5.1-codex") -> dict[str, Any]:
+    return _line("turn_context", {"model": model, "cwd": "/x"})
+
+
+def _convert(raw_lines: list[dict[str, Any]]) -> list[Event]:
+    async def collect() -> list[Event]:
+        events = parse_rollout_events(raw_lines)
+        return [e async for e in process_rollout_events(events)]
+
+    return asyncio.run(collect())
+
+
+# ── model event grouping ─────────────────────────────────────────────────
+
+
+def test_consecutive_assistant_items_become_one_model_event() -> None:
+    """Reasoning + message + two tool calls = one model response."""
+    scout_events = _convert(
+        [
+            _turn_context(),
+            _user("do two things"),
+            _line(
+                "response_item",
+                {
+                    "type": "reasoning",
+                    "summary": [{"type": "summary_text", "text": "Planning"}],
+                    "encrypted_content": "opaque",
+                },
+            ),
+            _assistant("Doing both now."),
+            _function_call("shell", '{"command": ["a"]}', "c1"),
+            _function_call("shell", '{"command": ["b"]}', "c2"),
+            _call_output("c1", "out a"),
+            _call_output("c2", "out b"),
+        ]
+    )
+    model_events = [e for e in scout_events if isinstance(e, ModelEvent)]
+    assert len(model_events) == 1
+    message = model_events[0].output.choices[0].message
+    assert message.tool_calls is not None and len(message.tool_calls) == 2
+    assert [tc.id for tc in message.tool_calls] == ["c1", "c2"]
+    assert isinstance(message.content, list)
+    assert isinstance(message.content[0], ContentReasoning)
+    assert isinstance(message.content[1], ContentText)
+    assert model_events[0].output.choices[0].stop_reason == "tool_calls"
+    assert model_events[0].model == "gpt-5.1-codex"
+
+    # both tool spans emitted
+    tool_events = [e for e in scout_events if isinstance(e, ToolEvent)]
+    assert [t.id for t in tool_events] == ["c1", "c2"]
+    assert tool_events[0].result == "out a"
+
+
+def test_model_event_input_accumulates_context() -> None:
+    scout_events = _convert(
+        [
+            _turn_context(),
+            _user("<environment_context>cwd: /x</environment_context>"),
+            _user("real question"),
+            _assistant("answer one"),
+            _line("event_msg", {"type": "token_count", "info": None}),
+            _user("second question"),
+            _assistant("answer two"),
+        ]
+    )
+    model_events = [e for e in scout_events if isinstance(e, ModelEvent)]
+    assert len(model_events) == 2
+    # first call saw both user messages (context + question)
+    assert [m.role for m in model_events[0].input] == ["user", "user"]
+    # second call saw everything before it
+    assert [m.role for m in model_events[1].input] == [
+        "user",
+        "user",
+        "assistant",
+        "user",
+    ]
+
+
+def test_usage_attached_from_token_count() -> None:
+    scout_events = _convert(
+        [
+            _turn_context(),
+            _user("q"),
+            _assistant("a"),
+            _line(
+                "event_msg",
+                {
+                    "type": "token_count",
+                    "info": {
+                        "total_token_usage": {
+                            "input_tokens": 100,
+                            "output_tokens": 20,
+                            "total_tokens": 120,
+                        },
+                        "last_token_usage": {
+                            "input_tokens": 100,
+                            "cached_input_tokens": 80,
+                            "cache_write_input_tokens": 5,
+                            "output_tokens": 20,
+                            "reasoning_output_tokens": 8,
+                            "total_tokens": 120,
+                        },
+                    },
+                },
+            ),
+        ]
+    )
+    model_events = [e for e in scout_events if isinstance(e, ModelEvent)]
+    usage = model_events[0].output.usage
+    assert usage is not None
+    assert usage.input_tokens == 20  # excludes cached
+    assert usage.input_tokens_cache_read == 80
+    assert usage.input_tokens_cache_write == 5
+    assert usage.output_tokens == 20
+    assert usage.reasoning_tokens == 8
+    assert usage.total_tokens == 120
+
+
+# ── extraction units ─────────────────────────────────────────────────────
+
+
+def test_is_context_message() -> None:
+    assert is_context_message("<environment_context>\n<cwd>/x</cwd>")
+    assert is_context_message("  <user_instructions>be nice</user_instructions>")
+    assert not is_context_message("fix the tests")
+    # bundled genuine user text is user speech
+    assert not is_context_message(
+        "<environment_context>...</environment_context>\n\n## My request for Codex:\nfix it"
+    )
+
+
+def test_output_to_result_polymorphism() -> None:
+    # plain string
+    result, exit_code = output_to_result("Exit code: 0\nOutput:\nok")
+    assert result == "Exit code: 0\nOutput:\nok" and exit_code is None
+
+    # legacy JSON-encoded form with metadata
+    result, exit_code = output_to_result(
+        '{"output": "boom", "metadata": {"exit_code": 2, "duration_seconds": 1.5}}'
+    )
+    assert result == "boom" and exit_code == 2
+
+    # content-item array with an image
+    result, exit_code = output_to_result(
+        [
+            {"type": "output_text", "text": "see image"},
+            {"type": "input_image", "image_url": "data:image/png;base64,AAAA"},
+        ]
+    )
+    assert isinstance(result, list)
+    assert isinstance(result[0], ContentText)
+    assert isinstance(result[1], ContentImage)
+
+    # text-only array collapses to a string
+    result, _ = output_to_result([{"type": "output_text", "text": "just text"}])
+    assert result == "just text"
+
+    assert output_to_result(None) == ("", None)
+
+
+def test_parse_arguments_tolerates_bad_json() -> None:
+    assert parse_arguments('{"a": 1}') == {"a": 1}
+    assert parse_arguments("") == {}
+    assert parse_arguments("not json") == {"arguments": "not json"}
+    assert parse_arguments('"bare string"') == {"arguments": "bare string"}
+
+
+def test_reasoning_to_content() -> None:
+    # encrypted-only with summary: summary used, marked redacted
+    encrypted = ResponseReasoning(
+        summary=[{"type": "summary_text", "text": "**Thinking**"}],
+        encrypted_content="opaque",
+    )
+    content = reasoning_to_content(encrypted)
+    assert content is not None
+    assert content.reasoning == "**Thinking**" and content.redacted
+
+    # plaintext reasoning available: not redacted
+    plaintext = ResponseReasoning(
+        summary=[],
+        content=[{"type": "reasoning_text", "text": "step by step"}],
+        encrypted_content="opaque",
+    )
+    content = reasoning_to_content(plaintext)
+    assert content is not None
+    assert content.reasoning == "step by step" and not content.redacted
+
+    # encrypted only, no summary: empty redacted block
+    opaque = ResponseReasoning(summary=[], encrypted_content="opaque")
+    content = reasoning_to_content(opaque)
+    assert content is not None
+    assert content.reasoning == "" and content.redacted
+
+    assert reasoning_to_content(ResponseReasoning(summary=[])) is None
+
+
+def test_usage_from_token_info_none_cases() -> None:
+    assert usage_from_token_info({}) is None
+    assert usage_from_token_info({"last_token_usage": {"total_tokens": 0}}) is None
+
+
+# ── boundary behaviors ───────────────────────────────────────────────────
+
+
+def test_rollback_truncates_accumulated_messages() -> None:
+    scout_events = _convert(
+        [
+            _turn_context(),
+            _user("q1"),
+            _assistant("a1"),
+            _user("q2"),
+            _assistant("a2"),
+            _line("event_msg", {"type": "thread_rolled_back", "num_turns": 1}),
+            _user("q3"),
+            _assistant("a3"),
+        ]
+    )
+    model_events = [e for e in scout_events if isinstance(e, ModelEvent)]
+    assert len(model_events) == 3
+    third_input = model_events[2].input
+    texts = [m.text for m in third_input]
+    assert texts == ["q1", "a1", "q3"]
+    info_events = [e for e in scout_events if isinstance(e, InfoEvent)]
+    assert any(
+        isinstance(e.data, dict) and e.data.get("type") == "thread_rolled_back"
+        for e in info_events
+    )
+
+
+def test_compaction_resets_input_to_replacement_history() -> None:
+    scout_events = _convert(
+        [
+            _turn_context(),
+            _user("q1"),
+            _assistant("a1"),
+            _line(
+                "event_msg",
+                {
+                    "type": "token_count",
+                    "info": {
+                        "total_token_usage": {"total_tokens": 50000},
+                        "last_token_usage": {
+                            "input_tokens": 40,
+                            "output_tokens": 10,
+                            "total_tokens": 50,
+                        },
+                    },
+                },
+            ),
+            _line(
+                "compacted",
+                {
+                    "message": "Summary of q1/a1.",
+                    "replacement_history": [
+                        {
+                            "type": "message",
+                            "role": "user",
+                            "content": [{"type": "input_text", "text": "q1"}],
+                        },
+                        {
+                            "type": "message",
+                            "role": "assistant",
+                            "content": [
+                                {"type": "output_text", "text": "Summary of q1/a1."}
+                            ],
+                        },
+                    ],
+                },
+            ),
+            _user("q2"),
+            _assistant("a2"),
+        ]
+    )
+    compactions = [e for e in scout_events if isinstance(e, CompactionEvent)]
+    assert len(compactions) == 1
+    assert compactions[0].tokens_before == 50000
+    assert compactions[0].type == "summary"
+
+    model_events = [e for e in scout_events if isinstance(e, ModelEvent)]
+    second_input = model_events[1].input
+    assert [m.text for m in second_input] == ["q1", "Summary of q1/a1.", "q2"]
+
+
+def test_remote_compaction_clears_messages() -> None:
+    scout_events = _convert(
+        [
+            _turn_context(),
+            _user("q1"),
+            _assistant("a1"),
+            _line("response_item", {"type": "compaction", "encrypted_content": "xyz"}),
+            _user("q2"),
+            _assistant("a2"),
+        ]
+    )
+    compactions = [e for e in scout_events if isinstance(e, CompactionEvent)]
+    assert len(compactions) == 1
+    assert compactions[0].metadata == {"trigger": "remote", "encrypted": True}
+    model_events = [e for e in scout_events if isinstance(e, ModelEvent)]
+    assert [m.text for m in model_events[1].input] == ["q2"]
+
+
+def test_turn_aborted_flushes_dangling_call_with_error() -> None:
+    scout_events = _convert(
+        [
+            _turn_context(),
+            _user("q"),
+            _function_call("shell", '{"command": ["sleep"]}', "c9"),
+            _line("event_msg", {"type": "turn_aborted", "reason": "interrupted"}),
+        ]
+    )
+    tool_events = [e for e in scout_events if isinstance(e, ToolEvent)]
+    assert len(tool_events) == 1
+    assert tool_events[0].error is not None
+    assert "interrupted" in tool_events[0].error.message
+    info_events = [e for e in scout_events if isinstance(e, InfoEvent)]
+    assert any(
+        isinstance(e.data, dict) and e.data.get("type") == "turn_aborted"
+        for e in info_events
+    )
+
+
+def test_dangling_call_flushed_at_end_without_error() -> None:
+    scout_events = _convert(
+        [
+            _turn_context(),
+            _user("q"),
+            _function_call("shell", '{"command": ["x"]}', "c1"),
+        ]
+    )
+    tool_events = [e for e in scout_events if isinstance(e, ToolEvent)]
+    assert len(tool_events) == 1
+    assert tool_events[0].result == "" and tool_events[0].error is None
+
+
+def test_web_search_call_emits_self_contained_span() -> None:
+    scout_events = _convert(
+        [
+            _turn_context(),
+            _user("look this up"),
+            _line(
+                "response_item",
+                {
+                    "type": "web_search_call",
+                    "id": "ws_1",
+                    "status": "completed",
+                    "action": {"type": "search", "query": "weather"},
+                },
+            ),
+            _assistant("It is sunny."),
+        ]
+    )
+    tool_events = [e for e in scout_events if isinstance(e, ToolEvent)]
+    assert len(tool_events) == 1
+    assert tool_events[0].function == "web_search"
+    assert tool_events[0].arguments == {"query": "weather"}
+    # tool span closed (no dangling pending call)
+    span_begins = [e for e in scout_events if isinstance(e, SpanBeginEvent)]
+    span_ends = [e for e in scout_events if isinstance(e, SpanEndEvent)]
+    assert len(span_begins) == len(span_ends) == 1
+
+
+def test_local_shell_call_pairs_with_output() -> None:
+    scout_events = _convert(
+        [
+            _turn_context(),
+            _user("q"),
+            _line(
+                "response_item",
+                {
+                    "type": "local_shell_call",
+                    "call_id": "lsc_1",
+                    "status": "completed",
+                    "action": {"type": "exec", "command": ["ls"], "timeout_ms": 1000},
+                },
+            ),
+            _call_output("lsc_1", "file.txt"),
+        ]
+    )
+    tool_events = [e for e in scout_events if isinstance(e, ToolEvent)]
+    assert len(tool_events) == 1
+    assert tool_events[0].function == "local_shell"
+    assert tool_events[0].arguments == {"command": ["ls"], "timeout_ms": 1000}
+    assert tool_events[0].result == "file.txt"
+
+
+def test_legacy_output_exit_code_sets_error() -> None:
+    scout_events = _convert(
+        [
+            _turn_context(),
+            _user("q"),
+            _function_call("shell", '{"command": ["false"]}', "c1"),
+            _call_output(
+                "c1", '{"output": "command failed", "metadata": {"exit_code": 1}}'
+            ),
+        ]
+    )
+    tool_events = [e for e in scout_events if isinstance(e, ToolEvent)]
+    assert tool_events[0].result == "command failed"
+    assert tool_events[0].error is not None
+
+
+def test_spawn_agent_span_with_child_loader() -> None:
+    child_model_event_calls: list[tuple[str, int]] = []
+
+    async def fake_loader(thread_id: str, max_depth: int) -> list[Event]:
+        child_model_event_calls.append((thread_id, max_depth))
+        return [
+            ModelEvent(
+                model="child-model",
+                input=[ChatMessageUser(content="child task")],
+                tools=[],
+                tool_choice="auto",
+                config=GenerateConfig(),
+                output=ModelOutput.from_content("child-model", "child answer"),
+                timestamp=datetime(2026, 8, 1, 10, 0, 5, tzinfo=timezone.utc),
+            )
+        ]
+
+    events = parse_rollout_events(
+        [
+            _turn_context(),
+            _user("spawn a helper"),
+            _function_call(
+                "spawn_agent",
+                '{"agent_type": "explorer", "message": "explore"}',
+                "call_sp",
+            ),
+            _call_output(
+                "call_sp", '{"agent_id": "child-thread-id", "nickname": "zippy"}'
+            ),
+        ]
+    )
+
+    async def collect() -> list[Event]:
+        return [
+            e async for e in process_rollout_events(events, child_loader=fake_loader)
+        ]
+
+    scout_events = asyncio.run(collect())
+
+    assert child_model_event_calls == [("child-thread-id", 4)]
+    agent_spans = [
+        e for e in scout_events if isinstance(e, SpanBeginEvent) and e.type == "agent"
+    ]
+    assert len(agent_spans) == 1
+    assert agent_spans[0].name == "zippy"
+    assert agent_spans[0].metadata is not None
+    assert agent_spans[0].metadata["thread_id"] == "child-thread-id"
+
+    # child ModelEvent nested (re-parented onto the agent span)
+    child_events = [
+        e
+        for e in scout_events
+        if isinstance(e, ModelEvent) and e.model == "child-model"
+    ]
+    assert len(child_events) == 1
+    assert child_events[0].span_id == agent_spans[0].id
+
+    # the spawn ToolEvent lives inside the agent span
+    tool_events = [e for e in scout_events if isinstance(e, ToolEvent)]
+    assert tool_events[0].function == "spawn_agent"
+    assert tool_events[0].agent_span_id == agent_spans[0].id
+
+
+def test_developer_message_becomes_system() -> None:
+    scout_events = _convert(
+        [
+            _turn_context(),
+            _line(
+                "response_item",
+                {
+                    "type": "message",
+                    "role": "developer",
+                    "content": [{"type": "input_text", "text": "dev instructions"}],
+                },
+            ),
+            _user("q"),
+            _assistant("a"),
+        ]
+    )
+    model_events = [e for e in scout_events if isinstance(e, ModelEvent)]
+    assert [m.role for m in model_events[0].input] == ["system", "user"]
+
+
+def test_output_without_matching_call_is_accumulated() -> None:
+    scout_events = _convert(
+        [
+            _turn_context(),
+            _call_output("orphan", "orphan output"),
+            _user("q"),
+            _assistant("a"),
+        ]
+    )
+    # no tool span, but message accumulated for fidelity
+    assert not [e for e in scout_events if isinstance(e, ToolEvent)]
+    model_events = [e for e in scout_events if isinstance(e, ModelEvent)]
+    assert [m.role for m in model_events[0].input] == ["tool", "user"]

--- a/tests/test_codex_rollout_events.py
+++ b/tests/test_codex_rollout_events.py
@@ -66,7 +66,9 @@ def test_agents_md_prefix_alone_is_genuine_user_speech(text: str) -> None:
 
 
 def test_output_to_result_unwraps_legacy_form() -> None:
-    legacy = '{"output": "hello\\n", "metadata": {"exit_code": 1, "duration_seconds": 0.2}}'
+    legacy = (
+        '{"output": "hello\\n", "metadata": {"exit_code": 1, "duration_seconds": 0.2}}'
+    )
     assert output_to_result(legacy) == ("hello\n", 1)
     assert output_to_result('{"output": "ok"}') == ("ok", None)
 
@@ -117,8 +119,11 @@ def test_context_messages_do_not_shift_rollback_boundary() -> None:
 
 
 def test_genuine_agents_md_prefixed_turn_is_a_rollback_boundary() -> None:
-    """A real user message starting with the AGENTS.md heading (no closing
-    marker) must count as a genuine turn, so num_turns=1 rolls back only it."""
+    """AGENTS.md-heading user speech is a genuine turn.
+
+    A real user message starting with the AGENTS.md heading (no closing
+    marker) must count as a genuine turn, so num_turns=1 rolls back only it.
+    """
     scout_events = asyncio.run(
         _convert(
             [
@@ -145,8 +150,11 @@ def test_genuine_agents_md_prefixed_turn_is_a_rollback_boundary() -> None:
 
 
 def test_compaction_summary_without_replacement_history_is_user_role() -> None:
-    """Codex re-injects the compaction summary via a user-role bridge message
-    (build_compacted_history), so the accumulated context must match."""
+    """Compaction summary fallback carries the user role.
+
+    Codex re-injects the compaction summary via a user-role bridge message
+    (build_compacted_history), so the accumulated context must match.
+    """
     scout_events = asyncio.run(
         _convert(
             [
@@ -171,8 +179,11 @@ def test_compaction_summary_without_replacement_history_is_user_role() -> None:
 
 
 def test_model_event_usage_is_set_when_yielded() -> None:
-    """Streaming consumers may serialize each event as it arrives, so usage
-    must be attached before the ModelEvent is yielded, not after."""
+    """Usage is present on ModelEvents at yield time.
+
+    Streaming consumers may serialize each event as it arrives, so usage
+    must be attached before the ModelEvent is yielded, not after.
+    """
     parsed = parse_rollout_events(
         [
             _message("user", "hi"),

--- a/tests/test_codex_rollout_events.py
+++ b/tests/test_codex_rollout_events.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 from typing import Any
 
 import pytest
-from inspect_ai.event import Event, InfoEvent, ModelEvent, SpanBeginEvent
+from inspect_ai.event import Event, InfoEvent, ModelEvent, SpanBeginEvent, ToolEvent
 from inspect_swe._codex_cli._events.rollout import process_rollout_events
 from inspect_swe._codex_cli._events.rollout_extraction import (
     is_context_message,
@@ -148,6 +148,38 @@ def test_genuine_agents_md_prefixed_turn_is_a_rollback_boundary() -> None:
     assert "AGENTS.md instructions are being ignored" not in input_text
     assert "second response" not in input_text
     assert "replacement user turn" in input_text
+
+
+def test_idless_web_search_fallback_ids_are_unique_across_responses() -> None:
+    def web_search(query: str) -> dict[str, Any]:
+        return _line(
+            "response_item",
+            {
+                "type": "web_search_call",
+                "status": "completed",
+                "action": {"type": "search", "query": query},
+            },
+        )
+
+    scout_events = asyncio.run(
+        _convert(
+            [
+                _message("user", "look these up"),
+                web_search("first"),
+                _message("assistant", "found the first"),
+                _message("user", "and another"),
+                web_search("second"),
+                _message("assistant", "found the second"),
+            ]
+        )
+    )
+
+    tool_ids = [
+        event.id
+        for event in scout_events
+        if isinstance(event, ToolEvent) and event.function == "web_search"
+    ]
+    assert tool_ids == ["web_search_0", "web_search_1"]
 
 
 def test_review_mode_payload_is_surfaced_on_info_event() -> None:

--- a/tests/test_codex_rollout_events.py
+++ b/tests/test_codex_rollout_events.py
@@ -144,6 +144,49 @@ def test_genuine_agents_md_prefixed_turn_is_a_rollback_boundary() -> None:
     assert "replacement user turn" in input_text
 
 
+def test_model_event_usage_is_set_when_yielded() -> None:
+    """Streaming consumers may serialize each event as it arrives, so usage
+    must be attached before the ModelEvent is yielded, not after."""
+    parsed = parse_rollout_events(
+        [
+            _message("user", "hi"),
+            _message("assistant", "hello"),
+            _line(
+                "event_msg",
+                {
+                    "type": "token_count",
+                    "info": {
+                        "total_token_usage": {"total_tokens": 30},
+                        "last_token_usage": {
+                            "input_tokens": 20,
+                            "output_tokens": 10,
+                            "total_tokens": 30,
+                        },
+                    },
+                },
+            ),
+            _message("user", "thanks"),
+            _message("assistant", "any time"),
+        ]
+    )
+
+    async def stream() -> list[tuple[ModelEvent, bool]]:
+        seen: list[tuple[ModelEvent, bool]] = []
+        async for event in process_rollout_events(parsed):
+            if isinstance(event, ModelEvent):
+                seen.append((event, event.output.usage is not None))
+        return seen
+
+    seen = asyncio.run(stream())
+    assert len(seen) == 2
+    first_event, first_had_usage = seen[0]
+    assert first_had_usage, "usage must be present at yield time"
+    assert first_event.output.usage is not None
+    assert first_event.output.usage.total_tokens == 30
+    # the second response has no token_count after it
+    assert seen[1][0].output.usage is None
+
+
 def test_subagent_activity_links_modern_spawn_result_to_child_thread() -> None:
     loader_calls: list[tuple[str, int]] = []
 

--- a/tests/test_codex_rollout_events.py
+++ b/tests/test_codex_rollout_events.py
@@ -144,6 +144,32 @@ def test_genuine_agents_md_prefixed_turn_is_a_rollback_boundary() -> None:
     assert "replacement user turn" in input_text
 
 
+def test_compaction_summary_without_replacement_history_is_user_role() -> None:
+    """Codex re-injects the compaction summary via a user-role bridge message
+    (build_compacted_history), so the accumulated context must match."""
+    scout_events = asyncio.run(
+        _convert(
+            [
+                _message("user", "long conversation"),
+                _message("assistant", "long response"),
+                _line("compacted", {"message": "summary of the thread"}),
+                _message("user", "next question"),
+                _message("assistant", "next answer"),
+            ]
+        )
+    )
+
+    final_model_event = next(
+        event for event in reversed(scout_events) if isinstance(event, ModelEvent)
+    )
+    summary = next(
+        message
+        for message in final_model_event.input
+        if "summary of the thread" in message.text
+    )
+    assert summary.role == "user"
+
+
 def test_model_event_usage_is_set_when_yielded() -> None:
     """Streaming consumers may serialize each event as it arrives, so usage
     must be attached before the ModelEvent is yielded, not after."""

--- a/tests/test_codex_rollout_events.py
+++ b/tests/test_codex_rollout_events.py
@@ -7,7 +7,10 @@ from typing import Any
 import pytest
 from inspect_ai.event import Event, ModelEvent, SpanBeginEvent
 from inspect_swe._codex_cli._events.rollout import process_rollout_events
-from inspect_swe._codex_cli._events.rollout_extraction import is_context_message
+from inspect_swe._codex_cli._events.rollout_extraction import (
+    is_context_message,
+    output_to_result,
+)
 from inspect_swe._codex_cli._events.rollout_models import (
     SubAgentActivityEvent,
     parse_rollout_events,
@@ -60,6 +63,26 @@ def test_modern_injected_messages_are_context(text: str) -> None:
 )
 def test_agents_md_prefix_alone_is_genuine_user_speech(text: str) -> None:
     assert not is_context_message(text)
+
+
+def test_output_to_result_unwraps_legacy_form() -> None:
+    legacy = '{"output": "hello\\n", "metadata": {"exit_code": 1, "duration_seconds": 0.2}}'
+    assert output_to_result(legacy) == ("hello\n", 1)
+    assert output_to_result('{"output": "ok"}') == ("ok", None)
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        # Genuine tool output that happens to be JSON with an "output" key
+        # (e.g. `cat config.json`) must pass through verbatim.
+        '{"output": "x", "metadata": {"exit_code": 1}, "extra": true}',
+        '{"output": {"nested": 1}, "metadata": {"exit_code": 1}}',
+        '{"output": "x", "metadata": "not-a-dict"}',
+    ],
+)
+def test_output_to_result_passes_through_non_legacy_json(text: str) -> None:
+    assert output_to_result(text) == (text, None)
 
 
 def test_context_messages_do_not_shift_rollback_boundary() -> None:

--- a/tests/test_codex_rollout_events.py
+++ b/tests/test_codex_rollout_events.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 from typing import Any
 
 import pytest
-from inspect_ai.event import Event, ModelEvent, SpanBeginEvent
+from inspect_ai.event import Event, InfoEvent, ModelEvent, SpanBeginEvent
 from inspect_swe._codex_cli._events.rollout import process_rollout_events
 from inspect_swe._codex_cli._events.rollout_extraction import (
     is_context_message,
@@ -13,6 +13,7 @@ from inspect_swe._codex_cli._events.rollout_extraction import (
 )
 from inspect_swe._codex_cli._events.rollout_models import (
     SubAgentActivityEvent,
+    parse_rollout_event,
     parse_rollout_events,
 )
 
@@ -147,6 +148,43 @@ def test_genuine_agents_md_prefixed_turn_is_a_rollback_boundary() -> None:
     assert "AGENTS.md instructions are being ignored" not in input_text
     assert "second response" not in input_text
     assert "replacement user turn" in input_text
+
+
+def test_review_mode_payload_is_surfaced_on_info_event() -> None:
+    scout_events = asyncio.run(
+        _convert(
+            [
+                _line(
+                    "event_msg",
+                    {
+                        "type": "entered_review_mode",
+                        "prompt": "review the diff",
+                        "user_facing_hint": "current changes",
+                    },
+                ),
+                _line("event_msg", {"type": "exited_review_mode"}),
+            ]
+        )
+    )
+
+    entered, exited = (event for event in scout_events if isinstance(event, InfoEvent))
+    assert entered.data == {
+        "type": "entered_review_mode",
+        "review": {"prompt": "review the diff", "user_facing_hint": "current changes"},
+    }
+    # no payload beyond the discriminator -> no review key
+    assert exited.data == {"type": "exited_review_mode"}
+
+
+def test_payload_timestamp_is_fallback_for_missing_envelope_timestamp() -> None:
+    event = parse_rollout_event(
+        {
+            "type": "session_meta",
+            "payload": {"id": "thread-1", "timestamp": "2026-08-10T20:05:06.000Z"},
+        }
+    )
+    assert event is not None
+    assert event.timestamp == "2026-08-10T20:05:06.000Z"
 
 
 def test_compaction_summary_without_replacement_history_is_user_role() -> None:

--- a/tests/test_codex_rollout_events.py
+++ b/tests/test_codex_rollout_events.py
@@ -49,6 +49,19 @@ def test_modern_injected_messages_are_context(text: str) -> None:
     assert is_context_message(text)
 
 
+@pytest.mark.parametrize(
+    "text",
+    [
+        # A genuine user message may start with the AGENTS.md heading; only
+        # the full injected shape (with the closing marker) is context.
+        "# AGENTS.md instructions are being ignored, why?",
+        "# AGENTS.md instructions\n\nplease review my draft below",
+    ],
+)
+def test_agents_md_prefix_alone_is_genuine_user_speech(text: str) -> None:
+    assert not is_context_message(text)
+
+
 def test_context_messages_do_not_shift_rollback_boundary() -> None:
     scout_events = asyncio.run(
         _convert(
@@ -58,7 +71,11 @@ def test_context_messages_do_not_shift_rollback_boundary() -> None:
                 _message("user", "<recommended_plugins>plugins</recommended_plugins>"),
                 _message("user", "second user turn"),
                 _message("assistant", "second response"),
-                _message("user", "# AGENTS.md instructions for /workspace"),
+                _message(
+                    "user",
+                    "# AGENTS.md instructions for /workspace\n\n"
+                    "<INSTRUCTIONS>be helpful</INSTRUCTIONS>",
+                ),
                 _line("event_msg", {"type": "thread_rolled_back", "num_turns": 1}),
                 _message("user", "replacement user turn"),
                 _message("assistant", "replacement response"),
@@ -72,6 +89,34 @@ def test_context_messages_do_not_shift_rollback_boundary() -> None:
     input_text = "\n".join(message.text for message in final_model_event.input)
     assert "first user turn" in input_text
     assert "second user turn" not in input_text
+    assert "second response" not in input_text
+    assert "replacement user turn" in input_text
+
+
+def test_genuine_agents_md_prefixed_turn_is_a_rollback_boundary() -> None:
+    """A real user message starting with the AGENTS.md heading (no closing
+    marker) must count as a genuine turn, so num_turns=1 rolls back only it."""
+    scout_events = asyncio.run(
+        _convert(
+            [
+                _message("user", "first user turn"),
+                _message("assistant", "first response"),
+                _message("user", "# AGENTS.md instructions are being ignored, why?"),
+                _message("assistant", "second response"),
+                _line("event_msg", {"type": "thread_rolled_back", "num_turns": 1}),
+                _message("user", "replacement user turn"),
+                _message("assistant", "replacement response"),
+            ]
+        )
+    )
+
+    final_model_event = next(
+        event for event in reversed(scout_events) if isinstance(event, ModelEvent)
+    )
+    input_text = "\n".join(message.text for message in final_model_event.input)
+    assert "first user turn" in input_text
+    assert "first response" in input_text
+    assert "AGENTS.md instructions are being ignored" not in input_text
     assert "second response" not in input_text
     assert "replacement user turn" in input_text
 

--- a/tests/test_codex_rollout_events.py
+++ b/tests/test_codex_rollout_events.py
@@ -1,0 +1,140 @@
+"""Regression tests for Codex rollout-file event conversion."""
+
+import asyncio
+from collections.abc import Sequence
+from typing import Any
+
+import pytest
+from inspect_ai.event import Event, ModelEvent, SpanBeginEvent
+from inspect_swe._codex_cli._events.rollout import process_rollout_events
+from inspect_swe._codex_cli._events.rollout_extraction import is_context_message
+from inspect_swe._codex_cli._events.rollout_models import (
+    SubAgentActivityEvent,
+    parse_rollout_events,
+)
+
+
+def _line(line_type: str, payload: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "timestamp": "2026-08-10T20:05:06.000Z",
+        "type": line_type,
+        "payload": payload,
+    }
+
+
+def _message(role: str, text: str) -> dict[str, Any]:
+    return _line(
+        "response_item",
+        {
+            "type": "message",
+            "role": role,
+            "content": [{"type": "input_text", "text": text}],
+        },
+    )
+
+
+async def _convert(raw_lines: Sequence[dict[str, Any]]) -> list[Event]:
+    events = parse_rollout_events(list(raw_lines))
+    return [event async for event in process_rollout_events(events)]
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "<recommended_plugins>\n<plugin>example</plugin>\n</recommended_plugins>",
+        "# AGENTS.md instructions for /workspace\n\n<INSTRUCTIONS>...</INSTRUCTIONS>",
+    ],
+)
+def test_modern_injected_messages_are_context(text: str) -> None:
+    assert is_context_message(text)
+
+
+def test_context_messages_do_not_shift_rollback_boundary() -> None:
+    scout_events = asyncio.run(
+        _convert(
+            [
+                _message("user", "first user turn"),
+                _message("assistant", "first response"),
+                _message("user", "<recommended_plugins>plugins</recommended_plugins>"),
+                _message("user", "second user turn"),
+                _message("assistant", "second response"),
+                _message("user", "# AGENTS.md instructions for /workspace"),
+                _line("event_msg", {"type": "thread_rolled_back", "num_turns": 1}),
+                _message("user", "replacement user turn"),
+                _message("assistant", "replacement response"),
+            ]
+        )
+    )
+
+    final_model_event = next(
+        event for event in reversed(scout_events) if isinstance(event, ModelEvent)
+    )
+    input_text = "\n".join(message.text for message in final_model_event.input)
+    assert "first user turn" in input_text
+    assert "second user turn" not in input_text
+    assert "second response" not in input_text
+    assert "replacement user turn" in input_text
+
+
+def test_subagent_activity_links_modern_spawn_result_to_child_thread() -> None:
+    loader_calls: list[tuple[str, int]] = []
+
+    async def fake_loader(thread_id: str, max_depth: int) -> list[Event]:
+        loader_calls.append((thread_id, max_depth))
+        return []
+
+    parsed = parse_rollout_events(
+        [
+            _message("user", "delegate this"),
+            _line(
+                "response_item",
+                {
+                    "type": "function_call",
+                    "name": "spawn_agent",
+                    "arguments": '{"task_name":"importer_qa_fixture"}',
+                    "call_id": "call_spawn",
+                },
+            ),
+            _line(
+                "event_msg",
+                {
+                    "type": "sub_agent_activity",
+                    "event_id": "call_spawn",
+                    "agent_thread_id": "019fed47-6294-7070-b852-b370a8e708cc",
+                    "agent_path": "/root/importer_qa_fixture",
+                    "kind": "started",
+                },
+            ),
+            _line(
+                "response_item",
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_spawn",
+                    "output": '{"task_name":"/root/importer_qa_fixture"}',
+                },
+            ),
+        ]
+    )
+    assert isinstance(parsed[2], SubAgentActivityEvent)
+
+    async def convert() -> list[Event]:
+        return [
+            event
+            async for event in process_rollout_events(parsed, child_loader=fake_loader)
+        ]
+
+    scout_events = asyncio.run(convert())
+
+    assert loader_calls == [("019fed47-6294-7070-b852-b370a8e708cc", 4)]
+    agent_span = next(
+        event
+        for event in scout_events
+        if isinstance(event, SpanBeginEvent) and event.type == "agent"
+    )
+    assert agent_span.name == "importer_qa_fixture"
+    assert agent_span.metadata == {
+        "agent_type": None,
+        "task_name": "importer_qa_fixture",
+        "thread_id": "019fed47-6294-7070-b852-b370a8e708cc",
+        "agent_path": "/root/importer_qa_fixture",
+    }

--- a/tests/test_codex_rollout_events.py
+++ b/tests/test_codex_rollout_events.py
@@ -200,9 +200,132 @@ def test_subagent_activity_links_modern_spawn_result_to_child_thread() -> None:
         if isinstance(event, SpanBeginEvent) and event.type == "agent"
     )
     assert agent_span.name == "importer_qa_fixture"
+    # Keys are present only when known (same shape as the live bridge).
     assert agent_span.metadata == {
-        "agent_type": None,
         "task_name": "importer_qa_fixture",
         "thread_id": "019fed47-6294-7070-b852-b370a8e708cc",
         "agent_path": "/root/importer_qa_fixture",
     }
+
+
+def _spawn_lines(output: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """A spawn_agent call + activity event, optionally followed by its output."""
+    lines = [
+        _message("user", "delegate this"),
+        _line(
+            "response_item",
+            {
+                "type": "function_call",
+                "name": "spawn_agent",
+                "arguments": '{"task_name":"qa"}',
+                "call_id": "call_spawn",
+            },
+        ),
+        _line(
+            "event_msg",
+            {
+                "type": "sub_agent_activity",
+                "event_id": "call_spawn",
+                "agent_thread_id": "thread-1",
+                "agent_path": "/root/qa",
+                "kind": "started",
+            },
+        ),
+    ]
+    if output is not None:
+        lines.append(_line("response_item", output))
+    return lines
+
+
+@pytest.mark.parametrize(
+    "trailing_lines",
+    [
+        # Turn aborted before the spawn's output was written
+        [{"type": "event_msg", "payload": {"type": "turn_aborted", "reason": "user"}}],
+        # File truncated while the sub-agent was still running
+        [],
+    ],
+)
+def test_dangling_spawn_still_emits_agent_span_and_loads_child(
+    trailing_lines: list[dict[str, Any]],
+) -> None:
+    loader_calls: list[str] = []
+
+    async def fake_loader(thread_id: str, max_depth: int) -> list[Event]:
+        loader_calls.append(thread_id)
+        return []
+
+    lines = _spawn_lines(output=None) + [
+        _line(raw["type"], raw["payload"]) for raw in trailing_lines
+    ]
+
+    async def convert() -> list[Event]:
+        parsed = parse_rollout_events(lines)
+        return [
+            event
+            async for event in process_rollout_events(parsed, child_loader=fake_loader)
+        ]
+
+    scout_events = asyncio.run(convert())
+
+    assert loader_calls == ["thread-1"]
+    agent_span = next(
+        event
+        for event in scout_events
+        if isinstance(event, SpanBeginEvent) and event.type == "agent"
+    )
+    assert agent_span.name == "qa"
+    assert agent_span.metadata is not None
+    assert agent_span.metadata["thread_id"] == "thread-1"
+
+
+def test_later_activity_event_does_not_erase_agent_path() -> None:
+    lines = _spawn_lines(output=None)
+    # A second lifecycle event without agent_path must not erase the bound path
+    lines.append(
+        _line(
+            "event_msg",
+            {
+                "type": "sub_agent_activity",
+                "event_id": "call_spawn",
+                "agent_thread_id": "thread-1",
+            },
+        )
+    )
+    lines.append(
+        _line(
+            "response_item",
+            {
+                "type": "function_call_output",
+                "call_id": "call_spawn",
+                "output": '{"task_name":"/root/qa"}',
+            },
+        )
+    )
+
+    scout_events = asyncio.run(_convert(lines))
+    agent_span = next(
+        event
+        for event in scout_events
+        if isinstance(event, SpanBeginEvent) and event.type == "agent"
+    )
+    assert agent_span.metadata is not None
+    assert agent_span.metadata["agent_path"] == "/root/qa"
+
+
+def test_v2_spawn_result_nickname_names_the_agent_span() -> None:
+    """V2 results carry nickname without agent_id; the nickname must win."""
+    lines = _spawn_lines(
+        output={
+            "type": "function_call_output",
+            "call_id": "call_spawn",
+            "output": '{"task_name":"/root/qa","nickname":"Ivy"}',
+        }
+    )
+    scout_events = asyncio.run(_convert(lines))
+    agent_span = next(
+        event
+        for event in scout_events
+        if isinstance(event, SpanBeginEvent) and event.type == "agent"
+    )
+    assert agent_span.name == "Ivy"

--- a/tests/test_codex_rollout_models.py
+++ b/tests/test_codex_rollout_models.py
@@ -1,0 +1,117 @@
+"""Unit tests for codex rollout envelope/model parsing."""
+
+from datetime import timedelta
+from typing import Any
+
+from inspect_swe._codex_cli._events.rollout import _RolloutProcessor
+from inspect_swe._codex_cli._events.rollout_extraction import parse_timestamp
+from inspect_swe._codex_cli._events.rollout_models import (
+    ResponseCompaction,
+    ResponseFunctionCall,
+    ResponseMessage,
+    SessionMetaEvent,
+    parse_rollout_event,
+    parse_rollout_events,
+)
+
+THREAD_ID = "0199aaaa-0000-7000-8000-000000000001"
+
+
+def _line(
+    type_: str, payload: dict[str, Any], ts: str = "2026-08-01T10:00:00Z"
+) -> dict[str, Any]:
+    return {"timestamp": ts, "type": type_, "payload": payload}
+
+
+def test_parse_session_meta_backfills_ids() -> None:
+    # old files have only id; parse should backfill session_id
+    event = parse_rollout_event(_line("session_meta", {"id": THREAD_ID, "cwd": "/x"}))
+    assert isinstance(event, SessionMetaEvent)
+    assert event.thread_id == THREAD_ID
+    assert event.session_id == THREAD_ID
+    assert event.timestamp == "2026-08-01T10:00:00Z"
+
+    event = parse_rollout_event(
+        {"type": "session_meta", "payload": {"session_id": THREAD_ID}}
+    )
+    assert isinstance(event, SessionMetaEvent)
+    assert event.thread_id == THREAD_ID
+
+
+def test_subagent_source_classification() -> None:
+    review = SessionMetaEvent(id=THREAD_ID, source={"subagent": "review"})
+    assert review.subagent_source() == "review"
+
+    spawn = SessionMetaEvent(
+        id=THREAD_ID, source={"subagent": {"thread_spawn": {"depth": 1}}}
+    )
+    subagent = spawn.subagent_source()
+    assert isinstance(subagent, dict) and "thread_spawn" in subagent
+
+    cli = SessionMetaEvent(id=THREAD_ID, source="cli")
+    assert cli.subagent_source() is None
+
+
+def test_parse_response_items() -> None:
+    events = parse_rollout_events(
+        [
+            _line(
+                "response_item",
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "hi"}],
+                },
+            ),
+            _line(
+                "response_item",
+                {
+                    "type": "function_call",
+                    "name": "shell",
+                    "arguments": '{"command": ["ls"]}',
+                    "call_id": "c1",
+                },
+            ),
+        ]
+    )
+    assert len(events) == 2
+    assert isinstance(events[0], ResponseMessage)
+    assert events[0].role == "user"
+    assert isinstance(events[1], ResponseFunctionCall)
+    assert events[1].call_id == "c1"
+
+
+def test_unknown_types_dropped() -> None:
+    events = parse_rollout_events(
+        [
+            _line("response_item", {"type": "some_future_item", "data": 1}),
+            _line("event_msg", {"type": "some_future_event"}),
+            _line("world_state", {"full": True, "state": {}}),
+            {"not": "an envelope"},
+            _line("response_item", {"type": "message", "role": "user", "content": []}),
+        ]
+    )
+    # only the message survives
+    assert len(events) == 1
+    assert isinstance(events[0], ResponseMessage)
+
+
+def test_compaction_alias_parsed() -> None:
+    for item_type in ("compaction", "compaction_summary", "context_compaction"):
+        event = parse_rollout_event(
+            _line("response_item", {"type": item_type, "encrypted_content": "xyz"})
+        )
+        assert isinstance(event, ResponseCompaction)
+
+
+def test_timestamp_parsing_and_monotonicity() -> None:
+    assert parse_timestamp("2026-08-01T10:00:00.500Z") is not None
+    assert parse_timestamp("not a timestamp") is None
+    assert parse_timestamp(None) is None
+
+    proc = _RolloutProcessor()
+    e1 = ResponseMessage(timestamp="2026-08-01T10:00:01Z", role="user")
+    e2 = ResponseMessage(timestamp="2026-08-01T10:00:00Z", role="user")  # earlier!
+    t1 = proc.update_timestamp(e1)
+    t2 = proc.update_timestamp(e2)
+    assert t2 == t1 + timedelta(milliseconds=1)


### PR DESCRIPTION
Adds a library for converting Codex CLI rollout files (`$CODEX_HOME/sessions/**/rollout-*.jsonl`) into Inspect events, following the same pattern as `_claude_code/_events` (which inspect_scout's Claude Code importer already consumes):

* `rollout_models.py` — lenient pydantic models for the rollout JSONL format (no format-version field upstream, so unknown types/fields are tolerated; ground truth is codex-rs `protocol.rs`)
* `rollout_extraction.py` — content/usage/context-message helpers
* `rollout.py` — stateful conversion to Inspect events: ModelEvents with accumulated input fidelity, tool spans, spawned sub-agent threads nested as agent spans (child rollouts loaded via a caller-supplied loader), compaction, thread rollback (undo), token usage, and review mode

Consumed by inspect_scout's Codex importer, which supplies the file-based child-thread loader and transcript assembly. Supports both Multi-Agent V1 and current V2 rollout formats (`sub_agent_activity` linking, task_name results, injected AGENTS.md/plugin context blocks).

Verified against inspect_scout's importer test suite (53 tests) in addition to the tests here.