### PR TITLE
test: bound example evals so a runaway agent fails instead of hanging CI

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -181,7 +181,33 @@ def run_example(
 
     if sandbox is not None:
         task_args["sandbox"] = sandbox
-    return eval(example_file, model=model, limit=1, task_args=task_args)
+
+    # Bound the agent. These examples are trivial by construction -- guess a
+    # number without calling tools, answer "what is 2+2" -- so a run that
+    # reaches either limit is a runaway CLI loop, not slow honest work.
+    # Nothing else bounds them: the tasks set no limits and the agents'
+    # sbox.exec_remote() calls pass no timeout, so the only backstop is the
+    # pytest timeout, which reports as an opaque stall (and, under
+    # --timeout-method=thread, as a bare "worker crashed"). Seen in
+    # meridianlabs-ai/actions run 31968805891, where gemini_cli looped for
+    # 9m21s and 1.68M tokens on multiple_attempts before pytest killed it.
+    #
+    # Both limits earn their place: time catches a wedged process that has
+    # stopped generating, tokens cap the cost of one that has not.
+    #
+    # The token ceiling is deliberately loose. It is shared by every example
+    # (system_explorer and web_search are genuinely multi-turn), and cached
+    # reads count toward it -- they were 1.4M of that 1.68M -- so a tight cap
+    # would clip honest runs. 500k still trips a runaway inside ~3 minutes,
+    # ahead of the time limit, while sitting well clear of real usage.
+    return eval(
+        example_file,
+        model=model,
+        limit=1,
+        task_args=task_args,
+        time_limit=300,
+        token_limit=500_000,
+    )
 
 
 # --- Wheels cache utilities ---


### PR DESCRIPTION
## What happened

The nightly slow-test run in `meridianlabs-ai/actions` stalled on `test_gemini_cli_attempts[docker]` until pytest killed it ([run 31966606629](https://github.com/meridianlabs-ai/actions/actions/runs/31966606629), reproduced with a clean traceback in [run 31968805891](https://github.com/meridianlabs-ai/actions/actions/runs/31968805891)). The eval summary captured at the kill shows it was never blocked:

```
google/gemini-3.1-pro-preview  1,681,569 tokens
[I: 259,322, CW: 0, CR: 1,407,082, O: 15,165, R: 12,505]
total time: 0:09:21   Samples: 0/1   HTTP retries: 0
```

1.68M tokens in nine minutes on a task whose whole job is to guess a number without calling tools. The agent was in a runaway loop, generating the entire time — not deadlocked, not waiting on the network (`HTTP retries: 0`, connections idle).

Nothing bounded it. The example tasks set no limits, and the agents' `sbox.exec_remote()` calls pass no timeout, so the only backstop was the pytest timeout — which reports the failure as an opaque stall, or (under `--timeout-method=thread`, as the nightly then used) as a bare `worker 'gwN' crashed` with the stack dump lost to the xdist worker's stderr.

## The change

Bound the evals in `run_example`, which every example test goes through.

A time limit catches a wedged process that has stopped generating; a token limit caps the cost of one that has not, and trips first on a loop like this one — roughly three minutes in rather than nine.

The token ceiling is loose on purpose. `run_example` is shared by seven examples, some genuinely multi-turn (`system_explorer`, `web_search`), and cached reads count toward the total — 1.4M of the 1.68M above — so a tight cap would clip honest runs.

A test whose agent runs away now fails on its existing assertions in minutes, with the sample's `limit` field naming the reason in the eval log, instead of consuming the CI budget and reporting as a dead worker.

## Verification

- `ruff check`, `ruff format --check`, and `mypy` clean
- Fast suite unchanged: `200 passed, 65 skipped`
- A runaway solver under a 5s time limit returns a completed log carrying `limit=type='time' limit=5.0` instead of running on

## Note

This is the bound, not a diagnosis of why gemini-cli looped on `multiple_attempts` in the first place. That is worth a separate look — the same test passed on 15 Aug, so it is recent drift in either the model's behaviour or the resolved gemini-cli build. This change makes that failure cheap and legible rather than silent.

Not related to #127: six of the seven gemini tests passed in the same run, all going through the same `cached_version_resolution("gemini-cli", …)` and the same docker install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mhtp2qK6t5hfQLwLHFFh4g

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mhtp2qK6t5hfQLwLHFFh4g)_