### PR TITLE
fix: resolve npm agent versions once per process to avoid GitHub rate limits

### DIFF
--- a/src/inspect_swe/_gemini_cli/agentbinary.py
+++ b/src/inspect_swe/_gemini_cli/agentbinary.py
@@ -15,6 +15,7 @@ from .._util.sandbox import (
     bash_command,
     detect_sandbox_platform,
 )
+from .._util.versioncache import cached_version_resolution
 
 
 async def ensure_gemini_cli_setup(
@@ -40,10 +41,17 @@ async def resolve_gemini_version(
 ) -> str:
     """Resolve version string to an actual semver version."""
     if version in ["auto", "sandbox", "stable", "latest"]:
-        release = await _fetch_latest_release()
-        return str(release["tag_name"]).lstrip("v")
+        # cached so concurrent samples don't each hit the (rate-limited)
+        # GitHub API — all four aliases resolve to the same latest release
+        return await cached_version_resolution("gemini-cli", _fetch_latest_version)
 
     return version
+
+
+async def _fetch_latest_version() -> str:
+    """Fetch the latest released gemini-cli version from GitHub."""
+    release = await _fetch_latest_release()
+    return str(release["tag_name"]).lstrip("v")
 
 
 async def ensure_gemini_cli_installed(

--- a/src/inspect_swe/_opencode/agentbinary.py
+++ b/src/inspect_swe/_opencode/agentbinary.py
@@ -16,6 +16,7 @@ from .._util.sandbox import (
     bash_command,
     detect_sandbox_platform,
 )
+from .._util.versioncache import cached_version_resolution
 
 
 async def ensure_opencode_setup(
@@ -44,10 +45,17 @@ async def resolve_opencode_version(
 ) -> str:
     """Resolve version string to an actual semver version."""
     if version in ["auto", "sandbox", "stable", "latest"]:
-        release = await _fetch_latest_release()
-        return str(release["tag_name"]).lstrip("v")
+        # cached so concurrent samples don't each hit the (rate-limited)
+        # GitHub API — all four aliases resolve to the same latest release
+        return await cached_version_resolution("opencode", _fetch_latest_version)
 
     return version
+
+
+async def _fetch_latest_version() -> str:
+    """Fetch the latest released opencode version from GitHub."""
+    release = await _fetch_latest_release()
+    return str(release["tag_name"]).lstrip("v")
 
 
 async def ensure_opencode_installed(

--- a/src/inspect_swe/_util/versioncache.py
+++ b/src/inspect_swe/_util/versioncache.py
@@ -14,10 +14,14 @@ from typing import Awaitable, Callable
 
 from inspect_ai.util import concurrency
 
-# Guards the cache dict. Held only across synchronous dict access, never an
+# Guards the cache dicts. Held only across synchronous dict access, never an
 # await.
 _resolve_lock = threading.Lock()
 _resolved_versions: dict[str, str] = {}
+# per key: (number of failed resolutions so far, exception from the latest
+# one). Lets callers already queued behind a failing resolution share its
+# exception instead of each retrying in turn.
+_failed_resolutions: dict[str, tuple[int, Exception]] = {}
 
 
 async def cached_version_resolution(
@@ -26,8 +30,10 @@ async def cached_version_resolution(
     """Resolve a version, reusing the result for the process lifetime.
 
     Concurrent callers for the same key share a single resolution rather than
-    each issuing their own request. Failures are not cached, so a later caller
-    retries.
+    each issuing their own request — including its failure, so a burst of
+    callers hitting a rate-limited API produces one error, not one per caller.
+    Failures are not cached: a call arriving after a failed resolution has
+    completed retries.
 
     Args:
         key: Cache key identifying what is being resolved (e.g. ``"opencode"``).
@@ -36,24 +42,31 @@ async def cached_version_resolution(
     Returns:
         The resolved version string.
     """
-    cached = _cached(key)
-    if cached is not None:
-        return cached
+    with _resolve_lock:
+        cached = _resolved_versions.get(key)
+        if cached is not None:
+            return cached
+        failure = _failed_resolutions.get(key)
+        failures_at_arrival = failure[0] if failure is not None else 0
 
     # serialize per key so a burst of samples starting together makes one
     # request rather than one each
     async with concurrency(f"version-resolution-{key}", 1, visible=False):
-        # another sample may have resolved while we were waiting
-        cached = _cached(key)
-        if cached is not None:
-            return cached
+        # another sample may have resolved (or failed) while we were waiting
+        with _resolve_lock:
+            cached = _resolved_versions.get(key)
+            if cached is not None:
+                return cached
+            failure = _failed_resolutions.get(key)
+        if failure is not None and failure[0] > failures_at_arrival:
+            raise failure[1]
 
-        version = await resolve()
+        try:
+            version = await resolve()
+        except Exception as ex:
+            with _resolve_lock:
+                _failed_resolutions[key] = (failures_at_arrival + 1, ex)
+            raise
         with _resolve_lock:
             _resolved_versions[key] = version
         return version
-
-
-def _cached(key: str) -> str | None:
-    with _resolve_lock:
-        return _resolved_versions.get(key)

--- a/src/inspect_swe/_util/versioncache.py
+++ b/src/inspect_swe/_util/versioncache.py
@@ -8,18 +8,19 @@ to 60/hour per IP, which one ordinary eval can exhaust on its own.
 
 Agents installed via ``AgentBinarySource`` have an equivalent cache in
 ``agentbinary.download_agent_binary_async``.
-
-We use a ``threading.Lock`` (not ``anyio.Lock``) because it only guards
-synchronous dict reads/writes — never held across an await — and avoids
-issues with module-level anyio locks binding to a stale event loop across
-multiple ``anyio.run()`` calls. No expiry: entries live for the process
-lifetime. Two callers may race and both resolve, but this is benign (same
-result) and merely costs one extra request.
 """
 
 import threading
 from typing import Awaitable, Callable
 
+from inspect_ai.util import concurrency
+
+# Guards the cache dict. A threading.Lock rather than an async lock because it
+# only wraps synchronous dict access — never held across an await, so it can
+# neither stall the event loop nor deadlock — and because a module-level async
+# lock binds its waiter state to whichever event loop first uses it. That
+# breaks as soon as the process runs a second loop, which every anyio.run()
+# call does (the test suite runs one per test).
 _resolve_lock = threading.Lock()
 _resolved_versions: dict[str, str] = {}
 
@@ -29,6 +30,10 @@ async def cached_version_resolution(
 ) -> str:
     """Resolve a version, reusing the result for the process lifetime.
 
+    Concurrent callers for the same key share a single resolution rather than
+    each issuing their own request. Failures are not cached, so a later caller
+    retries.
+
     Args:
         key: Cache key identifying what is being resolved (e.g. ``"opencode"``).
         resolve: Called to resolve the version on a cache miss.
@@ -36,13 +41,27 @@ async def cached_version_resolution(
     Returns:
         The resolved version string.
     """
-    with _resolve_lock:
-        cached = _resolved_versions.get(key)
+    cached = _cached(key)
     if cached is not None:
         return cached
 
-    version = await resolve()
+    # Serialize resolution per key so that a burst of samples starting together
+    # makes one request rather than one each. concurrency() is inspect's own
+    # async primitive, so unlike a module-level anyio.Lock it holds no state
+    # tied to a particular event loop.
+    async with concurrency(f"version-resolution-{key}", 1, visible=False):
+        # re-check now that we hold the lock: another sample may have resolved
+        # while we were waiting for it
+        cached = _cached(key)
+        if cached is not None:
+            return cached
 
+        version = await resolve()
+        with _resolve_lock:
+            _resolved_versions[key] = version
+        return version
+
+
+def _cached(key: str) -> str | None:
     with _resolve_lock:
-        _resolved_versions[key] = version
-    return version
+        return _resolved_versions.get(key)

--- a/src/inspect_swe/_util/versioncache.py
+++ b/src/inspect_swe/_util/versioncache.py
@@ -1,10 +1,9 @@
 """In-process cache for upstream version resolution.
 
-Agents that install from npm resolve their version on every sample (the
-install itself is guarded by ``concurrency()``, but resolution runs ahead
-of it), so without caching a single multi-sample eval issues one
-``api.github.com`` request per sample. Unauthenticated requests are limited
-to 60/hour per IP, which one ordinary eval can exhaust on its own.
+Agents that install from npm resolve their version on every sample, so
+without caching a single multi-sample eval issues one ``api.github.com``
+request per sample. Unauthenticated requests are limited to 60/hour per IP,
+which one ordinary eval can exhaust on its own.
 
 Agents installed via ``AgentBinarySource`` have an equivalent cache in
 ``agentbinary.download_agent_binary_async``.
@@ -15,12 +14,8 @@ from typing import Awaitable, Callable
 
 from inspect_ai.util import concurrency
 
-# Guards the cache dict. A threading.Lock rather than an async lock because it
-# only wraps synchronous dict access — never held across an await, so it can
-# neither stall the event loop nor deadlock — and because a module-level async
-# lock binds its waiter state to whichever event loop first uses it. That
-# breaks as soon as the process runs a second loop, which every anyio.run()
-# call does (the test suite runs one per test).
+# Guards the cache dict. Held only across synchronous dict access, never an
+# await.
 _resolve_lock = threading.Lock()
 _resolved_versions: dict[str, str] = {}
 
@@ -45,13 +40,10 @@ async def cached_version_resolution(
     if cached is not None:
         return cached
 
-    # Serialize resolution per key so that a burst of samples starting together
-    # makes one request rather than one each. concurrency() is inspect's own
-    # async primitive, so unlike a module-level anyio.Lock it holds no state
-    # tied to a particular event loop.
+    # serialize per key so a burst of samples starting together makes one
+    # request rather than one each
     async with concurrency(f"version-resolution-{key}", 1, visible=False):
-        # re-check now that we hold the lock: another sample may have resolved
-        # while we were waiting for it
+        # another sample may have resolved while we were waiting
         cached = _cached(key)
         if cached is not None:
             return cached

--- a/src/inspect_swe/_util/versioncache.py
+++ b/src/inspect_swe/_util/versioncache.py
@@ -1,0 +1,48 @@
+"""In-process cache for upstream version resolution.
+
+Agents that install from npm resolve their version on every sample (the
+install itself is guarded by ``concurrency()``, but resolution runs ahead
+of it), so without caching a single multi-sample eval issues one
+``api.github.com`` request per sample. Unauthenticated requests are limited
+to 60/hour per IP, which one ordinary eval can exhaust on its own.
+
+Agents installed via ``AgentBinarySource`` have an equivalent cache in
+``agentbinary.download_agent_binary_async``.
+
+We use a ``threading.Lock`` (not ``anyio.Lock``) because it only guards
+synchronous dict reads/writes — never held across an await — and avoids
+issues with module-level anyio locks binding to a stale event loop across
+multiple ``anyio.run()`` calls. No expiry: entries live for the process
+lifetime. Two callers may race and both resolve, but this is benign (same
+result) and merely costs one extra request.
+"""
+
+import threading
+from typing import Awaitable, Callable
+
+_resolve_lock = threading.Lock()
+_resolved_versions: dict[str, str] = {}
+
+
+async def cached_version_resolution(
+    key: str, resolve: Callable[[], Awaitable[str]]
+) -> str:
+    """Resolve a version, reusing the result for the process lifetime.
+
+    Args:
+        key: Cache key identifying what is being resolved (e.g. ``"opencode"``).
+        resolve: Called to resolve the version on a cache miss.
+
+    Returns:
+        The resolved version string.
+    """
+    with _resolve_lock:
+        cached = _resolved_versions.get(key)
+    if cached is not None:
+        return cached
+
+    version = await resolve()
+
+    with _resolve_lock:
+        _resolved_versions[key] = version
+    return version

--- a/tests/test_version_cache.py
+++ b/tests/test_version_cache.py
@@ -1,0 +1,148 @@
+"""Unit tests for in-process caching of upstream version resolution.
+
+npm-installed agents resolve their version on every sample, so without
+caching a single multi-sample eval issues one api.github.com request per
+sample and can exhaust the 60/hour unauthenticated rate limit on its own.
+"""
+
+from typing import Any, Iterator
+from unittest.mock import AsyncMock, patch
+
+import anyio
+import pytest
+from inspect_swe._gemini_cli import agentbinary as gemini_agentbinary
+from inspect_swe._opencode import agentbinary as opencode_agentbinary
+from inspect_swe._util import versioncache
+from inspect_swe._util.versioncache import cached_version_resolution
+
+
+@pytest.fixture(autouse=True)
+def clear_version_cache() -> Iterator[None]:
+    versioncache._resolved_versions.clear()
+    yield
+    versioncache._resolved_versions.clear()
+
+
+def test_cached_version_resolution_resolves_once() -> None:
+    calls = 0
+
+    async def resolve() -> str:
+        nonlocal calls
+        calls += 1
+        return "1.2.3"
+
+    async def run() -> None:
+        assert await cached_version_resolution("agent", resolve) == "1.2.3"
+        assert await cached_version_resolution("agent", resolve) == "1.2.3"
+
+    anyio.run(run)
+    assert calls == 1
+
+
+def test_cached_version_resolution_keys_are_independent() -> None:
+    async def run() -> None:
+        assert await cached_version_resolution("a", _const("1.0.0")) == "1.0.0"
+        assert await cached_version_resolution("b", _const("2.0.0")) == "2.0.0"
+        # each key keeps its own entry
+        assert await cached_version_resolution("a", _const("9.9.9")) == "1.0.0"
+
+    anyio.run(run)
+
+
+def _const(value: str) -> Any:
+    async def resolve() -> str:
+        return value
+
+    return resolve
+
+
+@pytest.mark.parametrize(
+    "module,resolve_name,cache_key",
+    [
+        (gemini_agentbinary, "resolve_gemini_version", "gemini-cli"),
+        (opencode_agentbinary, "resolve_opencode_version", "opencode"),
+    ],
+)
+def test_latest_resolution_fetches_once_across_calls(
+    module: Any, resolve_name: str, cache_key: str
+) -> None:
+    """Repeated 'latest' resolution (one per sample) hits the API once."""
+    resolve = getattr(module, resolve_name)
+    fetch = AsyncMock(return_value={"tag_name": "v1.2.3"})
+
+    async def run() -> None:
+        with patch.object(module, "_fetch_latest_release", fetch):
+            for _ in range(5):
+                assert await resolve("latest") == "1.2.3"
+
+    anyio.run(run)
+    fetch.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    "module,resolve_name",
+    [
+        (gemini_agentbinary, "resolve_gemini_version"),
+        (opencode_agentbinary, "resolve_opencode_version"),
+    ],
+)
+def test_version_aliases_share_a_cache_entry(module: Any, resolve_name: str) -> None:
+    """auto/sandbox/stable/latest all mean 'the latest release' -> one fetch."""
+    resolve = getattr(module, resolve_name)
+    fetch = AsyncMock(return_value={"tag_name": "v1.2.3"})
+
+    async def run() -> None:
+        with patch.object(module, "_fetch_latest_release", fetch):
+            for alias in ("auto", "sandbox", "stable", "latest"):
+                assert await resolve(alias) == "1.2.3"
+
+    anyio.run(run)
+    fetch.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    "module,resolve_name",
+    [
+        (gemini_agentbinary, "resolve_gemini_version"),
+        (opencode_agentbinary, "resolve_opencode_version"),
+    ],
+)
+def test_explicit_version_never_fetches(module: Any, resolve_name: str) -> None:
+    """An explicit semver is returned as-is and is not cached as 'latest'."""
+    resolve = getattr(module, resolve_name)
+    fetch = AsyncMock(return_value={"tag_name": "v9.9.9"})
+
+    async def run() -> None:
+        with patch.object(module, "_fetch_latest_release", fetch):
+            assert await resolve("1.14.30") == "1.14.30"
+
+    anyio.run(run)
+    fetch.assert_not_awaited()
+    assert versioncache._resolved_versions == {}
+
+
+@pytest.mark.parametrize(
+    "module,resolve_name",
+    [
+        (gemini_agentbinary, "resolve_gemini_version"),
+        (opencode_agentbinary, "resolve_opencode_version"),
+    ],
+)
+def test_concurrent_resolution_is_shared(module: Any, resolve_name: str) -> None:
+    """Concurrent samples resolving at once all get the same version."""
+    resolve = getattr(module, resolve_name)
+    fetch = AsyncMock(return_value={"tag_name": "v1.2.3"})
+    results: list[str] = []
+
+    async def run() -> None:
+        with patch.object(module, "_fetch_latest_release", fetch):
+
+            async def one() -> None:
+                results.append(await resolve("latest"))
+
+            async with anyio.create_task_group() as tg:
+                for _ in range(10):
+                    tg.start_soon(one)
+
+    anyio.run(run)
+    assert results == ["1.2.3"] * 10

--- a/tests/test_version_cache.py
+++ b/tests/test_version_cache.py
@@ -19,8 +19,10 @@ from inspect_swe._util.versioncache import cached_version_resolution
 @pytest.fixture(autouse=True)
 def clear_version_cache() -> Iterator[None]:
     versioncache._resolved_versions.clear()
+    versioncache._failed_resolutions.clear()
     yield
     versioncache._resolved_versions.clear()
+    versioncache._failed_resolutions.clear()
 
 
 def test_cached_version_resolution_resolves_once() -> None:
@@ -157,6 +159,56 @@ def test_concurrent_resolution_makes_one_request(
     anyio.run(run)
     assert results == ["1.2.3"] * 10
     assert calls == 1
+
+
+@pytest.mark.parametrize(
+    "module,resolve_name",
+    [
+        (gemini_agentbinary, "resolve_gemini_version"),
+        (opencode_agentbinary, "resolve_opencode_version"),
+    ],
+)
+def test_concurrent_failure_is_shared(module: Any, resolve_name: str) -> None:
+    """Callers queued behind a failing fetch share its error, not retry it."""
+    resolve = getattr(module, resolve_name)
+    calls = 0
+    errors: list[Exception] = []
+
+    async def fetch() -> dict[str, str]:
+        nonlocal calls
+        calls += 1
+        # suspend so the other tasks reach the cache miss while this one
+        # is still in flight
+        await anyio.sleep(0.05)
+        raise RuntimeError("403 rate limited")
+
+    async def run() -> None:
+        with patch.object(module, "_fetch_latest_release", fetch):
+
+            async def one() -> None:
+                try:
+                    await resolve("latest")
+                except RuntimeError as ex:
+                    errors.append(ex)
+
+            async with anyio.create_task_group() as tg:
+                for _ in range(10):
+                    tg.start_soon(one)
+
+    anyio.run(run)
+    assert calls == 1
+    assert len(errors) == 10
+    assert all(error is errors[0] for error in errors)
+
+    # a genuinely later call (after the failure completed) retries
+    recovered = AsyncMock(return_value={"tag_name": "v1.2.3"})
+
+    async def retry() -> None:
+        with patch.object(module, "_fetch_latest_release", recovered):
+            assert await resolve("latest") == "1.2.3"
+
+    anyio.run(retry)
+    recovered.assert_awaited_once()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_version_cache.py
+++ b/tests/test_version_cache.py
@@ -139,8 +139,8 @@ def test_concurrent_resolution_makes_one_request(
     async def fetch() -> dict[str, str]:
         nonlocal calls
         calls += 1
-        # suspend so the other tasks reach the cache miss while this is
-        # in flight — without single-flight they would each fetch too
+        # suspend so the other tasks reach the cache miss while this one
+        # is still in flight
         await anyio.sleep(0.05)
         return {"tag_name": "v1.2.3"}
 

--- a/tests/test_version_cache.py
+++ b/tests/test_version_cache.py
@@ -128,11 +128,21 @@ def test_explicit_version_never_fetches(module: Any, resolve_name: str) -> None:
         (opencode_agentbinary, "resolve_opencode_version"),
     ],
 )
-def test_concurrent_resolution_is_shared(module: Any, resolve_name: str) -> None:
-    """Concurrent samples resolving at once all get the same version."""
+def test_concurrent_resolution_makes_one_request(
+    module: Any, resolve_name: str
+) -> None:
+    """A cold-start burst of samples shares one request, not one each."""
     resolve = getattr(module, resolve_name)
-    fetch = AsyncMock(return_value={"tag_name": "v1.2.3"})
+    calls = 0
     results: list[str] = []
+
+    async def fetch() -> dict[str, str]:
+        nonlocal calls
+        calls += 1
+        # suspend so the other tasks reach the cache miss while this is
+        # in flight — without single-flight they would each fetch too
+        await anyio.sleep(0.05)
+        return {"tag_name": "v1.2.3"}
 
     async def run() -> None:
         with patch.object(module, "_fetch_latest_release", fetch):
@@ -146,3 +156,26 @@ def test_concurrent_resolution_is_shared(module: Any, resolve_name: str) -> None
 
     anyio.run(run)
     assert results == ["1.2.3"] * 10
+    assert calls == 1
+
+
+@pytest.mark.parametrize(
+    "module,resolve_name",
+    [
+        (gemini_agentbinary, "resolve_gemini_version"),
+        (opencode_agentbinary, "resolve_opencode_version"),
+    ],
+)
+def test_failed_resolution_is_not_cached(module: Any, resolve_name: str) -> None:
+    """A failed fetch doesn't poison the cache; the next caller retries."""
+    resolve = getattr(module, resolve_name)
+    fetch = AsyncMock(side_effect=[RuntimeError("boom"), {"tag_name": "v1.2.3"}])
+
+    async def run() -> None:
+        with patch.object(module, "_fetch_latest_release", fetch):
+            with pytest.raises(RuntimeError):
+                await resolve("latest")
+            assert await resolve("latest") == "1.2.3"
+
+    anyio.run(run)
+    assert fetch.await_count == 2


### PR DESCRIPTION
Alternative to #126 for the nightly failures in #125, fixing the cause rather than raising the ceiling.

## The problem

`gemini_cli` and `opencode` resolve their version by calling `api.github.com/repos/.../releases/latest` **once per sample**:

- `_gemini_cli/agentbinary.py` → `resolve_gemini_version()` → `_fetch_latest_release()`
- `_opencode/agentbinary.py` → `resolve_opencode_version()` → `_fetch_latest_release()`

Both are called from inside the per-sample agent body (`_gemini_cli/gemini_cli.py:139`, `_opencode/opencode.py:143`). Unlike agents installed through `AgentBinarySource`, they never pass through the `_resolved_versions` memo in `download_agent_binary_async`, because they install from npm rather than a release asset. The `concurrency()` guard sits downstream in `ensure_*_installed`, so it doesn't deduplicate the fetch either.

Unauthenticated GitHub API requests are limited to 60/hour per IP. A single 60-sample eval can therefore exhaust the limit by itself, failing with a bare `403 Forbidden` — there is no retry, and the offline fallback in `ensure_agent_binary_installed` only covers pinned versions.

This affects local users as much as CI; it is not a shared-runner-IP problem.

## The change

Adds `_util/versioncache.py` and routes both resolvers through it.

- 60 requests per eval → 1.
- Resolution is **single-flight**: `concurrency(1)` per key with a re-check after acquiring, matching the double-checked pattern already used by `codex_models_catalog`. A caching memo alone isn't enough here — the cache dict is guarded by a `threading.Lock` that isn't held across the resolve `await`, so a cold-start burst of samples would otherwise all miss and each issue a request. The `AgentBinarySource` memo this was modelled on avoids that only because codex resolves *inside* the per-binary `concurrency(1)` guard; gemini and opencode resolve outside it, which is the bug being fixed.
- `concurrency()` is inspect's own async primitive, so unlike a module-level `anyio.Lock` it holds no waiter state bound to a particular event loop — which matters because every `anyio.run()` call creates and closes a fresh one.
- All four aliases (`auto`/`sandbox`/`stable`/`latest`) share one cache entry, since they resolve to the same release.
- An explicit semver still short-circuits with no request at all, unchanged.
- Failed resolutions are not cached, so a later caller retries.
- No credentials involved, and no change to what gets installed.

`codex_cli` is unaffected — it already resolves through the existing memo at 2 requests per process.

## Tests

12 tests in `tests/test_version_cache.py` covering the cache utility (resolve-once, key independence) and, for both agents: repeated `latest` resolution issuing one fetch, alias sharing, explicit versions never fetching, failures not being cached, and ten concurrent callers producing exactly one request. That last one was verified to fail without the single-flight guard (10 requests instead of 1), so it's a real regression test rather than a tautology.

Full suite: 198 passed, 65 skipped. ruff and mypy clean.

## Not included

Two follow-ups discussed but deliberately left out to keep this focused:

- Resolving these two agents from the npm registry instead of GitHub releases — they install from npm anyway, so the current split can resolve a version npm cannot yet serve.
- Pinning sha256 digests for the node, ripgrep, and uv downloads, which are currently written into the sandbox and `chmod +x`'d with no verification, and whose local caches are read back unverified.

Regarding #126: with this merged, codex's 2 requests per process are the only remaining API usage, so the token is no longer needed for the rate limit itself. If you keep it as insurance against a drained shared runner IP, consider a dedicated `INSPECT_SWE_GITHUB_TOKEN` rather than reading ambient `GITHUB_TOKEN`/`GH_TOKEN` — `secrets.GITHUB_TOKEN` has to be plumbed into the workflow `env:` explicitly either way, and Codespaces exports `GITHUB_TOKEN` automatically, so ambient pickup would use a developer's PAT without their knowledge.