### PR TITLE
test: replace retired claude-sonnet-4-0 with claude-sonnet-4-5

### DIFF
--- a/tests/test_attempts.py
+++ b/tests/test_attempts.py
@@ -17,7 +17,7 @@ from tests.conftest import (
 @skip_if_no_docker
 @pytest.mark.parametrize("sandbox", get_available_sandboxes())
 def test_claude_code_attempts(sandbox: str) -> None:
-    check_attempts("claude_code", "anthropic/claude-sonnet-4-0", sandbox)
+    check_attempts("claude_code", "anthropic/claude-sonnet-4-5", sandbox)
 
 
 @skip_if_no_openai
@@ -45,7 +45,7 @@ def test_mini_swe_attempts(sandbox: str) -> None:
 @skip_if_no_docker
 @pytest.mark.parametrize("sandbox", get_available_sandboxes())
 def test_opencode_attempts(sandbox: str) -> None:
-    check_attempts("opencode", "anthropic/claude-sonnet-4-0", sandbox)
+    check_attempts("opencode", "anthropic/claude-sonnet-4-5", sandbox)
 
 
 def check_attempts(

--- a/tests/test_bridged_tools.py
+++ b/tests/test_bridged_tools.py
@@ -15,7 +15,7 @@ from tests.conftest import (
 @skip_if_no_docker
 def test_claude_code_bridged_tools() -> None:
     check_bridged_tools(
-        "claude_code", "anthropic/claude-sonnet-4-0", "mcp__secrets__secret_lookup"
+        "claude_code", "anthropic/claude-sonnet-4-5", "mcp__secrets__secret_lookup"
     )
 
 
@@ -37,7 +37,7 @@ def test_gemini_cli_bridged_tools() -> None:
 @skip_if_no_docker
 def test_kimi_code_bridged_tools() -> None:
     check_bridged_tools(
-        "kimi_code", "anthropic/claude-sonnet-4-0", "mcp__secrets__secret_lookup"
+        "kimi_code", "anthropic/claude-sonnet-4-5", "mcp__secrets__secret_lookup"
     )
 
 
@@ -45,7 +45,7 @@ def test_kimi_code_bridged_tools() -> None:
 @skip_if_no_docker
 def test_opencode_bridged_tools() -> None:
     check_bridged_tools(
-        "opencode", "anthropic/claude-sonnet-4-0", "secrets_secret_lookup"
+        "opencode", "anthropic/claude-sonnet-4-5", "secrets_secret_lookup"
     )
 
 

--- a/tests/test_codex_align.py
+++ b/tests/test_codex_align.py
@@ -114,7 +114,7 @@ def test_codex_align_older_openai_passes_through() -> None:
 @skip_if_no_anthropic
 @skip_if_no_docker
 def test_codex_align_non_openai_uses_generic_fallback() -> None:
-    capture = _run_codex("anthropic/claude-sonnet-4-0")
+    capture = _run_codex("anthropic/claude-sonnet-4-5")
     assert capture.system_prompt, "expected a non-empty system prompt"
     assert not _offers_apply_patch(capture.tool_names or []), (
         f"expected no apply_patch for a non-OpenAI model, got tools: {capture.tool_names}"

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -15,7 +15,7 @@ from tests.conftest import (
 @skip_if_no_docker
 def test_claude_code_mcp() -> None:
     check_mcp(
-        "claude_code", "anthropic/claude-sonnet-4-0", "mcp__memory__create_entities"
+        "claude_code", "anthropic/claude-sonnet-4-5", "mcp__memory__create_entities"
     )
 
 
@@ -34,7 +34,7 @@ def test_gemini_cli_mcp() -> None:
 @skip_if_no_anthropic
 @skip_if_no_docker
 def test_opencode_mcp() -> None:
-    check_mcp("opencode", "anthropic/claude-sonnet-4-0", "memory_create_entities")
+    check_mcp("opencode", "anthropic/claude-sonnet-4-5", "memory_create_entities")
 
 
 def check_mcp(

--- a/tests/test_multi_call.py
+++ b/tests/test_multi_call.py
@@ -18,7 +18,7 @@ from tests.conftest import (
 @skip_if_no_docker
 @pytest.mark.parametrize("sandbox", get_available_sandboxes())
 def test_claude_code_multi_call(sandbox: str) -> None:
-    check_multi_call("claude_code", "anthropic/claude-sonnet-4-0", sandbox)
+    check_multi_call("claude_code", "anthropic/claude-sonnet-4-5", sandbox)
 
 
 @skip_if_no_anthropic
@@ -35,7 +35,7 @@ def test_claude_code_system_prompt_not_duplicated(sandbox: str) -> None:
     (``ModelEvent.call.request``).
     """
     log = run_example(
-        "multi_call", "claude_code", "anthropic/claude-sonnet-4-0", sandbox=sandbox
+        "multi_call", "claude_code", "anthropic/claude-sonnet-4-5", sandbox=sandbox
     )[0]
     assert log.samples
     sample = log.samples[0]
@@ -114,7 +114,7 @@ def test_mini_swe_agent_multi_call_anthropic(sandbox: str) -> None:
 @skip_if_no_docker
 @pytest.mark.parametrize("sandbox", get_available_sandboxes())
 def test_opencode_multi_call(sandbox: str) -> None:
-    check_multi_call("opencode", "anthropic/claude-sonnet-4-0", sandbox)
+    check_multi_call("opencode", "anthropic/claude-sonnet-4-5", sandbox)
 
 
 def check_multi_call(

--- a/tests/test_system_explorer.py
+++ b/tests/test_system_explorer.py
@@ -16,7 +16,7 @@ from tests.conftest import (
 @skip_if_no_docker
 @pytest.mark.parametrize("sandbox", get_available_sandboxes())
 def test_claude_code_system_explorer(sandbox: str) -> None:
-    check_system_explorer_example("claude_code", "anthropic/claude-sonnet-4-0", sandbox)
+    check_system_explorer_example("claude_code", "anthropic/claude-sonnet-4-5", sandbox)
 
 
 @skip_if_no_openai
@@ -46,7 +46,7 @@ def test_mini_swe_agent_system_explorer(sandbox: str) -> None:
 @skip_if_no_docker
 @pytest.mark.parametrize("sandbox", get_available_sandboxes())
 def test_opencode_system_explorer(sandbox: str) -> None:
-    check_system_explorer_example("opencode", "anthropic/claude-sonnet-4-0", sandbox)
+    check_system_explorer_example("opencode", "anthropic/claude-sonnet-4-5", sandbox)
 
 
 def check_system_explorer_example(

--- a/tests/test_web_search.py
+++ b/tests/test_web_search.py
@@ -16,7 +16,7 @@ from tests.conftest import (
 @pytest.mark.parametrize("sandbox", get_available_sandboxes())
 def test_claude_code_web_search(sandbox: str) -> None:
     log = run_example(
-        "web_search", "claude_code", "anthropic/claude-sonnet-4-0", sandbox=sandbox
+        "web_search", "claude_code", "anthropic/claude-sonnet-4-5", sandbox=sandbox
     )[0]
     assert log.status == "success"
     assert log.samples


### PR DESCRIPTION
The first inspect_swe nightly slow-test run (meridianlabs-ai/actions run 31623632234) failed 20 tests. The largest cluster: every test driving claude_code/opencode/kimi against `anthropic/claude-sonnet-4-0`, which Anthropic retired on 2026-06-15 — the API returns `404 not_found_error` for it now. These tests never ran in CI before, so nothing caught it.

This bumps all live-API usages (14 refs across 7 test files) to `anthropic/claude-sonnet-4-5`, which the newer tests in this repo already use and which passed in the same nightly run. The two `claude-sonnet-4-0` strings left in `test_codex_model_catalog.py` are slug-resolution fixtures that never reach the API.

Not addressed here: `test_codex_cli_multi_call` also failed with a message-count drift (6 user messages vs the hardcoded 5) — codex CLI scaffold behavior changed. That needs its own look rather than a blind count bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)