### PR TITLE
feat: expose agent binary installation APIs

### DIFF
--- a/src/inspect_swe/__init__.py
+++ b/src/inspect_swe/__init__.py
@@ -1,5 +1,7 @@
 from ._antigravity.antigravity import antigravity
+from ._claude_code.agentbinary import claude_code_binary_source
 from ._claude_code.claude_code import claude_code
+from ._codex_cli.agentbinary import codex_cli_binary_source
 from ._codex_cli.codex_cli import codex_cli
 from ._codex_cli.config import CodexAutoReview
 from ._gemini_cli.gemini_cli import gemini_cli
@@ -7,6 +9,7 @@ from ._kimi_code.kimi_code import kimi_code
 from ._mini_swe_agent.mini_swe_agent import mini_swe_agent
 from ._opencode.opencode import opencode
 from ._tools.download import AgentBinary, cached_agent_binaries, download_agent_binary
+from ._util.agentbinary import ensure_agent_binary_installed
 from ._util.agentwheel import download_wheels_tarball
 from ._util.centaur import CentaurOptions
 from ._util.sandbox import SandboxPlatform
@@ -27,7 +30,9 @@ __all__ = [
     "acp_connection",
     "bridge_mcp_to_acp",
     "antigravity",
+    "claude_code_binary_source",
     "claude_code",
+    "codex_cli_binary_source",
     "codex_cli",
     "gemini_cli",
     "kimi_code",
@@ -44,4 +49,5 @@ __all__ = [
     "CodexAutoReview",
     "__version__",
     "download_wheels_tarball",
+    "ensure_agent_binary_installed",
 ]

--- a/tests/test_codex_agentbinary.py
+++ b/tests/test_codex_agentbinary.py
@@ -65,6 +65,25 @@ def test_codex_models_catalog_falls_back_to_bundled_on_fetch_error(
         assert not cache_file.exists()
 
 
+def test_agentbinary_installation_api_is_public() -> None:
+    # Given
+    from inspect_swe import (
+        claude_code_binary_source,
+        codex_cli_binary_source,
+        ensure_agent_binary_installed,
+    )
+
+    # When
+    public_api = (
+        ensure_agent_binary_installed,
+        claude_code_binary_source,
+        codex_cli_binary_source,
+    )
+
+    # Then
+    assert all(callable(symbol) for symbol in public_api)
+
+
 @skip_if_github_action
 def test_bundled_catalog_tracks_live_latest() -> None:
     """Drift check for the bundled fallback (``_bundled_catalog.py``).


### PR DESCRIPTION
## Summary
- Expose the async agent binary installer and Claude Code/Codex source factories from inspect_swe.
- Add a public-import regression test.

## Verification
A fresh reviewer imported ensure_agent_binary_installed, claude_code_binary_source, and codex_cli_binary_source from inspect_swe and confirmed each is callable. The focused Codex agent-binary test suite passes (9 tests).