### PR TITLE
fix: make bridged MCP readiness timeouts configurable

### DIFF
--- a/docs/antigravity.qmd
+++ b/docs/antigravity.qmd
@@ -17,6 +17,7 @@ The following options are supported for customizing the behavior of the agent:
 | `system_prompt` | Additional system prompt to append to default system prompt. |
 | `mcp_servers` | MCP servers to make available to the agent. localharness reaches servers over streamable HTTP, so `type="http"` configs are required and `type="sse"` is rejected rather than silently reconstructed. |
 | `bridged_tools` | Host-side Inspect tools to expose via MCP. |
+| `mcp_ready_timeout` | Seconds to wait for bridged MCP endpoints to serve tools before the agent launch errors. |
 | `model` | Model name to use for agent (defaults to main model for task). |
 | `model_aliases` | Mapping of model names to Model instances/strings; alias keys resolve against `endpoint_model`. |
 | `filter` | Filter for intercepting bridged model requests (Model-first `GenerateFilter` form only). |

--- a/docs/claude_code.qmd
+++ b/docs/claude_code.qmd
@@ -20,6 +20,7 @@ The following options are supported for customizing the behavior of the agent:
 | `skills` | Additional [skills](https://inspect.aisi.org.uk/tools-standard.html#sec-skill) to make available to the agent. |
 | `mcp_servers` | MCP servers (see [MCP Servers](#mcp-servers) below for details). |
 | `bridged_tools` | Host-side Inspect tools to expose via MCP (see [Bridged Tools](#bridged-tools) below for details). |
+| `mcp_ready_timeout` | Seconds to wait for bridged MCP endpoints to serve tools before the agent launch errors. |
 | `disallowed_tools` | Optionally disallow tools (e.g. `"{{< meta agent_disallowed_tool >}}"`) |
 | `centaur` | Run in [Centaur Mode](#centaur-mode), which makes Claude Code available to an Inspect `human_cli()` agent rather than running it unattended. | 
 | `attempts` | Allow the agent to have multiple scored attempts at solving the task. |

--- a/docs/codex_cli.qmd
+++ b/docs/codex_cli.qmd
@@ -19,6 +19,7 @@ The following options are supported for customizing the behavior of the agent:
 | `skills` | Additional [skills](https://inspect.aisi.org.uk/tools-standard.html#sec-skill) to make available to the agent. |
 | `mcp_servers` | MCP servers (see [MCP Servers](#mcp-servers) below for details). |
 | `bridged_tools` | Host-side Inspect tools to expose via MCP (see [Bridged Tools](#bridged-tools) below for details). |
+| `mcp_ready_timeout` | Seconds to wait for bridged MCP endpoints to serve tools before the agent launch errors. |
 | `web_search` | Web search mode. Use `"live"` for live web search, `"cached"` for cached web search, or `"disabled"` to disable web search. Defaults to `"live"`. |
 | `goals` | Enable Codex goal tools. Defaults to `True`. |
 | `auto_review` | Enable Codex [automated approval review](https://developers.openai.com/codex/concepts/sandboxing/auto-review) (see [Auto Review](#auto-review) below for details). Defaults to `False`. |

--- a/docs/codex_cli.qmd
+++ b/docs/codex_cli.qmd
@@ -20,6 +20,7 @@ The following options are supported for customizing the behavior of the agent:
 | `mcp_servers` | MCP servers (see [MCP Servers](#mcp-servers) below for details). |
 | `bridged_tools` | Host-side Inspect tools to expose via MCP (see [Bridged Tools](#bridged-tools) below for details). |
 | `mcp_ready_timeout` | Seconds to wait for bridged MCP endpoints to serve tools before the agent launch errors. |
+| `mcp_startup_timeout` | Seconds Codex waits for bridged MCP server startup. Defaults to 300; pass `None` to use Codex's default. |
 | `web_search` | Web search mode. Use `"live"` for live web search, `"cached"` for cached web search, or `"disabled"` to disable web search. Defaults to `"live"`. |
 | `goals` | Enable Codex goal tools. Defaults to `True`. |
 | `auto_review` | Enable Codex [automated approval review](https://developers.openai.com/codex/concepts/sandboxing/auto-review) (see [Auto Review](#auto-review) below for details). Defaults to `False`. |

--- a/docs/gemini_cli.qmd
+++ b/docs/gemini_cli.qmd
@@ -19,6 +19,7 @@ The following options are supported for customizing the behavior of the agent:
 | `skills` | Additional [skills](https://inspect.aisi.org.uk/tools-standard.html#sec-skill) to make available to the agent. |
 | `mcp_servers` | MCP servers (see [MCP Servers](#mcp-servers) below for details). |
 | `bridged_tools` | Host-side Inspect tools to expose via MCP (see [Bridged Tools](#bridged-tools) below for details). |
+| `mcp_ready_timeout` | Seconds to wait for bridged MCP endpoints to serve tools before the agent launch errors. |
 | `web_search` | Enable the agent's web search tool (defaults to `True`). |
 | `centaur` | Run in [Centaur Mode](#centaur-mode), which makes Gemini CLI available to an Inspect `human_cli()` agent rather than running it unattended. |
 | `attempts` | Allow the agent to have multiple scored attempts at solving the task. |

--- a/docs/kimi_code.qmd
+++ b/docs/kimi_code.qmd
@@ -19,6 +19,7 @@ The following options are supported for customizing the behavior of the agent:
 | `skills` | Additional [skills](https://inspect.aisi.org.uk/tools-standard.html#sec-skill) to make available to the agent. |
 | `mcp_servers` | MCP servers (see [MCP Servers](#mcp-servers) below for details). |
 | `bridged_tools` | Host-side Inspect tools to expose via MCP (see [Bridged Tools](#bridged-tools) below for details). |
+| `mcp_ready_timeout` | Seconds to wait for bridged MCP endpoints to serve tools before the agent launch errors. |
 | `centaur` | Run in [Centaur Mode](#centaur-mode), which makes {{< meta agent_name >}} available to an Inspect `human_cli()` agent rather than running it unattended. |
 | `attempts` | Allow the agent to have multiple scored attempts at solving the task. |
 | `model` | Model name to use for agent (defaults to main model for task). |

--- a/docs/opencode.qmd
+++ b/docs/opencode.qmd
@@ -19,6 +19,7 @@ The following options are supported for customizing the behavior of the agent:
 | `skills` | Additional [skills](https://inspect.aisi.org.uk/tools-standard.html#sec-skill) to make available to the agent. |
 | `mcp_servers` | MCP servers (see [MCP Servers](#mcp-servers) below for details). |
 | `bridged_tools` | Host-side Inspect tools to expose via MCP (see [Bridged Tools](#bridged-tools) below for details). |
+| `mcp_ready_timeout` | Seconds to wait for bridged MCP endpoints to serve tools before the agent launch errors. |
 | `centaur` | Run in [Centaur Mode](#centaur-mode), which makes OpenCode available to an Inspect `human_cli()` agent rather than running it unattended. |
 | `attempts` | Allow the agent to have multiple scored attempts at solving the task. |
 | `model` | Model name to use for agent (defaults to main model for task). |

--- a/src/inspect_swe/_antigravity/antigravity.py
+++ b/src/inspect_swe/_antigravity/antigravity.py
@@ -29,7 +29,10 @@ from inspect_ai.util import sandbox as sandbox_env
 from inspect_ai.util import store
 from inspect_ai.util._sandbox import ExecRemoteAwaitableOptions
 
-from inspect_swe._util.mcp_ready import wait_for_mcp_endpoints
+from inspect_swe._util.mcp_ready import (
+    DEFAULT_MCP_READY_TIMEOUT,
+    wait_for_mcp_endpoints,
+)
 from inspect_swe._util.messages import build_user_prompt
 from inspect_swe._util.path import join_path
 from inspect_swe._util.sandbox import resolve_agent_cwd
@@ -261,6 +264,7 @@ def antigravity(
     system_prompt: str | None = None,
     mcp_servers: Sequence[MCPServerConfig] | None = None,
     bridged_tools: Sequence[BridgedToolsSpec] | None = None,
+    mcp_ready_timeout: float = DEFAULT_MCP_READY_TIMEOUT,
     model: str | None = None,
     model_aliases: dict[str, str | Model] | None = None,
     filter: _ModelGenerateFilter | None = None,
@@ -287,6 +291,8 @@ def antigravity(
         mcp_servers: MCP servers to make available to the agent (HTTP configs;
             localharness reaches servers over streamable HTTP).
         bridged_tools: Host-side Inspect tools to expose to the agent via MCP.
+        mcp_ready_timeout: Seconds to wait for bridged MCP endpoints to serve
+            tools before the agent launch errors.
         model: Model name to use for the inspect bridge (defaults to the task model).
         model_aliases: Optional mapping of model names to Model instances/strings.
             Alias keys resolve against the client-sent model name, which for this
@@ -363,7 +369,11 @@ def antigravity(
             ]
             if bridged_http_configs:
                 await wait_for_mcp_endpoints(
-                    bridged_http_configs, bridge, sandbox=sandbox, required=True
+                    bridged_http_configs,
+                    bridge,
+                    sandbox=sandbox,
+                    timeout=mcp_ready_timeout,
+                    required=True,
                 )
 
             prompt, has_assistant_response = build_user_prompt(state.messages)

--- a/src/inspect_swe/_claude_code/claude_code.py
+++ b/src/inspect_swe/_claude_code/claude_code.py
@@ -45,7 +45,10 @@ from inspect_swe._claude_code._events.stream import (
     claude_code_event_stream,
 )
 from inspect_swe._util.centaur import CentaurOptions, run_centaur
-from inspect_swe._util.mcp_ready import wait_for_mcp_endpoints
+from inspect_swe._util.mcp_ready import (
+    DEFAULT_MCP_READY_TIMEOUT,
+    wait_for_mcp_endpoints,
+)
 from inspect_swe._util.path import join_path
 from inspect_swe._util.websearch import web_search_tool_disallowed
 
@@ -119,6 +122,7 @@ def claude_code(
     skills: Sequence[str | Path | Skill] | None = None,
     mcp_servers: Sequence[MCPServerConfig] | None = None,
     bridged_tools: Sequence[BridgedToolsSpec] | None = None,
+    mcp_ready_timeout: float = DEFAULT_MCP_READY_TIMEOUT,
     disallowed_tools: list[str] | None = None,
     centaur: bool | CentaurOptions = False,
     attempts: int | AgentAttempts = 1,
@@ -166,6 +170,8 @@ def claude_code(
         bridged_tools: Host-side Inspect tools to expose to the agent via MCP.
             Each BridgedToolsSpec creates an MCP server that makes the specified
             tools available to the agent running in the sandbox.
+        mcp_ready_timeout: Seconds to wait for bridged MCP endpoints to serve
+            tools before the agent launch errors.
         disallowed_tools: List of tool names to disallow entirely (disallowing
             `"WebSearch"` also disables web search for the agent).
         centaur: Run in 'centaur' mode, which makes Claude Code available to an Inspect `human_cli()` agent rather than running it unattended.
@@ -389,7 +395,11 @@ def claude_code(
             # per-attempt gate below covers unattended retries after that.
             if http_mcp_configs:
                 await wait_for_mcp_endpoints(
-                    http_mcp_configs, bridge, sandbox=sandbox, required=True
+                    http_mcp_configs,
+                    bridge,
+                    sandbox=sandbox,
+                    timeout=mcp_ready_timeout,
+                    required=True,
                 )
 
             # centaur mode uses human_cli with custom instructions and bash rc
@@ -468,7 +478,11 @@ def claude_code(
                         is_retry = attempt_count > 0 or uncaught_error_count > 0
                         if http_mcp_configs and is_retry:
                             await wait_for_mcp_endpoints(
-                                http_mcp_configs, bridge, sandbox=sandbox, required=True
+                                http_mcp_configs,
+                                bridge,
+                                sandbox=sandbox,
+                                timeout=mcp_ready_timeout,
+                                required=True,
                             )
 
                         # launch Claude Code in streaming mode; drain stdout in

--- a/src/inspect_swe/_codex_cli/codex_cli.py
+++ b/src/inspect_swe/_codex_cli/codex_cli.py
@@ -53,6 +53,7 @@ from .agentbinary import (
     codex_models_catalog,
 )
 from .config import (
+    MCP_STARTUP_TIMEOUT_SEC,
     CodexApprovalPolicy,
     CodexAutoReview,
     CodexDeprecatedArgs,
@@ -96,6 +97,7 @@ def codex_cli(
     mcp_servers: Sequence[MCPServerConfig] | None = None,
     bridged_tools: Sequence[BridgedToolsSpec] | None = None,
     mcp_ready_timeout: float = DEFAULT_MCP_READY_TIMEOUT,
+    mcp_startup_timeout: int | None = MCP_STARTUP_TIMEOUT_SEC,
     web_search: CodexWebSearch = "live",
     goals: bool = True,
     auto_review: bool | CodexAutoReview = False,
@@ -141,6 +143,8 @@ def codex_cli(
             tools available to the agent running in the sandbox.
         mcp_ready_timeout: Seconds to wait for bridged MCP endpoints to serve
             tools before the agent launch errors.
+        mcp_startup_timeout: Seconds Codex waits for bridged MCP server startup.
+            Defaults to 300; pass `None` to use Codex's default.
         web_search: Web search mode. Use "live" for live web search, "cached" for cached web search, or "disabled" to disable web search. Defaults to "live".
         goals: Enable Codex goal tools (defaults to `True`).
         auto_review: Enable Codex automated approval review (guardian). When enabled,
@@ -566,6 +570,7 @@ def codex_cli(
                     bridged_server_names,
                     effective_approval_policy,
                     force_approve=approve_static_mcp_tools,
+                    bridged_startup_timeout=mcp_startup_timeout,
                 )
             )
             toml_config.update(
@@ -574,6 +579,7 @@ def codex_cli(
                     bridged_server_names,
                     effective_approval_policy,
                     force_approve=True,
+                    bridged_startup_timeout=mcp_startup_timeout,
                 )
             )
 

--- a/src/inspect_swe/_codex_cli/codex_cli.py
+++ b/src/inspect_swe/_codex_cli/codex_cli.py
@@ -35,7 +35,10 @@ from typing_extensions import Unpack
 
 from inspect_swe._util._async import is_callable_coroutine
 from inspect_swe._util.centaur import CentaurOptions, run_centaur
-from inspect_swe._util.mcp_ready import wait_for_mcp_endpoints
+from inspect_swe._util.mcp_ready import (
+    DEFAULT_MCP_READY_TIMEOUT,
+    wait_for_mcp_endpoints,
+)
 from inspect_swe._util.messages import build_user_prompt
 from inspect_swe._util.path import join_path
 from inspect_swe._util.sandbox import resolve_agent_cwd, sandbox_exec
@@ -92,6 +95,7 @@ def codex_cli(
     skills: Sequence[str | Path | Skill] | None = None,
     mcp_servers: Sequence[MCPServerConfig] | None = None,
     bridged_tools: Sequence[BridgedToolsSpec] | None = None,
+    mcp_ready_timeout: float = DEFAULT_MCP_READY_TIMEOUT,
     web_search: CodexWebSearch = "live",
     goals: bool = True,
     auto_review: bool | CodexAutoReview = False,
@@ -135,6 +139,8 @@ def codex_cli(
         bridged_tools: Host-side Inspect tools to expose to the agent via MCP.
             Each BridgedToolsSpec creates an MCP server that makes the specified
             tools available to the agent running in the sandbox.
+        mcp_ready_timeout: Seconds to wait for bridged MCP endpoints to serve
+            tools before the agent launch errors.
         web_search: Web search mode. Use "live" for live web search, "cached" for cached web search, or "disabled" to disable web search. Defaults to "live".
         goals: Enable Codex goal tools (defaults to `True`).
         auto_review: Enable Codex automated approval review (guardian). When enabled,
@@ -607,7 +613,11 @@ def codex_cli(
             ]
             if _http_mcp_configs:
                 await wait_for_mcp_endpoints(
-                    _http_mcp_configs, bridge, sandbox=sandbox, required=True
+                    _http_mcp_configs,
+                    bridge,
+                    sandbox=sandbox,
+                    timeout=mcp_ready_timeout,
+                    required=True,
                 )
 
             if centaur:
@@ -644,7 +654,11 @@ def codex_cli(
                     is_retry = attempt_count > 0 or cp.attempt == "resume"
                     if _http_mcp_configs and is_retry:
                         await wait_for_mcp_endpoints(
-                            _http_mcp_configs, bridge, sandbox=sandbox, required=True
+                            _http_mcp_configs,
+                            bridge,
+                            sandbox=sandbox,
+                            timeout=mcp_ready_timeout,
+                            required=True,
                         )
 
                     result = await sbox.exec_remote(

--- a/src/inspect_swe/_codex_cli/config.py
+++ b/src/inspect_swe/_codex_cli/config.py
@@ -7,6 +7,8 @@ from inspect_ai.tool import MCPServerConfig
 from pydantic import BaseModel, ConfigDict, Field
 from typing_extensions import TypedDict
 
+MCP_STARTUP_TIMEOUT_SEC = 300
+
 CodexWebSearch = Literal["live", "cached", "disabled"]
 
 
@@ -386,7 +388,9 @@ def resolve_codex_sandbox_mode(
 
 
 def codex_mcp_server_config(
-    mcp_server: MCPServerConfig, bridged_server_names: AbstractSet[str]
+    mcp_server: MCPServerConfig,
+    bridged_server_names: AbstractSet[str],
+    bridged_startup_timeout: int | None,
 ) -> dict[str, Any]:
     """TOML table for one `mcp_servers.<name>` entry in codex config.
 
@@ -402,6 +406,8 @@ def codex_mcp_server_config(
     server_config = mcp_server.model_dump(exclude={"name", "tools"}, exclude_none=True)
     if mcp_server.name in bridged_server_names:
         server_config["required"] = True
+        if bridged_startup_timeout is not None:
+            server_config["startup_timeout_sec"] = bridged_startup_timeout
     return server_config
 
 
@@ -410,6 +416,7 @@ def codex_mcp_servers_toml(
     bridged_server_names: AbstractSet[str],
     approval_policy: CodexApprovalPolicy,
     force_approve: bool,
+    bridged_startup_timeout: int | None,
 ) -> dict[str, dict[str, Any]]:
     """Build `[mcp_servers.<name>]` TOML tables for one class of MCP server.
 
@@ -423,11 +430,15 @@ def codex_mcp_servers_toml(
     return {
         f"mcp_servers.{mcp_server.name}": (
             codex_mcp_server_toml(
-                codex_mcp_server_config(mcp_server, bridged_server_names),
+                codex_mcp_server_config(
+                    mcp_server, bridged_server_names, bridged_startup_timeout
+                ),
                 approval_policy,
             )
             if force_approve
-            else codex_mcp_server_config(mcp_server, bridged_server_names)
+            else codex_mcp_server_config(
+                mcp_server, bridged_server_names, bridged_startup_timeout
+            )
         )
         for mcp_server in mcp_servers
     }

--- a/src/inspect_swe/_gemini_cli/gemini_cli.py
+++ b/src/inspect_swe/_gemini_cli/gemini_cli.py
@@ -23,7 +23,10 @@ from inspect_ai.util._sandbox import ExecRemoteAwaitableOptions
 
 from inspect_swe._util._async import is_callable_coroutine
 from inspect_swe._util.centaur import CentaurOptions, run_centaur
-from inspect_swe._util.mcp_ready import wait_for_mcp_endpoints
+from inspect_swe._util.mcp_ready import (
+    DEFAULT_MCP_READY_TIMEOUT,
+    wait_for_mcp_endpoints,
+)
 from inspect_swe._util.messages import build_user_prompt
 from inspect_swe._util.path import join_path
 from inspect_swe._util.sandbox import resolve_agent_cwd
@@ -43,6 +46,7 @@ def gemini_cli(
     skills: Sequence[str | Path | Skill] | None = None,
     mcp_servers: Sequence[MCPServerConfig] | None = None,
     bridged_tools: Sequence[BridgedToolsSpec] | None = None,
+    mcp_ready_timeout: float = DEFAULT_MCP_READY_TIMEOUT,
     web_search: bool = True,
     centaur: bool | CentaurOptions = False,
     attempts: int | AgentAttempts = 1,
@@ -73,6 +77,8 @@ def gemini_cli(
         skills: Additional [skills](https://inspect.aisi.org.uk/tools-standard.html#sec-skill) to make available to the agent.
         mcp_servers: MCP servers to make available to the agent
         bridged_tools: Host-side Inspect tools to expose to the agent via MCP
+        mcp_ready_timeout: Seconds to wait for bridged MCP endpoints to serve
+            tools before the agent launch errors.
         web_search: Enable the agent's web search tool (defaults to `True`).
         centaur: Run in 'centaur' mode, which makes Gemini CLI available to an Inspect `human_cli()` agent rather than running it unattended.
         attempts: Configure agent to make multiple attempts
@@ -218,7 +224,11 @@ def gemini_cli(
             ]
             if _http_mcp_configs:
                 await wait_for_mcp_endpoints(
-                    _http_mcp_configs, bridge, sandbox=sandbox, required=True
+                    _http_mcp_configs,
+                    bridge,
+                    sandbox=sandbox,
+                    timeout=mcp_ready_timeout,
+                    required=True,
                 )
 
             if centaur:
@@ -250,7 +260,11 @@ def gemini_cli(
                     # iteration.
                     if _http_mcp_configs and attempt_count > 0:
                         await wait_for_mcp_endpoints(
-                            _http_mcp_configs, bridge, sandbox=sandbox, required=True
+                            _http_mcp_configs,
+                            bridge,
+                            sandbox=sandbox,
+                            timeout=mcp_ready_timeout,
+                            required=True,
                         )
                     result = await sbox.exec_remote(
                         cmd=["bash", "-c", 'exec 0</dev/null; "$@"', "bash"]

--- a/src/inspect_swe/_kimi_code/kimi_code.py
+++ b/src/inspect_swe/_kimi_code/kimi_code.py
@@ -47,7 +47,10 @@ from inspect_ai.util._sandbox import ExecRemoteAwaitableOptions
 
 from inspect_swe._util._async import is_callable_coroutine
 from inspect_swe._util.centaur import CentaurOptions, run_centaur
-from inspect_swe._util.mcp_ready import wait_for_mcp_endpoints
+from inspect_swe._util.mcp_ready import (
+    DEFAULT_MCP_READY_TIMEOUT,
+    wait_for_mcp_endpoints,
+)
 from inspect_swe._util.messages import build_user_prompt
 from inspect_swe._util.trace import trace
 
@@ -112,6 +115,7 @@ def kimi_code(
     skills: Sequence[str | Path | Skill] | None = None,
     mcp_servers: Sequence[MCPServerConfig] | None = None,
     bridged_tools: Sequence[BridgedToolsSpec] | None = None,
+    mcp_ready_timeout: float = DEFAULT_MCP_READY_TIMEOUT,
     centaur: bool | CentaurOptions = False,
     attempts: int | AgentAttempts = 1,
     model: str | None = None,
@@ -147,6 +151,8 @@ def kimi_code(
         skills: Additional [skills](https://inspect.aisi.org.uk/tools-standard.html#sec-skill) to make available to the agent.
         mcp_servers: MCP servers to make available to the agent
         bridged_tools: Host-side Inspect tools to expose to the agent via MCP
+        mcp_ready_timeout: Seconds to wait for bridged MCP endpoints to serve
+            tools before the agent launch errors.
         centaur: Run in 'centaur' mode, which makes Kimi Code available to an Inspect `human_cli()` agent rather than running it unattended.
         attempts: Configure agent to make multiple attempts
         model: Model name to use for inspect bridge (defaults to main model for task)
@@ -310,7 +316,11 @@ def kimi_code(
             ]
             if _http_mcp_configs:
                 await wait_for_mcp_endpoints(
-                    _http_mcp_configs, bridge, sandbox=sandbox, required=True
+                    _http_mcp_configs,
+                    bridge,
+                    sandbox=sandbox,
+                    timeout=mcp_ready_timeout,
+                    required=True,
                 )
 
             if centaur:
@@ -340,7 +350,11 @@ def kimi_code(
                     # iteration.
                     if _http_mcp_configs and attempt_count > 0:
                         await wait_for_mcp_endpoints(
-                            _http_mcp_configs, bridge, sandbox=sandbox, required=True
+                            _http_mcp_configs,
+                            bridge,
+                            sandbox=sandbox,
+                            timeout=mcp_ready_timeout,
+                            required=True,
                         )
 
                     # NOTE: endpoint readiness is the strongest guarantee

--- a/src/inspect_swe/_opencode/opencode.py
+++ b/src/inspect_swe/_opencode/opencode.py
@@ -23,7 +23,7 @@ from inspect_ai.util._sandbox import ExecRemoteAwaitableOptions
 
 from inspect_swe._util._async import is_callable_coroutine
 from inspect_swe._util.centaur import CentaurOptions, run_centaur
-from inspect_swe._util.mcp_ready import wait_for_mcp_endpoints
+from inspect_swe._util.mcp_ready import DEFAULT_MCP_READY_TIMEOUT, wait_for_mcp_endpoints
 from inspect_swe._util.messages import build_user_prompt
 from inspect_swe._util.sandbox import resolve_agent_cwd
 from inspect_swe._util.trace import trace
@@ -43,6 +43,7 @@ def opencode(
     skills: Sequence[str | Path | Skill] | None = None,
     mcp_servers: Sequence[MCPServerConfig] | None = None,
     bridged_tools: Sequence[BridgedToolsSpec] | None = None,
+    mcp_ready_timeout: float = DEFAULT_MCP_READY_TIMEOUT,
     centaur: bool | CentaurOptions = False,
     attempts: int | AgentAttempts = 1,
     model: str | None = None,
@@ -72,6 +73,8 @@ def opencode(
         skills: Additional [skills](https://inspect.aisi.org.uk/tools-standard.html#sec-skill) to make available to the agent.
         mcp_servers: MCP servers to make available to the agent
         bridged_tools: Host-side Inspect tools to expose to the agent via MCP
+        mcp_ready_timeout: Seconds to wait for bridged MCP endpoints to serve
+            tools before the agent launch errors.
         centaur: Run in 'centaur' mode, which makes OpenCode available to an Inspect `human_cli()` agent rather than running it unattended.
         attempts: Configure agent to make multiple attempts
         model: Model name to use for inspect bridge (defaults to main model for task)
@@ -244,7 +247,11 @@ def opencode(
             ]
             if _http_mcp_configs:
                 await wait_for_mcp_endpoints(
-                    _http_mcp_configs, bridge, sandbox=sandbox, required=True
+                    _http_mcp_configs,
+                    bridge,
+                    sandbox=sandbox,
+                    timeout=mcp_ready_timeout,
+                    required=True,
                 )
 
             if centaur:
@@ -276,7 +283,11 @@ def opencode(
                     # iteration.
                     if _http_mcp_configs and attempt_count > 0:
                         await wait_for_mcp_endpoints(
-                            _http_mcp_configs, bridge, sandbox=sandbox, required=True
+                            _http_mcp_configs,
+                            bridge,
+                            sandbox=sandbox,
+                            timeout=mcp_ready_timeout,
+                            required=True,
                         )
 
                     result = await sbox.exec_remote(

--- a/src/inspect_swe/_opencode/opencode.py
+++ b/src/inspect_swe/_opencode/opencode.py
@@ -23,7 +23,10 @@ from inspect_ai.util._sandbox import ExecRemoteAwaitableOptions
 
 from inspect_swe._util._async import is_callable_coroutine
 from inspect_swe._util.centaur import CentaurOptions, run_centaur
-from inspect_swe._util.mcp_ready import DEFAULT_MCP_READY_TIMEOUT, wait_for_mcp_endpoints
+from inspect_swe._util.mcp_ready import (
+    DEFAULT_MCP_READY_TIMEOUT,
+    wait_for_mcp_endpoints,
+)
 from inspect_swe._util.messages import build_user_prompt
 from inspect_swe._util.sandbox import resolve_agent_cwd
 from inspect_swe._util.trace import trace

--- a/src/inspect_swe/acp/agent.py
+++ b/src/inspect_swe/acp/agent.py
@@ -21,7 +21,10 @@ from inspect_ai.tool import MCPServerConfig, MCPServerConfigHTTP
 from inspect_ai.util import ExecRemoteProcess
 from typing_extensions import TypedDict, Unpack
 
-from inspect_swe._util.mcp_ready import DEFAULT_MCP_READY_TIMEOUT, wait_for_mcp_endpoints
+from inspect_swe._util.mcp_ready import (
+    DEFAULT_MCP_READY_TIMEOUT,
+    wait_for_mcp_endpoints,
+)
 
 from .client import ACPError, acp_connection, format_acp_failure
 
@@ -114,7 +117,9 @@ class ACPAgent(Agent):
         self.sandbox = kwargs.get("sandbox")
         mcp_ready_timeout = kwargs.get("mcp_ready_timeout")
         self.mcp_ready_timeout = (
-            DEFAULT_MCP_READY_TIMEOUT if mcp_ready_timeout is None else mcp_ready_timeout
+            DEFAULT_MCP_READY_TIMEOUT
+            if mcp_ready_timeout is None
+            else mcp_ready_timeout
         )
 
         self.model_map: dict[str, str | Model] = self._build_model_map()

--- a/src/inspect_swe/acp/agent.py
+++ b/src/inspect_swe/acp/agent.py
@@ -21,7 +21,7 @@ from inspect_ai.tool import MCPServerConfig, MCPServerConfigHTTP
 from inspect_ai.util import ExecRemoteProcess
 from typing_extensions import TypedDict, Unpack
 
-from inspect_swe._util.mcp_ready import wait_for_mcp_endpoints
+from inspect_swe._util.mcp_ready import DEFAULT_MCP_READY_TIMEOUT, wait_for_mcp_endpoints
 
 from .client import ACPError, acp_connection, format_acp_failure
 
@@ -60,6 +60,8 @@ class ACPAgentParams(TypedDict, total=False):
         env: Extra environment variables for the agent process.
         user: User to execute the agent as in the sandbox.
         sandbox: Sandbox environment name.
+        mcp_ready_timeout: Seconds to wait for bridged MCP endpoints to serve
+            tools before the agent launch errors.
     """
 
     model: str | Model | None
@@ -73,6 +75,7 @@ class ACPAgentParams(TypedDict, total=False):
     env: dict[str, str] | None
     user: str | None
     sandbox: str | None
+    mcp_ready_timeout: float
 
 
 class ACPAgent(Agent):
@@ -109,6 +112,10 @@ class ACPAgent(Agent):
         self.env: dict[str, str] = kwargs.get("env") or {}
         self.user = kwargs.get("user")
         self.sandbox = kwargs.get("sandbox")
+        mcp_ready_timeout = kwargs.get("mcp_ready_timeout")
+        self.mcp_ready_timeout = (
+            DEFAULT_MCP_READY_TIMEOUT if mcp_ready_timeout is None else mcp_ready_timeout
+        )
 
         self.model_map: dict[str, str | Model] = self._build_model_map()
         model_map_override = kwargs.get("model_map")
@@ -212,6 +219,7 @@ class ACPAgent(Agent):
                             bridged_http_configs,
                             bridge,
                             sandbox=self.sandbox,
+                            timeout=self.mcp_ready_timeout,
                             required=True,
                         )
 

--- a/tests/test_codex_config.py
+++ b/tests/test_codex_config.py
@@ -6,6 +6,7 @@ from inspect_ai.tool._mcp._config import MCPServerConfigHTTP
 from inspect_swe import codex_cli, interactive_codex_cli
 from inspect_swe._codex_cli.config import (
     GUARDIAN_MODEL_SLUG,
+    MCP_STARTUP_TIMEOUT_SEC,
     CodexApprovalPolicy,
     CodexAutoReview,
     CodexSandboxMode,
@@ -527,7 +528,7 @@ def test_bridged_mcp_server_is_marked_required() -> None:
         type="http", name="bridged-tools", url="http://localhost:9000/mcp"
     )
 
-    config = codex_mcp_server_config(server, {"bridged-tools"})
+    config = codex_mcp_server_config(server, {"bridged-tools"}, None)
 
     assert config["required"] is True
     assert "name" not in config
@@ -540,9 +541,39 @@ def test_static_mcp_server_is_not_marked_required() -> None:
         type="http", name="caller-tools", url="http://localhost:9001/mcp"
     )
 
-    config = codex_mcp_server_config(server, {"bridged-tools"})
+    config = codex_mcp_server_config(server, {"bridged-tools"}, None)
 
     assert "required" not in config
+
+
+def test_bridged_mcp_server_gets_the_startup_timeout() -> None:
+    server = MCPServerConfigHTTP(
+        type="http", name="bridged-tools", url="http://localhost:9000/mcp"
+    )
+
+    config = codex_mcp_server_config(server, {"bridged-tools"}, MCP_STARTUP_TIMEOUT_SEC)
+
+    assert config["startup_timeout_sec"] == 300
+
+
+def test_static_mcp_server_keeps_codex_default_startup_timeout() -> None:
+    server = MCPServerConfigHTTP(
+        type="http", name="caller-tools", url="http://localhost:9001/mcp"
+    )
+
+    config = codex_mcp_server_config(server, {"bridged-tools"}, MCP_STARTUP_TIMEOUT_SEC)
+
+    assert "startup_timeout_sec" not in config
+
+
+def test_bridged_mcp_server_accepts_an_explicit_startup_timeout() -> None:
+    server = MCPServerConfigHTTP(
+        type="http", name="bridged-tools", url="http://localhost:9000/mcp"
+    )
+
+    config = codex_mcp_server_config(server, {"bridged-tools"}, 60)
+
+    assert config["startup_timeout_sec"] == 60
 
 
 def test_codex_cli_rejects_non_bool_centaur() -> None:
@@ -595,13 +626,21 @@ def test_codex_mcp_servers_toml_gates_on_force_approve() -> None:
     bridged_server_names = {"bridged-tools"}
 
     static_toml = codex_mcp_servers_toml(
-        [static], bridged_server_names, "never", force_approve=False
+        [static],
+        bridged_server_names,
+        "never",
+        force_approve=False,
+        bridged_startup_timeout=MCP_STARTUP_TIMEOUT_SEC,
     )
     assert "default_tools_approval_mode" not in static_toml["mcp_servers.caller-tools"]
     assert "required" not in static_toml["mcp_servers.caller-tools"]
 
     static_opted_in = codex_mcp_servers_toml(
-        [static], bridged_server_names, "never", force_approve=True
+        [static],
+        bridged_server_names,
+        "never",
+        force_approve=True,
+        bridged_startup_timeout=MCP_STARTUP_TIMEOUT_SEC,
     )
     assert (
         static_opted_in["mcp_servers.caller-tools"]["default_tools_approval_mode"]
@@ -609,7 +648,11 @@ def test_codex_mcp_servers_toml_gates_on_force_approve() -> None:
     )
 
     bridged_toml = codex_mcp_servers_toml(
-        [bridged], bridged_server_names, "never", force_approve=True
+        [bridged],
+        bridged_server_names,
+        "never",
+        force_approve=True,
+        bridged_startup_timeout=MCP_STARTUP_TIMEOUT_SEC,
     )
     assert (
         bridged_toml["mcp_servers.bridged-tools"]["default_tools_approval_mode"]

--- a/tests/test_mcp_ready.py
+++ b/tests/test_mcp_ready.py
@@ -720,3 +720,160 @@ def test_slow_probes_count_against_the_wall_clock_timeout() -> None:
         f"timeout ignored probe duration: {calls} probes ran, wall-clock "
         "deadline should have stopped after ~4"
     )
+
+
+def _param_default(fn: ast.FunctionDef | ast.AsyncFunctionDef, name: str) -> ast.expr:
+    """The AST default expression bound to parameter ``name`` of ``fn``.
+
+    Handles positional-or-keyword parameters via the offset between ``args``
+    and ``defaults`` -- computing ``timeout_index - first_default_index`` and
+    trusting it to be non-negative is not safe: a parameter with no default at
+    all produces a negative offset, and Python's negative indexing then
+    silently returns a *different* parameter's default instead of raising.
+    Also handles keyword-only parameters, which live in
+    ``kwonlyargs``/``kw_defaults`` and never touch ``args.defaults`` at all --
+    a factory that made this parameter keyword-only would otherwise blow up
+    the lookup with a bare, unlabeled ``StopIteration``.
+    """
+    offset = len(fn.args.args) - len(fn.args.defaults)
+    for i, arg in enumerate(fn.args.args):
+        if arg.arg == name:
+            assert i >= offset, f"{fn.name}: {name} has no default"
+            return fn.args.defaults[i - offset]
+    for arg, default in zip(fn.args.kwonlyargs, fn.args.kw_defaults, strict=True):
+        if arg.arg == name:
+            assert default is not None, f"{fn.name}: {name} has no default"
+            return default
+    raise AssertionError(f"{fn.name}() has no parameter named {name!r}")
+
+
+def test_every_gated_call_site_forwards_a_configurable_mcp_ready_timeout() -> None:
+    """Auto-discover every gate instead of hand-listing the agents that have one.
+
+    This used to hand-list six agent modules in a dict. That is the same
+    omission mechanism ``test_every_self_launching_bridged_agent_gates_on_mcp_readiness``
+    above exists to catch for the gate itself: a seventh gated agent, or a new
+    gate added to a module absent from the dict, could await
+    ``wait_for_mcp_endpoints`` without forwarding a configurable timeout and
+    this suite would stay green until someone remembered to update the dict --
+    which is exactly how OpenCode and ACP were previously missed here (see
+    that test's docstring). So this walks every awaited
+    ``wait_for_mcp_endpoints`` call under the package instead, the same way
+    the two tests above walk every module for the gate itself.
+
+    A discovered call's ``timeout=`` must be a bare name or an attribute
+    access -- never a literal, which would not be caller-configurable. For a
+    bare name (every top-level agent factory), that name must also be a
+    parameter of its enclosing top-level function, and that parameter's own
+    default must be ``DEFAULT_MCP_READY_TIMEOUT``. For an attribute access
+    (ACP's ``self.mcp_ready_timeout``, resolved via ``TypedDict`` +
+    ``kwargs.get`` rather than a plain parameter default) only the
+    caller-configurable shape is checked here; ACP's own default is pinned by
+    ``test_acp_agent_forwards_configured_mcp_readiness_timeout`` below.
+    """
+    root = Path(__file__).parent.parent / "src" / "inspect_swe"
+
+    def _call_name(call: ast.Call) -> str | None:
+        func = call.func
+        return (
+            func.attr
+            if isinstance(func, ast.Attribute)
+            else (func.id if isinstance(func, ast.Name) else None)
+        )
+
+    def _gated_calls(node: ast.AST) -> list[ast.Call]:
+        return [
+            n.value
+            for n in ast.walk(node)
+            if isinstance(n, ast.Await)
+            and isinstance(n.value, ast.Call)
+            and _call_name(n.value) == "wait_for_mcp_endpoints"
+        ]
+
+    def _enclosing_function(
+        call: ast.Call, functions: list[ast.FunctionDef | ast.AsyncFunctionDef]
+    ) -> ast.FunctionDef | ast.AsyncFunctionDef | None:
+        for function in functions:
+            if any(node is call for node in ast.walk(function)):
+                return function
+        return None
+
+    covered: set[str] = set()
+    offenders: list[str] = []
+    for path in sorted(root.rglob("*.py")):
+        if path.name == "mcp_ready.py":
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        rel = path.relative_to(root).as_posix()
+        top_level_functions = [
+            node
+            for node in tree.body
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        ]
+
+        for call in _gated_calls(tree):
+            covered.add(rel)
+            label = f"{rel}:{call.lineno}"
+            timeout_kw = next((kw for kw in call.keywords if kw.arg == "timeout"), None)
+            if timeout_kw is None:
+                offenders.append(f"{label} passes no timeout=")
+                continue
+            if not isinstance(timeout_kw.value, (ast.Name, ast.Attribute)):
+                offenders.append(
+                    f"{label} timeout= is not forwarded from a caller-"
+                    f"configurable name or attribute: {ast.dump(timeout_kw.value)}"
+                )
+                continue
+            if not isinstance(timeout_kw.value, ast.Name):
+                continue  # e.g. ACP's `self.mcp_ready_timeout`; checked below.
+
+            param_name = timeout_kw.value.id
+            function = _enclosing_function(call, top_level_functions)
+            if function is None:
+                offenders.append(
+                    f"{label} timeout={param_name} is not inside a top-level "
+                    "factory function whose default can be checked"
+                )
+                continue
+            try:
+                default = _param_default(function, param_name)
+            except AssertionError as error:
+                offenders.append(f"{rel}:{function.name}: {error}")
+                continue
+            if not (
+                isinstance(default, ast.Name)
+                and default.id == "DEFAULT_MCP_READY_TIMEOUT"
+            ):
+                offenders.append(
+                    f"{rel}:{function.name}: {param_name} does not default to "
+                    "DEFAULT_MCP_READY_TIMEOUT"
+                )
+
+    assert covered, "found no wait_for_mcp_endpoints call sites to check"
+    assert offenders == [], offenders
+
+
+def test_acp_agent_forwards_configured_mcp_readiness_timeout() -> None:
+    """Pin ACP's `TypedDict` field; the call site's shape is checked elsewhere.
+
+    ACP resolves its timeout via `TypedDict` + `kwargs.get`, not a plain
+    parameter default, so it can't be discovered the way the auto-discovered
+    factories above are. The call site's shape (a caller-configurable
+    `timeout=`) is covered by
+    `test_every_gated_call_site_forwards_a_configurable_mcp_ready_timeout`;
+    this only pins the `TypedDict` field.
+    """
+    path = Path(__file__).parent.parent / "src" / "inspect_swe" / "acp" / "agent.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    params = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "ACPAgentParams"
+    )
+
+    assert any(
+        isinstance(node, ast.AnnAssign)
+        and isinstance(node.target, ast.Name)
+        and node.target.id == "mcp_ready_timeout"
+        for node in params.body
+    )


### PR DESCRIPTION
## Scope

Follow-up to #106. Adds `mcp_ready_timeout` to every gated agent entry point, including OpenCode and the public ACP base path. Each readiness wait receives the configured value.

Codex now applies a 300-second MCP startup timeout only to bridged servers. Static caller-provided servers retain Codex defaults. `mcp_startup_timeout` permits an explicit bridged-server value or `None` for the Codex default.

All affected agent option tables document the timeout settings.

## Verification

Claude ran `tests/test_mcp_ready.py` and `tests/test_codex_config.py`: 57 passed. Claude ran ruff on the changed Python paths: passed. The repository-wide mypy gate passes on CI for 3.10 and 3.11.
