### PR TITLE
fix: retry agent binary downloads and raise the http timeout

### DIFF
--- a/src/inspect_swe/_util/download.py
+++ b/src/inspect_swe/_util/download.py
@@ -1,11 +1,37 @@
+import anyio
 import httpx
+
+# These helpers fetch version pointers, manifests, and multi-megabyte agent
+# binaries from external CDNs (github.com, code.kimi.com, storage.googleapis.com).
+# httpx's default 5-second read timeout is too tight for some of these endpoints
+# from CI runners (code.kimi.com's latest.json alone has breached it), and with
+# no retry a single transient blip fails the whole eval — so use a generous
+# timeout and retry transient failures with backoff.
+_TIMEOUT = httpx.Timeout(60.0, connect=30.0)
+
+# delay before each retry (attempts = len + 1)
+_RETRY_DELAYS: tuple[float, ...] = (1.0, 2.0, 4.0)
 
 
 async def download_file(url: str) -> bytes:
-    async with httpx.AsyncClient() as client:
-        response = await client.get(url, follow_redirects=True)
-        response.raise_for_status()
-        return response.content
+    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        attempts = len(_RETRY_DELAYS) + 1
+        for attempt in range(attempts):
+            try:
+                response = await client.get(url, follow_redirects=True)
+                response.raise_for_status()
+                return response.content
+            except (httpx.TransportError, httpx.HTTPStatusError) as ex:
+                # transport errors (timeouts, resets, DNS) and 5xx responses
+                # are transient; 4xx responses are permanent
+                permanent = (
+                    isinstance(ex, httpx.HTTPStatusError)
+                    and ex.response.status_code < 500
+                )
+                if permanent or attempt == attempts - 1:
+                    raise
+                await anyio.sleep(_RETRY_DELAYS[attempt])
+    raise RuntimeError("unreachable")  # satisfies type checker
 
 
 async def download_text_file(url: str) -> str:

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,14 +1,17 @@
+import asyncio
 import sys
 from pathlib import Path
-from typing import Literal
+from typing import Callable, Literal
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 from inspect_swe import (
     cached_agent_binaries,
     download_agent_binary,
     download_wheels_tarball,
 )
+from inspect_swe._util.download import download_file
 
 
 @pytest.mark.slow
@@ -209,6 +212,81 @@ def test_ensure_pip_available_bootstraps_when_missing() -> None:
             capture_output=True,
             text=True,
         )
+
+
+def _download_with_transport(
+    handler: Callable[[httpx.Request], httpx.Response],
+) -> bytes:
+    """Run download_file against a mock transport with zero retry delays."""
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+
+    def client_with_mock_transport(**kwargs: object) -> httpx.AsyncClient:
+        return real_async_client(transport=transport, **kwargs)  # type: ignore[arg-type]
+
+    with (
+        patch("httpx.AsyncClient", client_with_mock_transport),
+        patch("inspect_swe._util.download._RETRY_DELAYS", (0.0, 0.0, 0.0)),
+    ):
+        return asyncio.run(download_file("https://example.com/file"))
+
+
+def test_download_file_retries_transient_errors() -> None:
+    """Transient transport errors (e.g. read timeouts) are retried."""
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls < 3:
+            raise httpx.ReadTimeout("timed out", request=request)
+        return httpx.Response(200, content=b"ok")
+
+    assert _download_with_transport(handler) == b"ok"
+    assert calls == 3
+
+
+def test_download_file_retries_server_errors() -> None:
+    """5xx responses are treated as transient and retried."""
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return httpx.Response(503)
+        return httpx.Response(200, content=b"ok")
+
+    assert _download_with_transport(handler) == b"ok"
+    assert calls == 2
+
+
+def test_download_file_does_not_retry_client_errors() -> None:
+    """4xx responses are permanent and raise immediately."""
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(404)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        _download_with_transport(handler)
+    assert calls == 1
+
+
+def test_download_file_raises_after_retries_exhausted() -> None:
+    """The last error is raised once all attempts are used."""
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        raise httpx.ReadTimeout("timed out", request=request)
+
+    with pytest.raises(httpx.ReadTimeout):
+        _download_with_transport(handler)
+    assert calls == 4
 
 
 def test_ensure_pip_available_raises_on_failure() -> None:


### PR DESCRIPTION
Fixes the nightly test failure reported in meridianlabs-ai/actions#95.

### Problem

The 2026-08-19 nightly run failed `tests/test_bridged_tools.py::test_kimi_code_bridged_tools` with an `httpx.ReadTimeout` raised from `_fetch_latest_version()` while fetching `https://code.kimi.com/kimi-code/latest.json` ([failing run](https://github.com/meridianlabs-ai/actions/actions/runs/32231665676/job/96097706123)).

Root cause: `_util/download.py`'s `download_file()` created an `httpx.AsyncClient()` with all defaults — a 5-second read timeout and no retries — so a single slow response from an external CDN errored the entire eval. Every agent binary source funnels through this helper (claude_code, codex_cli, kimi_code, opencode, gemini_cli, plus the node and ripgrep installers), so any of them could fail the same way.

### Fix

- Raise the client timeout to 60s (30s connect).
- Retry transient failures — transport errors (timeouts, resets, DNS) and 5xx responses — up to 3 times with 1s/2s/4s backoff.
- 4xx responses are permanent and still raise immediately.

### Testing

- Added 4 unit tests in `tests/test_download.py` covering retry-on-timeout, retry-on-5xx, no-retry-on-4xx, and retry exhaustion (all fast, no network) — passing locally.
- `ruff format --check`, `ruff check`, and `mypy --strict` clean on both changed files.

Generated with [Claude Code](https://claude.ai/code)
