### PR TITLE
fix: send GITHUB_TOKEN on GitHub API requests to avoid rate limits

### DIFF
--- a/src/inspect_swe/_util/download.py
+++ b/src/inspect_swe/_util/download.py
@@ -1,9 +1,30 @@
+import os
+from urllib.parse import urlparse
+
 import httpx
+
+
+def github_api_headers(url: str) -> dict[str, str]:
+    """Auth headers for GitHub API requests.
+
+    Unauthenticated requests to api.github.com are limited to 60/hour per IP,
+    which shared CI runner IPs routinely exhaust (403 "rate limit exceeded").
+    Sending a token raises the limit to 5,000/hour. The token is scoped to
+    api.github.com only so it is never sent to other hosts (e.g. release-asset
+    downloads that redirect to objects.githubusercontent.com).
+    """
+    if urlparse(url).hostname == "api.github.com":
+        token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+        if token:
+            return {"Authorization": f"Bearer {token}"}
+    return {}
 
 
 async def download_file(url: str) -> bytes:
     async with httpx.AsyncClient() as client:
-        response = await client.get(url, follow_redirects=True)
+        response = await client.get(
+            url, follow_redirects=True, headers=github_api_headers(url)
+        )
         response.raise_for_status()
         return response.content
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -177,6 +177,49 @@ def test_mini_swe_agent_cache_hit(wheels_cache_cleanup: Path) -> None:
     assert cache_file.stat().st_atime >= cache_mtime
 
 
+def test_github_api_headers_uses_token_for_api_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from inspect_swe._util.download import github_api_headers
+
+    monkeypatch.setenv("GITHUB_TOKEN", "test-token")
+    headers = github_api_headers("https://api.github.com/repos/openai/codex/releases")
+    assert headers == {"Authorization": "Bearer test-token"}
+
+
+def test_github_api_headers_falls_back_to_gh_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from inspect_swe._util.download import github_api_headers
+
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setenv("GH_TOKEN", "gh-token")
+    headers = github_api_headers("https://api.github.com/repos/openai/codex/releases")
+    assert headers == {"Authorization": "Bearer gh-token"}
+
+
+def test_github_api_headers_empty_without_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from inspect_swe._util.download import github_api_headers
+
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    assert github_api_headers("https://api.github.com/repos/openai/codex") == {}
+
+
+def test_github_api_headers_never_sent_to_other_hosts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from inspect_swe._util.download import github_api_headers
+
+    monkeypatch.setenv("GITHUB_TOKEN", "test-token")
+    assert github_api_headers("https://objects.githubusercontent.com/asset") == {}
+    assert github_api_headers("https://raw.githubusercontent.com/x/y") == {}
+    assert github_api_headers("https://code.kimi.com/kimi-code/latest.json") == {}
+    assert github_api_headers("https://evil.example.com/api.github.com/x") == {}
+
+
 def test_ensure_pip_available_noop_when_present() -> None:
     from inspect_swe._util.agentwheel import _ensure_pip_available
 


### PR DESCRIPTION
Fixes #125

Nightly slow tests failed 19 tests because unauthenticated requests to
api.github.com (codex/gemini/opencode release resolution) hit GitHub's
60/hour per-IP rate limit, which shared CI runner IPs routinely exhaust.
Attach a Bearer token from GITHUB_TOKEN (or GH_TOKEN) when downloading
from api.github.com, raising the limit to 5,000/hour. The token is
scoped to that host only so it never leaks to asset-download redirects
or non-GitHub hosts.

Co-authored-by: Charles Teague <261654+dragonstyle@users.noreply.github.com>