### PR TITLE
fix(claude_code): carry the caller's system prompt into centaur sessions

### DIFF
--- a/src/inspect_swe/_claude_code/claude_code.py
+++ b/src/inspect_swe/_claude_code/claude_code.py
@@ -13,7 +13,13 @@ from inspect_ai.agent import (
     agent_with,
     sandbox_agent_bridge,
 )
-from inspect_ai.model import ChatMessageSystem, GenerateFilter, Model, StopReason
+from inspect_ai.model import (
+    ChatMessage,
+    ChatMessageSystem,
+    GenerateFilter,
+    Model,
+    StopReason,
+)
 from inspect_ai.scorer import score
 from inspect_ai.tool import (
     MCPServerConfig,
@@ -452,7 +458,13 @@ def claude_code(
             if centaur:
                 await run_claude_code_centaur(
                     options=centaur,
-                    claude_cmd=[claude_binary] + cmd,
+                    claude_cmd=_centaur_claude_cmd(
+                        claude_binary,
+                        cmd,
+                        state.messages,
+                        system_prompt,
+                        replace_system_prompt,
+                    ),
                     agent_env=agent_env,
                     state=state,
                 )
@@ -477,15 +489,8 @@ def claude_code(
                         # resume. Appended messages are not re-sent because the bridge
                         # round-trips them into state.messages and appending them again
                         # would duplicate the effective prompt.
-                        system_texts = [
-                            m.text
-                            for m in state.messages
-                            if isinstance(m, ChatMessageSystem)
-                        ]
-                        if system_prompt is not None:
-                            system_texts.append(system_prompt)
                         system_args = _system_prompt_args(
-                            system_texts,
+                            _system_texts(state.messages, system_prompt),
                             replace_system_prompt,
                             is_resume=is_resume,
                         )
@@ -646,6 +651,50 @@ def claude_code(
 
     # return agent with specified name and descritpion
     return agent_with(execute, name=name, description=description)
+
+
+def _system_texts(
+    messages: Sequence[ChatMessage], system_prompt: str | None
+) -> list[str]:
+    """System texts to append: the task's own, then the caller's.
+
+    Shared by the centaur and unattended launches so the operator's `claude`
+    alias and the unattended agent cannot disagree about the effective prompt.
+    """
+    texts = [m.text for m in messages if isinstance(m, ChatMessageSystem)]
+    if system_prompt is not None:
+        texts.append(system_prompt)
+    return texts
+
+
+def _centaur_claude_cmd(
+    claude_binary: str,
+    cmd: Sequence[str],
+    messages: Sequence[ChatMessage],
+    system_prompt: str | None,
+    replace_system_prompt: str | None,
+) -> list[str]:
+    """The `claude` invocation aliased into the operator's centaur shell.
+
+    Carries the SAME system prompt the unattended launch builds. Without the
+    prompt args here, `system_prompt` and `replace_system_prompt` are silently
+    dropped in centaur mode: the human's session runs with Claude Code's stock
+    prompt while the caller has every reason to believe the one it passed is in
+    effect.
+
+    `is_resume=False` because the alias always starts a fresh session --
+    `claude --resume` is the operator's own call, and re-sending an append there
+    would duplicate the effective prompt.
+    """
+    return (
+        [claude_binary]
+        + list(cmd)
+        + _system_prompt_args(
+            _system_texts(messages, system_prompt),
+            replace_system_prompt,
+            is_resume=False,
+        )
+    )
 
 
 def _system_prompt_args(

--- a/src/inspect_swe/_claude_code/claude_code.py
+++ b/src/inspect_swe/_claude_code/claude_code.py
@@ -456,14 +456,21 @@ def claude_code(
 
             # centaur mode uses human_cli with custom instructions and bash rc
             if centaur:
+                centaur_system_texts = _system_texts(state.messages, system_prompt)
                 await run_claude_code_centaur(
                     options=centaur,
                     claude_cmd=_centaur_claude_cmd(
                         claude_binary,
                         cmd,
-                        state.messages,
-                        system_prompt,
+                        centaur_system_texts,
                         replace_system_prompt,
+                    ),
+                    resume_claude_cmd=_centaur_claude_cmd(
+                        claude_binary,
+                        cmd,
+                        centaur_system_texts,
+                        replace_system_prompt,
+                        is_resume=True,
                     ),
                     agent_env=agent_env,
                     state=state,
@@ -670,29 +677,23 @@ def _system_texts(
 def _centaur_claude_cmd(
     claude_binary: str,
     cmd: Sequence[str],
-    messages: Sequence[ChatMessage],
-    system_prompt: str | None,
+    system_texts: Sequence[str],
     replace_system_prompt: str | None,
+    *,
+    is_resume: bool = False,
 ) -> list[str]:
-    """The `claude` invocation aliased into the operator's centaur shell.
+    """Build a Claude invocation for the operator's Centaur shell.
 
-    Carries the SAME system prompt the unattended launch builds. Without the
-    prompt args here, `system_prompt` and `replace_system_prompt` are silently
-    dropped in centaur mode: the human's session runs with Claude Code's stock
-    prompt while the caller has every reason to believe the one it passed is in
-    effect.
-
-    `is_resume=False` because the alias always starts a fresh session --
-    `claude --resume` is the operator's own call, and re-sending an append there
-    would duplicate the effective prompt.
+    A resumed Claude session already contains appended task and caller prompts,
+    so it retains a replacement prompt but omits appended system prompt args.
     """
     return (
         [claude_binary]
         + list(cmd)
         + _system_prompt_args(
-            _system_texts(messages, system_prompt),
+            system_texts,
             replace_system_prompt,
-            is_resume=False,
+            is_resume=is_resume,
         )
     )
 
@@ -799,6 +800,7 @@ def resolve_mcp_server_allowed_tools(
 async def run_claude_code_centaur(
     options: CentaurOptions,
     claude_cmd: list[str],
+    resume_claude_cmd: list[str],
     agent_env: dict[str, str],
     state: AgentState,
 ) -> None:
@@ -812,10 +814,30 @@ async def run_claude_code_centaur(
         'export PATH="$HOME/.local/bin:$PATH"',
         f'ln -sf {claude_cmd[0]} "$HOME/.local/bin/claude"',
     ]
-    alias_cmd = shlex.join(claude_cmd)
-    alias_cmd = "alias claude='" + alias_cmd.replace("'", "'\\''") + "'"
+    if claude_cmd == resume_claude_cmd:
+        alias_cmd = shlex.join(claude_cmd)
+        claude_cmd_def = "alias claude='" + alias_cmd.replace("'", "'\\''") + "'"
+    else:
+        fresh_cmd = shlex.join(claude_cmd)
+        resume_cmd = shlex.join(resume_claude_cmd)
+        claude_cmd_def = dedent(f"""
+            claude() {{
+              for arg in "$@"; do
+                case "$arg" in
+                  --resume|--resume=*)
+                    command {resume_cmd} "$@"
+                    return
+                    ;;
+                  --)
+                    break
+                    ;;
+                esac
+              done
+              command {fresh_cmd} "$@"
+            }}
+        """).strip()
     bashrc = "\n".join(
-        agent_env_vars + path_config + ["", claude_config, "", alias_cmd]
+        agent_env_vars + path_config + ["", claude_config, "", claude_cmd_def]
     )
 
     # run the human cli

--- a/src/inspect_swe/_claude_code/claude_code.py
+++ b/src/inspect_swe/_claude_code/claude_code.py
@@ -13,7 +13,13 @@ from inspect_ai.agent import (
     agent_with,
     sandbox_agent_bridge,
 )
-from inspect_ai.model import ChatMessageSystem, GenerateFilter, Model, StopReason
+from inspect_ai.model import (
+    ChatMessage,
+    ChatMessageSystem,
+    GenerateFilter,
+    Model,
+    StopReason,
+)
 from inspect_ai.scorer import score
 from inspect_ai.tool import (
     MCPServerConfig,
@@ -406,7 +412,13 @@ def claude_code(
             if centaur:
                 await run_claude_code_centaur(
                     options=centaur,
-                    claude_cmd=[claude_binary] + cmd,
+                    claude_cmd=_centaur_claude_cmd(
+                        claude_binary,
+                        cmd,
+                        state.messages,
+                        system_prompt,
+                        replace_system_prompt,
+                    ),
                     agent_env=agent_env,
                     state=state,
                 )
@@ -431,15 +443,8 @@ def claude_code(
                         # resume. Appended messages are not re-sent because the bridge
                         # round-trips them into state.messages and appending them again
                         # would duplicate the effective prompt.
-                        system_texts = [
-                            m.text
-                            for m in state.messages
-                            if isinstance(m, ChatMessageSystem)
-                        ]
-                        if system_prompt is not None:
-                            system_texts.append(system_prompt)
                         system_args = _system_prompt_args(
-                            system_texts,
+                            _system_texts(state.messages, system_prompt),
                             replace_system_prompt,
                             is_resume=is_resume,
                         )
@@ -600,6 +605,50 @@ def claude_code(
 
     # return agent with specified name and descritpion
     return agent_with(execute, name=name, description=description)
+
+
+def _system_texts(
+    messages: Sequence[ChatMessage], system_prompt: str | None
+) -> list[str]:
+    """System texts to append: the task's own, then the caller's.
+
+    Shared by the centaur and unattended launches so the operator's `claude`
+    alias and the unattended agent cannot disagree about the effective prompt.
+    """
+    texts = [m.text for m in messages if isinstance(m, ChatMessageSystem)]
+    if system_prompt is not None:
+        texts.append(system_prompt)
+    return texts
+
+
+def _centaur_claude_cmd(
+    claude_binary: str,
+    cmd: Sequence[str],
+    messages: Sequence[ChatMessage],
+    system_prompt: str | None,
+    replace_system_prompt: str | None,
+) -> list[str]:
+    """The `claude` invocation aliased into the operator's centaur shell.
+
+    Carries the SAME system prompt the unattended launch builds. Without the
+    prompt args here, `system_prompt` and `replace_system_prompt` are silently
+    dropped in centaur mode: the human's session runs with Claude Code's stock
+    prompt while the caller has every reason to believe the one it passed is in
+    effect.
+
+    `is_resume=False` because the alias always starts a fresh session --
+    `claude --resume` is the operator's own call, and re-sending an append there
+    would duplicate the effective prompt.
+    """
+    return (
+        [claude_binary]
+        + list(cmd)
+        + _system_prompt_args(
+            _system_texts(messages, system_prompt),
+            replace_system_prompt,
+            is_resume=False,
+        )
+    )
 
 
 def _system_prompt_args(

--- a/tests/test_claude_code_system_prompt.py
+++ b/tests/test_claude_code_system_prompt.py
@@ -1,11 +1,20 @@
+import os
+import subprocess
+from pathlib import Path
+
+import anyio
 import pytest
+from inspect_ai.agent import AgentState
 from inspect_ai.model import ChatMessage, ChatMessageSystem, ChatMessageUser
 from inspect_swe import claude_code
+from inspect_swe._claude_code import claude_code as claude_code_module
 from inspect_swe._claude_code.claude_code import (
     _centaur_claude_cmd,
     _system_prompt_args,
     _system_texts,
+    run_claude_code_centaur,
 )
+from inspect_swe._util.centaur import CentaurOptions
 
 
 def test_system_prompt_appends_to_default() -> None:
@@ -85,8 +94,7 @@ def test_centaur_alias_carries_the_task_and_caller_system_prompts() -> None:
     cmd = _centaur_claude_cmd(
         "/usr/bin/claude",
         ["--model", "sonnet"],
-        [ChatMessageSystem(content="Task prompt")],
-        "Agent prompt",
+        ["Task prompt"],
         None,
     )
 
@@ -95,7 +103,7 @@ def test_centaur_alias_carries_the_task_and_caller_system_prompts() -> None:
         "--model",
         "sonnet",
         "--append-system-prompt",
-        "Task prompt\n\nAgent prompt",
+        "Task prompt",
     ]
 
 
@@ -104,7 +112,6 @@ def test_centaur_alias_replaces_the_stock_prompt_when_asked() -> None:
         "/usr/bin/claude",
         ["--model", "sonnet"],
         [],
-        None,
         "Replacement prompt",
     )
 
@@ -118,10 +125,73 @@ def test_centaur_alias_replaces_the_stock_prompt_when_asked() -> None:
 
 
 def test_centaur_alias_adds_no_prompt_flags_when_there_is_no_prompt() -> None:
-    assert _centaur_claude_cmd(
-        "/usr/bin/claude", ["--model", "sonnet"], [], None, None
-    ) == [
+    assert _centaur_claude_cmd("/usr/bin/claude", ["--model", "sonnet"], [], None) == [
         "/usr/bin/claude",
         "--model",
         "sonnet",
+    ]
+
+
+def test_centaur_claude_resume_omits_appended_messages_but_reapplies_replacement_prompt(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`claude --resume` must not append prompts already in the session."""
+    captured: dict[str, str] = {}
+
+    async def fake_run_centaur(
+        options: CentaurOptions, instructions: str, bashrc: str, state: AgentState
+    ) -> None:
+        captured["bashrc"] = bashrc
+
+    monkeypatch.setattr(claude_code_module, "run_centaur", fake_run_centaur)
+
+    capture_file = tmp_path / "claude-args"
+    claude_binary = tmp_path / "claude"
+    claude_binary.write_text('#!/bin/sh\nprintf "%s\\n" "$@" > "$CLAUDE_CAPTURE"\n')
+    claude_binary.chmod(0o755)
+
+    anyio.run(
+        lambda: run_claude_code_centaur(
+            options=CentaurOptions(),
+            claude_cmd=_centaur_claude_cmd(
+                str(claude_binary),
+                ["--model", "sonnet"],
+                ["Task prompt"],
+                "Replacement prompt",
+            ),
+            resume_claude_cmd=_centaur_claude_cmd(
+                str(claude_binary),
+                ["--model", "sonnet"],
+                ["Task prompt"],
+                "Replacement prompt",
+                is_resume=True,
+            ),
+            agent_env={},
+            state=AgentState(messages=[]),
+        )
+    )
+
+    bashrc = tmp_path / "bashrc"
+    bashrc.write_text(captured["bashrc"])
+    shell = tmp_path / "run-claude"
+    shell.write_text(
+        f'shopt -s expand_aliases\nsource "{bashrc}"\nclaude --resume session-123\n'
+    )
+    subprocess.run(
+        ["bash", str(shell)],
+        check=True,
+        env={
+            "CLAUDE_CAPTURE": str(capture_file),
+            "HOME": str(tmp_path / "home"),
+            "PATH": os.environ["PATH"],
+        },
+    )
+
+    assert capture_file.read_text().splitlines() == [
+        "--model",
+        "sonnet",
+        "--system-prompt",
+        "Replacement prompt",
+        "--resume",
+        "session-123",
     ]

--- a/tests/test_claude_code_system_prompt.py
+++ b/tests/test_claude_code_system_prompt.py
@@ -1,6 +1,11 @@
 import pytest
+from inspect_ai.model import ChatMessageSystem, ChatMessageUser
 from inspect_swe import claude_code
-from inspect_swe._claude_code.claude_code import _system_prompt_args
+from inspect_swe._claude_code.claude_code import (
+    _centaur_claude_cmd,
+    _system_prompt_args,
+    _system_texts,
+)
 
 
 def test_system_prompt_appends_to_default() -> None:
@@ -52,3 +57,71 @@ def test_append_and_replace_system_prompts_are_mutually_exclusive() -> None:
             system_prompt="Additional prompt",
             replace_system_prompt="Replacement prompt",
         )
+
+
+def test_system_texts_takes_task_messages_then_caller_prompt() -> None:
+    messages = [
+        ChatMessageSystem(content="Task prompt"),
+        ChatMessageUser(content="Do the thing"),
+    ]
+
+    assert _system_texts(messages, "Agent prompt") == ["Task prompt", "Agent prompt"]
+
+
+def test_system_texts_without_caller_prompt_keeps_only_task_messages() -> None:
+    assert _system_texts([ChatMessageSystem(content="Task prompt")], None) == [
+        "Task prompt"
+    ]
+
+
+def test_centaur_alias_carries_the_task_and_caller_system_prompts() -> None:
+    """Regression: centaur dropped the caller's system prompt entirely.
+
+    The alias was built from ``[claude_binary] + cmd`` while
+    ``_system_prompt_args`` was computed only in the unattended branch, so
+    ``system_prompt``/``replace_system_prompt`` never reached the operator's
+    ``claude`` and a human session silently ran with Claude Code's stock prompt.
+    """
+    cmd = _centaur_claude_cmd(
+        "/usr/bin/claude",
+        ["--model", "sonnet"],
+        [ChatMessageSystem(content="Task prompt")],
+        "Agent prompt",
+        None,
+    )
+
+    assert cmd == [
+        "/usr/bin/claude",
+        "--model",
+        "sonnet",
+        "--append-system-prompt",
+        "Task prompt\n\nAgent prompt",
+    ]
+
+
+def test_centaur_alias_replaces_the_stock_prompt_when_asked() -> None:
+    cmd = _centaur_claude_cmd(
+        "/usr/bin/claude",
+        ["--model", "sonnet"],
+        [],
+        None,
+        "Replacement prompt",
+    )
+
+    assert cmd == [
+        "/usr/bin/claude",
+        "--model",
+        "sonnet",
+        "--system-prompt",
+        "Replacement prompt",
+    ]
+
+
+def test_centaur_alias_adds_no_prompt_flags_when_there_is_no_prompt() -> None:
+    assert _centaur_claude_cmd(
+        "/usr/bin/claude", ["--model", "sonnet"], [], None, None
+    ) == [
+        "/usr/bin/claude",
+        "--model",
+        "sonnet",
+    ]

--- a/tests/test_claude_code_system_prompt.py
+++ b/tests/test_claude_code_system_prompt.py
@@ -1,5 +1,5 @@
 import pytest
-from inspect_ai.model import ChatMessageSystem, ChatMessageUser
+from inspect_ai.model import ChatMessage, ChatMessageSystem, ChatMessageUser
 from inspect_swe import claude_code
 from inspect_swe._claude_code.claude_code import (
     _centaur_claude_cmd,
@@ -60,7 +60,7 @@ def test_append_and_replace_system_prompts_are_mutually_exclusive() -> None:
 
 
 def test_system_texts_takes_task_messages_then_caller_prompt() -> None:
-    messages = [
+    messages: list[ChatMessage] = [
         ChatMessageSystem(content="Task prompt"),
         ChatMessageUser(content="Do the thing"),
     ]


### PR DESCRIPTION
## Problem

`claude_code(system_prompt=..., replace_system_prompt=...)` was accepted and then silently ignored when `centaur` was set.

The operator's `claude` command was built from `[claude_binary] + cmd` at the Centaur launch, while `_system_prompt_args()` was computed later inside the unattended-launch branch. A human Centaur session therefore ran with Claude Code's stock system prompt even though the caller had supplied one.

This affects Centaur sessions intended to reproduce a specific agent prompt in the task's sandbox.

## Change

`_system_texts(messages, system_prompt)` gathers the task system messages followed by the caller prompt, so Centaur and unattended launches build the same effective prompt.

`_centaur_claude_cmd(...)` builds both a fresh invocation and a resume invocation. When appended system text is present, the Centaur `claude` command is a shell function: it routes an invocation containing `--resume` before `--` to the resume command, which retains `--system-prompt` but omits `--append-system-prompt`. Fresh invocations still append the task and caller prompts. When the commands are identical, Centaur keeps the simple alias.

The unattended path's behavior is unchanged.

## Tests

The PR adds six tests in `tests/test_claude_code_system_prompt.py`: the original five tests, including two `_system_texts` tests and three Centaur-command tests, plus a behavioral regression that sources the generated bashrc and runs `claude --resume` against a test binary. The regression verifies that a replacement prompt remains while the appended task prompt is omitted.

`uv run --frozen pytest tests/test_claude_code_system_prompt.py -q` passes 12 tests. Scoped `mypy`, `ruff check`, and `ruff format --check` also pass for the changed module and test file.

### Agent review
- Reviewer: Fable 5 via independent reviewer subagent, fresh context, 1 pass
- Findings: 4, fixed: 4, dismissed: 0. Fixed Centaur `claude --resume` prompt duplication, updated the branch onto current `main`, corrected the test count, and added this disclosure.
