### PR TITLE
test: lower-bound codex_cli user-message count in multi_call

### DIFF
--- a/tests/test_multi_call.py
+++ b/tests/test_multi_call.py
@@ -140,7 +140,10 @@ def check_multi_call(
             assert len(user_messages) == 4
             assert len(assistant_messages) == 4
         case "codex_cli":
-            assert len(user_messages) == 5
+            # scaffold count varies by codex version (e.g. newer versions
+            # inject an "# AGENTS.md instructions" user message), so only
+            # lower-bound the user messages
+            assert len(user_messages) >= 4
             assert len(assistant_messages) == 4
         case "gemini_cli":
             assert len(user_messages) >= 4


### PR DESCRIPTION
Last holdout from the nightly slow-test burn-down (run 31631334620: 2 failed / 244 passed).

`test_codex_cli_multi_call` hardcodes 5 user messages, which baked in the previous codex scaffold behavior. Newer codex versions inject an `# AGENTS.md instructions` user message into conversation history (visible in the failure detail: the 6th `ChatMessageUser` starts with `# AGENTS.md instr...`), so the count drifted to 6.

Fix follows the file's existing pattern for scaffold-variable agents (`gemini_cli`, `opencode`, `mini_swe_agent` all use `>= 4`): lower-bound the user messages — which still verifies all four sequential calls traversed the bridge — and keep the assistant count exact, since scaffold doesn't add assistant turns.

(The only other failure in that run, `test_gemini_cli_attempts`, was an xdist worker crash — infra flake, passed in the prior run.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)