### PR TITLE
fix: acquire the OpenCode binary host-side, not via in-sandbox npm

### DIFF
--- a/src/inspect_swe/_opencode/agentbinary.py
+++ b/src/inspect_swe/_opencode/agentbinary.py
@@ -78,8 +78,10 @@ def opencode_binary_source() -> AgentBinarySource:
                 f"release {version}"
             )
 
-        # Extract checksum (format: "sha256:xxx")
-        digest = asset.get("digest", "")
+        # Extract checksum (format: "sha256:xxx"). GitHub serves
+        # "digest": null for assets uploaded before digest support, so
+        # normalize None to "" rather than crashing on .startswith.
+        digest = asset.get("digest") or ""
         if not digest.startswith("sha256:"):
             raise RuntimeError(f"Invalid digest format: {digest}")
         expected_checksum = digest[7:]  # Remove "sha256:" prefix
@@ -96,10 +98,10 @@ def opencode_binary_source() -> AgentBinarySource:
         )
 
     def cached_binary_path(version: str, platform: SandboxPlatform) -> Path:
-        # Legacy single-binary cache layout. No longer written (resolve_version
-        # always returns package=True now), kept only so a cache populated
-        # before opencode moved to package-archive caching still serves as an
-        # offline fallback.
+        # Never written or read in practice: resolve_version always returns
+        # package=True, and opencode never shipped a single-binary cache (the
+        # npm era cached bundles under "opencode-bundles"). Defined only
+        # because AgentBinarySource requires it.
         return cached_binary_dir / f"opencode-{version}-{platform}"
 
     def cached_package_path(version: str, platform: SandboxPlatform) -> Path:

--- a/src/inspect_swe/_opencode/agentbinary.py
+++ b/src/inspect_swe/_opencode/agentbinary.py
@@ -15,7 +15,6 @@ from .._util.download import download_text_file
 from .._util.node import ensure_node_available
 from .._util.ripgrep import ensure_ripgrep_available
 from .._util.sandbox import SandboxPlatform, detect_sandbox_platform
-from .._util.tarball import extract_tarball
 
 
 async def ensure_opencode_setup(
@@ -53,20 +52,31 @@ def opencode_binary_source() -> AgentBinarySource:
     async def resolve_version(
         version: Literal["stable", "latest"] | str, platform: SandboxPlatform
     ) -> AgentBinaryVersion:
-        # Resolve version alias if needed
+        # Resolve the version and its release assets together:
+        # /releases/latest returns both the tag name and the full asset list
+        # in one response, so "stable"/"latest" resolves with exactly one
+        # API call rather than a tag lookup followed by a second, per-tag
+        # lookup. Halving the request count also halves how often a sample
+        # queued behind a rate-limited neighbor has to repeat the exact call
+        # that just failed. A pinned version still needs its own,
+        # unavoidable per-tag lookup.
         if version in ["stable", "latest"]:
-            version = await _fetch_latest_version()
+            release = await _fetch_latest_release()
+            version = str(release["tag_name"]).lstrip("v")
+        else:
+            release = await _fetch_release_assets(version)
 
-        # The release asset name is the platform string verbatim, and each variant
-        # is dynamically linked against its own libc (glibc for linux-x64, musl for
-        # linux-x64-musl, ...) — so the platform-matched asset is correct by
-        # construction. detect_sandbox_platform picks the right libc for the sandbox.
-        release = await _fetch_release_assets(version)
-        asset_name = f"opencode-{platform}.tar.gz"
         assets = {a["name"]: a for a in release.get("assets", [])}
-        asset = assets.get(asset_name)
+        asset = None
+        for asset_name in _asset_name_candidates(platform):
+            asset = assets.get(asset_name)
+            if asset is not None:
+                break
         if asset is None:
-            raise RuntimeError(f"No asset {asset_name!r} in opencode release {version}")
+            raise RuntimeError(
+                f"No matching asset for platform {platform!r} in opencode "
+                f"release {version}"
+            )
 
         # Extract checksum (format: "sha256:xxx")
         digest = asset.get("digest", "")
@@ -75,10 +85,25 @@ def opencode_binary_source() -> AgentBinarySource:
         expected_checksum = digest[7:]  # Remove "sha256:" prefix
 
         download_url = asset["browser_download_url"]
-        return AgentBinaryVersion(version, expected_checksum, download_url)
+        # The release asset is a tar.gz wrapping the single opencode binary.
+        # Cache it verbatim, checksum and all — as a "package" archive in
+        # AgentBinarySource terms — and let ensure_agent_binary_installed
+        # extract it in the sandbox at install time, rather than transforming
+        # it host-side (post_download) into a blob a later cache hit can no
+        # longer verify against the release digest.
+        return AgentBinaryVersion(
+            version, expected_checksum, download_url, package=True
+        )
 
     def cached_binary_path(version: str, platform: SandboxPlatform) -> Path:
+        # Legacy single-binary cache layout. No longer written (resolve_version
+        # always returns package=True now), kept only so a cache populated
+        # before opencode moved to package-archive caching still serves as an
+        # offline fallback.
         return cached_binary_dir / f"opencode-{version}-{platform}"
+
+    def cached_package_path(version: str, platform: SandboxPlatform) -> Path:
+        return cached_binary_dir / f"opencode-package-{version}-{platform}.tar.gz"
 
     def list_cached_binaries() -> list[Path]:
         return list(cached_binary_dir.glob("opencode-*"))
@@ -89,23 +114,47 @@ def opencode_binary_source() -> AgentBinarySource:
         resolve_version=resolve_version,
         cached_binary_path=cached_binary_path,
         list_cached_binaries=list_cached_binaries,
-        # The release asset is a tar.gz wrapping a single binary; unwrap it
-        # host-side so the staged file is the executable itself.
-        post_download=extract_tarball,
+        post_download=None,
         post_install=None,
+        package_entrypoint="opencode",
+        cached_package_path=cached_package_path,
     )
 
 
-async def _fetch_latest_version() -> str:
-    """Fetch the latest released opencode version from GitHub."""
+def _asset_name_candidates(platform: SandboxPlatform) -> list[str]:
+    """Ordered release-asset name candidates for a platform, most preferred first.
+
+    Every x64 release ships two builds: the default, compiled with AVX2
+    instructions, and a "-baseline" build without them. OpenCode's own npm
+    postinstall probes the *host's* CPU at install time and picks between
+    them; we install host-side, before any in-sandbox probe ever runs, and
+    can't reliably read the underlying host's CPU flags from out here — the
+    sandbox may be scheduled onto a different physical host than the one
+    that eventually runs the binary, and some sandbox providers don't expose
+    real CPU flags at all. We deliberately prefer the baseline asset on
+    every x64 platform: it trades a little performance on modern hosts for
+    never staging a binary that SIGILLs on any host predating AVX2 (~2013),
+    which is the safer default for sandbox portability. arm64 has no
+    baseline variant (AVX2 is an x86 extension) and needs no fallback.
+    """
+    if platform in ("linux-x64", "linux-x64-musl"):
+        musl = "-musl" if platform.endswith("-musl") else ""
+        return [
+            f"opencode-linux-x64-baseline{musl}.tar.gz",
+            f"opencode-linux-x64{musl}.tar.gz",
+        ]
+    return [f"opencode-{platform}.tar.gz"]
+
+
+async def _fetch_latest_release() -> dict[str, Any]:
+    """Fetch the latest opencode release, tag and assets together."""
     latest_url = "https://api.github.com/repos/anomalyco/opencode/releases/latest"
-    latest = json.loads(await download_text_file(latest_url))
-    tag_name = str(latest["tag_name"])
-    return tag_name.lstrip("v")
+    result: dict[str, Any] = json.loads(await download_text_file(latest_url))
+    return result
 
 
 async def _fetch_release_assets(version: str) -> dict[str, Any]:
-    """Fetch release assets for a specific version."""
+    """Fetch release assets for a specific pinned version."""
     tag = f"v{version}"
     release_url = f"https://api.github.com/repos/anomalyco/opencode/releases/tags/{tag}"
     release_json = await download_text_file(release_url)

--- a/src/inspect_swe/_opencode/agentbinary.py
+++ b/src/inspect_swe/_opencode/agentbinary.py
@@ -1,22 +1,21 @@
 import json
-from typing import Any, Literal
+from pathlib import Path
+from typing import Any
 
-from inspect_ai.util import SandboxEnvironment, concurrency
+from inspect_ai.util import SandboxEnvironment
+from typing_extensions import Literal
 
+from .._util.agentbinary import (
+    AgentBinarySource,
+    AgentBinaryVersion,
+    ensure_agent_binary_installed,
+)
+from .._util.appdirs import package_cache_dir
 from .._util.download import download_text_file
-from .._util.node import (
-    create_npm_bundle,
-    ensure_node_available,
-    install_npm_bundle,
-)
+from .._util.node import ensure_node_available
 from .._util.ripgrep import ensure_ripgrep_available
-from .._util.sandbox import (
-    SANDBOX_INSTALL_DIR,
-    SandboxPlatform,
-    bash_command,
-    detect_sandbox_platform,
-)
-from .._util.versioncache import cached_version_resolution
+from .._util.sandbox import SandboxPlatform, detect_sandbox_platform
+from .._util.tarball import extract_tarball
 
 
 async def ensure_opencode_setup(
@@ -24,7 +23,16 @@ async def ensure_opencode_setup(
     version: Literal["auto", "sandbox", "stable", "latest"] | str,
     user: str | None,
 ) -> tuple[str, list[str]]:
-    """Install OpenCode and return its binary plus dependency bin directories."""
+    """Install OpenCode and return its binary plus dependency bin directories.
+
+    OpenCode ships a standalone, self-contained binary per platform on GitHub
+    releases, so it is acquired through the same host-side download-and-stage path
+    as claude_code and codex_cli (``ensure_agent_binary_installed``): a ``which``
+    probe reuses an already-installed/overlaid binary, otherwise the runner fetches
+    the release tarball, verifies its checksum, and writes the binary into the
+    sandbox. Nothing runs ``npm`` — and nothing downloads from inside the sandbox —
+    so this works in a network-isolated sandbox where an in-sandbox fetch would hang.
+    """
     platform = await detect_sandbox_platform(sandbox)
 
     node_binary = await ensure_node_available(sandbox, platform, user)
@@ -33,103 +41,73 @@ async def ensure_opencode_setup(
         await ensure_ripgrep_available(sandbox, platform, user),
     ]
 
-    opencode_version = await resolve_opencode_version(version)
-    opencode_binary = await ensure_opencode_installed(
-        sandbox, node_binary, opencode_version, platform, user
+    opencode_binary = await ensure_agent_binary_installed(
+        opencode_binary_source(), version, user, sandbox
     )
     return opencode_binary, dependency_bin_dirs
 
 
-async def resolve_opencode_version(
-    version: Literal["auto", "sandbox", "stable", "latest"] | str,
-) -> str:
-    """Resolve version string to an actual semver version."""
-    if version in ["auto", "sandbox", "stable", "latest"]:
-        # cached so concurrent samples don't each hit the (rate-limited)
-        # GitHub API — all four aliases resolve to the same latest release
-        return await cached_version_resolution("opencode", _fetch_latest_version)
+def opencode_binary_source() -> AgentBinarySource:
+    cached_binary_dir = package_cache_dir("opencode-downloads")
 
-    return version
+    async def resolve_version(
+        version: Literal["stable", "latest"] | str, platform: SandboxPlatform
+    ) -> AgentBinaryVersion:
+        # Resolve version alias if needed
+        if version in ["stable", "latest"]:
+            version = await _fetch_latest_version()
+
+        # The release asset name is the platform string verbatim, and each variant
+        # is dynamically linked against its own libc (glibc for linux-x64, musl for
+        # linux-x64-musl, ...) — so the platform-matched asset is correct by
+        # construction. detect_sandbox_platform picks the right libc for the sandbox.
+        release = await _fetch_release_assets(version)
+        asset_name = f"opencode-{platform}.tar.gz"
+        assets = {a["name"]: a for a in release.get("assets", [])}
+        asset = assets.get(asset_name)
+        if asset is None:
+            raise RuntimeError(f"No asset {asset_name!r} in opencode release {version}")
+
+        # Extract checksum (format: "sha256:xxx")
+        digest = asset.get("digest", "")
+        if not digest.startswith("sha256:"):
+            raise RuntimeError(f"Invalid digest format: {digest}")
+        expected_checksum = digest[7:]  # Remove "sha256:" prefix
+
+        download_url = asset["browser_download_url"]
+        return AgentBinaryVersion(version, expected_checksum, download_url)
+
+    def cached_binary_path(version: str, platform: SandboxPlatform) -> Path:
+        return cached_binary_dir / f"opencode-{version}-{platform}"
+
+    def list_cached_binaries() -> list[Path]:
+        return list(cached_binary_dir.glob("opencode-*"))
+
+    return AgentBinarySource(
+        agent="opencode",
+        binary="opencode",
+        resolve_version=resolve_version,
+        cached_binary_path=cached_binary_path,
+        list_cached_binaries=list_cached_binaries,
+        # The release asset is a tar.gz wrapping a single binary; unwrap it
+        # host-side so the staged file is the executable itself.
+        post_download=extract_tarball,
+        post_install=None,
+    )
 
 
 async def _fetch_latest_version() -> str:
     """Fetch the latest released opencode version from GitHub."""
-    release = await _fetch_latest_release()
-    return str(release["tag_name"]).lstrip("v")
+    latest_url = "https://api.github.com/repos/anomalyco/opencode/releases/latest"
+    latest = json.loads(await download_text_file(latest_url))
+    tag_name = str(latest["tag_name"])
+    return tag_name.lstrip("v")
 
 
-async def ensure_opencode_installed(
-    sandbox: SandboxEnvironment,
-    node_path: str,
-    version: str,
-    platform: SandboxPlatform,
-    user: str | None = None,
-) -> str:
-    """Install OpenCode via npm and return path to the opencode binary."""
-    install_dir = f"{SANDBOX_INSTALL_DIR}/opencode"
-    binary = f"{install_dir}/node_modules/.bin/opencode"
-
-    result = await sandbox.exec(bash_command(f"test -x {binary}"), user=user)
-    if result.success:
-        result = await sandbox.exec(cmd=[node_path, binary, "--version"], user=user)
-        if result.success and result.stdout.strip() == version:
-            return binary
-
-    async with concurrency("opencode-install", 1, visible=False):
-        bundle_data = create_npm_bundle(
-            package="opencode-ai",
-            version=version,
-            platform=platform,
-            cache_name="opencode-bundles",
-            ignore_scripts=True,
-        )
-        binary_path = await install_npm_bundle(
-            sandbox=sandbox,
-            bundle_data=bundle_data,
-            install_dir=install_dir,
-            binary_name="opencode",
-            user=user,
-        )
-        await _run_opencode_postinstall(sandbox, node_path, install_dir, user)
-        return binary_path
-
-
-async def _run_opencode_postinstall(
-    sandbox: SandboxEnvironment,
-    node_path: str,
-    install_dir: str,
-    user: str | None,
-) -> None:
-    """Run the opencode-ai postinstall script inside the sandbox.
-
-    The postinstall fetches the platform-specific opencode binary
-    (e.g. ``opencode-linux-arm64``). We skip it on the host (host is
-    typically darwin/arm64 and the linux-only bundle wouldn't contain
-    a matching package) and run it here where the platform matches.
-    """
-    package_dir = f"{install_dir}/node_modules/opencode-ai"
-    postinstall = f"{package_dir}/postinstall.mjs"
-
-    exists = await sandbox.exec(bash_command(f"test -f {postinstall}"), user=user)
-    if not exists.success:
-        return
-
-    result = await sandbox.exec(
-        cmd=[node_path, "postinstall.mjs"],
-        cwd=package_dir,
-        user=user,
-        timeout=120,
-    )
-    if not result.success:
-        raise RuntimeError(
-            f"opencode-ai postinstall failed:\n"
-            f"stdout: {result.stdout}\n"
-            f"stderr: {result.stderr}"
-        )
-
-
-async def _fetch_latest_release() -> dict[str, Any]:
-    """Fetch the latest release from GitHub."""
-    releases_url = "https://api.github.com/repos/anomalyco/opencode/releases"
-    release_json = await download_text_file(f"{releases_url}/latest")
-    return dict(json.loads(release_json))
+async def _fetch_release_assets(version: str) -> dict[str, Any]:
+    """Fetch release assets for a specific version."""
+    tag = f"v{version}"
+    release_url = f"https://api.github.com/repos/anomalyco/opencode/releases/tags/{tag}"
+    release_json = await download_text_file(release_url)
+    result: dict[str, Any] = json.loads(release_json)
+    return result

--- a/src/inspect_swe/_tools/download.py
+++ b/src/inspect_swe/_tools/download.py
@@ -4,6 +4,7 @@ from typing import Literal, NamedTuple
 
 from .._claude_code.agentbinary import claude_code_binary_source
 from .._codex_cli.agentbinary import codex_cli_binary_source
+from .._opencode.agentbinary import opencode_binary_source
 from .._util._async import run_coroutine
 from .._util.agentbinary import (
     AgentBinarySource,
@@ -15,7 +16,7 @@ from .._util.sandbox import SandboxPlatform
 class AgentBinary(NamedTuple):
     """Agent binary."""
 
-    agent: Literal["claude_code", "codex_cli"]
+    agent: Literal["claude_code", "codex_cli", "opencode"]
     """Agent type."""
 
     version: str
@@ -51,7 +52,7 @@ class AgentBinaries(list[AgentBinary]):
 
 
 def download_agent_binary(
-    binary: Literal["claude_code", "codex_cli"],
+    binary: Literal["claude_code", "codex_cli", "opencode"],
     version: Literal["stable", "latest"] | str,
     platform: SandboxPlatform,
 ) -> None:
@@ -66,19 +67,14 @@ def download_agent_binary(
         version: Version to download ("stable", "latest", or an explicit version number).
         platform: Target platform ("linux-x64", "linux-arm64", "linux-x64-musl", or "linux-arm64-musl")
     """
-    match binary:
-        case "claude_code":
-            source = claude_code_binary_source()
-        case "codex_cli":
-            source = codex_cli_binary_source()
-        case _:
-            raise ValueError(f"Unsuported agent binary type: {binary}")
+    source = _agent_binary_source(binary)
 
     run_coroutine(download_agent_binary_async(source, version, platform))
 
 
 def cached_agent_binaries(
-    binary: Literal["claude_code", "codex_cli"] | None = None, quiet: bool = False
+    binary: Literal["claude_code", "codex_cli", "opencode"] | None = None,
+    quiet: bool = False,
 ) -> AgentBinaries:
     """List the agent binaries which have been cached on this system.
 
@@ -92,7 +88,9 @@ def cached_agent_binaries(
     """
     if binary is None:
         return AgentBinaries(
-            cached_agent_binaries("claude_code") + cached_agent_binaries("codex_cli")
+            cached_agent_binaries("claude_code")
+            + cached_agent_binaries("codex_cli")
+            + cached_agent_binaries("opencode")
         )
 
     source = _agent_binary_source(binary)
@@ -139,12 +137,14 @@ def cached_agent_binaries(
 
 
 def _agent_binary_source(
-    binary: Literal["claude_code", "codex_cli"],
+    binary: Literal["claude_code", "codex_cli", "opencode"],
 ) -> AgentBinarySource:
     match binary:
         case "claude_code":
             return claude_code_binary_source()
         case "codex_cli":
             return codex_cli_binary_source()
+        case "opencode":
+            return opencode_binary_source()
         case _:
             raise ValueError(f"Unsuported agent binary type: {binary}")

--- a/src/inspect_swe/_util/agentbinary.py
+++ b/src/inspect_swe/_util/agentbinary.py
@@ -1,3 +1,4 @@
+import logging
 import threading
 from dataclasses import dataclass
 from pathlib import Path
@@ -8,7 +9,7 @@ from inspect_ai.util import sandbox as sandbox_env
 
 from inspect_swe._util.trace import trace
 
-from .checksum import verify_checksum
+from .checksum import ChecksumMismatchError, verify_checksum
 from .download import download_file
 from .sandbox import (
     SANDBOX_INSTALL_DIR,
@@ -17,6 +18,8 @@ from .sandbox import (
     detect_sandbox_platform,
     sandbox_exec,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class AgentBinaryVersion(NamedTuple):
@@ -169,13 +172,31 @@ async def ensure_agent_binary_installed(
                 )
                 resolved_version = resolved.version
                 package = resolved.package
+            except ChecksumMismatchError:
+                # integrity failure: the freshly-downloaded (or shared,
+                # already-failed) bytes did not match the expected digest.
+                # never mask this by silently installing unverified bytes
+                # from the legacy single-binary cache — a corrupted cache
+                # or a poisoned download must fail loudly, not fall through.
+                raise
             except Exception:
                 # offline fallback: a pinned version with a cached single
-                # binary still installs (without companion executables)
+                # binary still installs (without companion executables) when
+                # resolution/download failed for a network or availability
+                # reason (checksum failures are excluded above and always
+                # propagate).
                 if version not in ["stable", "latest"]:
                     binary_bytes = read_cached_binary(source, version, platform, None)
                 if binary_bytes is None:
                     raise
+                cache_path = source.cached_binary_path(version, platform)
+                logger.warning(
+                    f"{source.agent} {version} could not be resolved or "
+                    f"downloaded over the network; installing the cached "
+                    f"binary at {cache_path} ({platform}) WITHOUT checksum "
+                    "verification, because no digest can be obtained "
+                    "offline to verify it."
+                )
                 trace(
                     f"Unable to resolve {source.agent} {version}; using cached "
                     f"single binary ({platform})"
@@ -265,7 +286,7 @@ async def download_agent_binary_async(
         # not in cache, download and verify checksum
         binary_data = await download_file(download_url)
         if not verify_checksum(binary_data, expected_checksum):
-            raise ValueError("Checksum verification failed")
+            raise ChecksumMismatchError("Checksum verification failed")
 
         # apply post-download processing if provided (e.g., extract from tar.gz)
         if not resolved.package and source.post_download is not None:

--- a/src/inspect_swe/_util/agentbinary.py
+++ b/src/inspect_swe/_util/agentbinary.py
@@ -55,11 +55,61 @@ class AgentBinarySource:
 # because it only guards synchronous dict reads/writes — never held across
 # an await — and avoids issues with module-level anyio.Lock binding to a
 # stale event loop across multiple anyio.run() calls. No expiry: entries
-# live for the process lifetime. Two callers may race on the same key and
-# both call resolve_version(), but this is benign (same result) and unlikely
-# given the per-binary concurrency(1) lock in ensure_agent_binary_installed.
+# live for the process lifetime.
 _resolve_version_lock = threading.Lock()
 _resolved_versions: dict[tuple[str, str, SandboxPlatform], AgentBinaryVersion] = {}
+# per key: (number of failed resolutions so far, exception from the latest
+# one). Lets callers already queued behind a failing resolution share its
+# exception instead of each retrying in turn — mirrors
+# versioncache.cached_version_resolution's idiom for npm-installed agents.
+_failed_resolutions: dict[tuple[str, str, SandboxPlatform], tuple[int, Exception]] = {}
+
+
+async def _resolve_agent_binary_version(
+    source: AgentBinarySource,
+    version: Literal["stable", "latest"] | str,
+    platform: SandboxPlatform,
+) -> AgentBinaryVersion:
+    """Resolve a binary's version, reusing the result for the process lifetime.
+
+    Concurrent/queued callers for the same (binary, version, platform) key
+    share a single resolution — including its failure, so a burst of samples
+    hitting a rate-limited API produces one error, not one retry per queued
+    sample. Failures are not cached: a call arriving after a failed
+    resolution has completed retries.
+    """
+    cache_key = (source.binary, version, platform)
+    with _resolve_version_lock:
+        cached = _resolved_versions.get(cache_key)
+        if cached is not None:
+            return cached
+        failure = _failed_resolutions.get(cache_key)
+        failures_at_arrival = failure[0] if failure is not None else 0
+
+    # serialize per key so a burst of samples starting together makes one
+    # request rather than one each (in addition to, and independent of, the
+    # per-binary install concurrency(1) lock in ensure_agent_binary_installed)
+    async with concurrency(
+        f"{source.binary}-version-resolution-{version}-{platform}", 1, visible=False
+    ):
+        # another sample may have resolved (or failed) while we were waiting
+        with _resolve_version_lock:
+            cached = _resolved_versions.get(cache_key)
+            if cached is not None:
+                return cached
+            failure = _failed_resolutions.get(cache_key)
+        if failure is not None and failure[0] > failures_at_arrival:
+            raise failure[1]
+
+        try:
+            resolved = await source.resolve_version(version, platform)
+        except Exception as ex:
+            with _resolve_version_lock:
+                _failed_resolutions[cache_key] = (failures_at_arrival + 1, ex)
+            raise
+        with _resolve_version_lock:
+            _resolved_versions[cache_key] = resolved
+        return resolved
 
 
 async def ensure_agent_binary_installed(
@@ -187,16 +237,10 @@ async def download_agent_binary_async(
     logger = logger or print
 
     # determine version and checksum (cached so concurrent samples don't
-    # repeat upstream API calls that may be rate-limited)
-    cache_key = (source.binary, version, platform)
-    with _resolve_version_lock:
-        cached = _resolved_versions.get(cache_key)
-    if cached is not None:
-        resolved = cached
-    else:
-        resolved = await source.resolve_version(version, platform)
-        with _resolve_version_lock:
-            _resolved_versions[cache_key] = resolved
+    # repeat upstream API calls that may be rate-limited, sharing a failure
+    # too so a queue of samples behind a rate-limited call doesn't each
+    # retry it in turn)
+    resolved = await _resolve_agent_binary_version(source, version, platform)
     version = resolved.version
     expected_checksum = resolved.expected_checksum
     download_url = resolved.download_url

--- a/src/inspect_swe/_util/checksum.py
+++ b/src/inspect_swe/_util/checksum.py
@@ -1,6 +1,16 @@
 import hashlib
 
 
+class ChecksumMismatchError(ValueError):
+    """Downloaded (or shared-resolution) bytes did not match the expected digest.
+
+    Distinct from other ``ValueError``s raised in this module so callers can
+    single out an integrity failure (tampered/corrupted download) from
+    ordinary network or resolution failures — an integrity failure must
+    never be papered over by falling back to unverified cached bytes.
+    """
+
+
 def verify_checksum(data: bytes, expected_checksum: str) -> bool:
     actual_checksum = hashlib.sha256(data).hexdigest()
     return actual_checksum == expected_checksum

--- a/tests/test_agentbinary_install.py
+++ b/tests/test_agentbinary_install.py
@@ -245,3 +245,111 @@ def test_offline_pinned_version_falls_back_to_cached_binary(tmp_path: Path) -> N
 
     assert binary_path == f"{SANDBOX_INSTALL_DIR}/codex-9.9.6-linux-arm64"
     assert sandbox.written == [binary_path]
+
+
+def test_concurrent_version_resolution_shares_one_request(tmp_path: Path) -> None:
+    # a cold-start burst of concurrent installs for the same (binary,
+    # version, platform) key shares one resolve_version call, not one each
+    calls = 0
+
+    async def resolve_version(version: str, platform: str) -> AgentBinaryVersion:
+        nonlocal calls
+        calls += 1
+        # suspend so the other tasks reach the cache miss while this one is
+        # still in flight
+        await anyio.sleep(0.05)
+        return AgentBinaryVersion("9.5.1", "checksum", "https://example.com/pkg.tar.gz")
+
+    source = AgentBinarySource(
+        agent="test agent",
+        binary="test-agent-concurrent-ok",
+        resolve_version=resolve_version,
+        cached_binary_path=lambda v, p: tmp_path / f"{v}-{p}",
+        list_cached_binaries=lambda: [],
+        post_download=None,
+        post_install=None,
+    )
+    results: list[AgentBinaryVersion] = []
+
+    async def run() -> None:
+        async def one() -> None:
+            results.append(
+                await agentbinary._resolve_agent_binary_version(
+                    source, "9.5.1", "linux-x64"
+                )
+            )
+
+        async with anyio.create_task_group() as tg:
+            for _ in range(10):
+                tg.start_soon(one)
+
+    anyio.run(run)
+    assert calls == 1
+    assert results == [results[0]] * 10
+    assert results[0].version == "9.5.1"
+
+
+def test_concurrent_version_resolution_failure_is_shared(tmp_path: Path) -> None:
+    # callers queued behind a failing resolve_version share its exception —
+    # a rate-limit cascade across queued samples produces one failed API
+    # call, not one retry per queued sample
+    calls = 0
+    errors: list[Exception] = []
+
+    async def failing_resolve_version(
+        version: str, platform: str
+    ) -> AgentBinaryVersion:
+        nonlocal calls
+        calls += 1
+        await anyio.sleep(0.05)
+        raise RuntimeError("403 rate limited")
+
+    source = AgentBinarySource(
+        agent="test agent",
+        binary="test-agent-concurrent-fail",
+        resolve_version=failing_resolve_version,
+        cached_binary_path=lambda v, p: tmp_path / f"{v}-{p}",
+        list_cached_binaries=lambda: [],
+        post_download=None,
+        post_install=None,
+    )
+
+    async def run() -> None:
+        async def one() -> None:
+            try:
+                await agentbinary._resolve_agent_binary_version(
+                    source, "9.5.2", "linux-x64"
+                )
+            except RuntimeError as ex:
+                errors.append(ex)
+
+        async with anyio.create_task_group() as tg:
+            for _ in range(10):
+                tg.start_soon(one)
+
+    anyio.run(run)
+    assert calls == 1
+    assert len(errors) == 10
+    assert all(error is errors[0] for error in errors)
+
+    # a genuinely later call (after the failure completed) retries rather
+    # than replaying the stale failure forever — same (binary, version,
+    # platform) key, a fresh source whose resolve_version now succeeds
+    async def recovered_resolve_version(
+        version: str, platform: str
+    ) -> AgentBinaryVersion:
+        return AgentBinaryVersion("9.5.2", "checksum", "https://example.com/pkg.tar.gz")
+
+    retry_source = AgentBinarySource(
+        agent="test agent",
+        binary="test-agent-concurrent-fail",
+        resolve_version=recovered_resolve_version,
+        cached_binary_path=lambda v, p: tmp_path / f"{v}-{p}",
+        list_cached_binaries=lambda: [],
+        post_download=None,
+        post_install=None,
+    )
+    resolved = anyio.run(
+        agentbinary._resolve_agent_binary_version, retry_source, "9.5.2", "linux-x64"
+    )
+    assert resolved.version == "9.5.2"

--- a/tests/test_agentbinary_install.py
+++ b/tests/test_agentbinary_install.py
@@ -1,6 +1,7 @@
 """Unit tests for package-archive installs in the agent binary machinery."""
 
 import hashlib
+import logging
 from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
@@ -16,6 +17,7 @@ from inspect_swe._util.agentbinary import (
     download_agent_binary_async,
     ensure_agent_binary_installed,
 )
+from inspect_swe._util.checksum import ChecksumMismatchError
 from inspect_swe._util.sandbox import SANDBOX_INSTALL_DIR
 
 
@@ -219,11 +221,15 @@ def test_stale_single_binary_cache_still_installs_package(tmp_path: Path) -> Non
     assert not stale.exists()
 
 
-def test_offline_pinned_version_falls_back_to_cached_binary(tmp_path: Path) -> None:
-    # when resolution fails (offline) a pinned version with a cached single
-    # binary still installs, without the package
+def test_offline_pinned_version_falls_back_to_cached_binary(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    # when resolution fails for a network/availability reason (offline) a
+    # pinned version with a cached single binary still installs, without the
+    # package -- and a loud warning names the unverified fallback
     source = _package_source(tmp_path)  # resolve_version raises (resolved=None)
-    source.cached_binary_path("9.9.6", "linux-arm64").write_bytes(b"single-binary")
+    cache_path = source.cached_binary_path("9.9.6", "linux-arm64")
+    cache_path.write_bytes(b"single-binary")
 
     sandbox = _FakeSandbox(installed=False)
     with (
@@ -234,6 +240,7 @@ def test_offline_pinned_version_falls_back_to_cached_binary(tmp_path: Path) -> N
         ),
         patch.object(agentbinary, "trace", lambda msg: None),
         patch.object(agentbinary, "sandbox_exec", AsyncMock(return_value="")),
+        caplog.at_level(logging.WARNING, logger="inspect_swe._util.agentbinary"),
     ):
         binary_path = anyio.run(
             ensure_agent_binary_installed,
@@ -245,6 +252,92 @@ def test_offline_pinned_version_falls_back_to_cached_binary(tmp_path: Path) -> N
 
     assert binary_path == f"{SANDBOX_INSTALL_DIR}/codex-9.9.6-linux-arm64"
     assert sandbox.written == [binary_path]
+    assert len(caplog.records) == 1
+    warning = caplog.records[0].getMessage()
+    assert "9.9.6" in warning
+    assert str(cache_path) in warning
+    assert "WITHOUT checksum" in warning
+
+
+def test_checksum_mismatch_raises_without_cached_fallback(tmp_path: Path) -> None:
+    # a checksum failure is an integrity failure, not a network/resolution
+    # failure -- it must propagate rather than being treated like offline
+    # unavailability and swallowed into the unverified-cache fallback
+    resolved = AgentBinaryVersion(
+        "9.9.3",
+        hashlib.sha256(b"correct-bytes").hexdigest(),
+        "https://example.com/codex.tar.gz",
+        False,
+    )
+    source = _package_source(tmp_path, resolved)
+
+    sandbox = _FakeSandbox(installed=False)
+    with (
+        patch.object(
+            agentbinary,
+            "detect_sandbox_platform",
+            AsyncMock(return_value="linux-arm64"),
+        ),
+        patch.object(agentbinary, "trace", lambda msg: None),
+        patch.object(agentbinary, "sandbox_exec", AsyncMock(return_value="")),
+        patch.object(
+            agentbinary, "download_file", AsyncMock(return_value=b"tampered-bytes")
+        ),
+        pytest.raises(ChecksumMismatchError),
+    ):
+        anyio.run(
+            ensure_agent_binary_installed,
+            source,
+            "9.9.3",
+            None,
+            cast(SandboxEnvironment, sandbox),
+        )
+
+    assert sandbox.written == []
+
+
+def test_corrupted_package_download_does_not_fall_back_to_legacy_cache(
+    tmp_path: Path,
+) -> None:
+    # regression: a package-capable source whose download fails checksum
+    # verification (tampered/corrupted release asset) must not silently
+    # install an untouched legacy single-binary cache left by an older
+    # inspect_swe -- that cache lives at a different path than the package
+    # cache, so it survives the failed download and must still not be used
+    resolved = AgentBinaryVersion(
+        "9.9.5",
+        hashlib.sha256(b"correct-bytes").hexdigest(),
+        "https://example.com/pkg.tar.gz",
+        True,
+    )
+    source = _package_source(tmp_path, resolved)
+    legacy = source.cached_binary_path("9.9.5", "linux-arm64")
+    legacy.write_bytes(b"legacy-single-binary")
+
+    sandbox = _FakeSandbox(installed=False)
+    with (
+        patch.object(
+            agentbinary,
+            "detect_sandbox_platform",
+            AsyncMock(return_value="linux-arm64"),
+        ),
+        patch.object(agentbinary, "trace", lambda msg: None),
+        patch.object(agentbinary, "sandbox_exec", AsyncMock(return_value="")),
+        patch.object(
+            agentbinary, "download_file", AsyncMock(return_value=b"tampered-bytes")
+        ),
+        pytest.raises(ChecksumMismatchError),
+    ):
+        anyio.run(
+            ensure_agent_binary_installed,
+            source,
+            "9.9.5",
+            None,
+            cast(SandboxEnvironment, sandbox),
+        )
+
+    assert sandbox.written == []
+    assert legacy.read_bytes() == b"legacy-single-binary"
 
 
 def test_concurrent_version_resolution_shares_one_request(tmp_path: Path) -> None:

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,7 +1,7 @@
 import sys
 from pathlib import Path
 from typing import Literal
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from inspect_swe import (
@@ -45,6 +45,32 @@ def test_codex_cli_binary_download() -> None:
     assert cached[0].agent == "codex_cli"
     assert cached[0].path.exists()
     assert cached[0].path.stat().st_size > 0
+
+
+def test_opencode_download_routes_to_opencode_source() -> None:
+    # the docs' offline-install path (download_agent_binary("opencode", ...))
+    # must route to the opencode binary source rather than raising ValueError
+    from inspect_swe._tools import download as download_tool
+
+    mock_download = AsyncMock(return_value=(b"", None))
+    with patch.object(download_tool, "download_agent_binary_async", mock_download):
+        download_agent_binary("opencode", "1.14.30", "linux-x64")
+
+    assert mock_download.await_args is not None
+    source, version, platform = mock_download.await_args.args
+    assert source.agent == "opencode"
+    assert version == "1.14.30"
+    assert platform == "linux-x64"
+
+
+def test_cached_agent_binaries_lists_opencode(tmp_path: Path) -> None:
+    from inspect_swe._opencode import agentbinary as opencode_agentbinary
+
+    with patch.object(opencode_agentbinary, "package_cache_dir", return_value=tmp_path):
+        (tmp_path / "opencode-package-1.14.30-linux-x64.tar.gz").write_bytes(b"x")
+        cached = cached_agent_binaries("opencode")
+
+    assert [(b.agent, b.version) for b in cached] == [("opencode", "1.14.30")]
 
 
 @pytest.mark.slow

--- a/tests/test_opencode_setup.py
+++ b/tests/test_opencode_setup.py
@@ -138,14 +138,21 @@ def test_opencode_resolve_version_resolves_alias_with_a_single_api_call() -> Non
 
 
 def test_opencode_resolve_version_raises_when_platform_asset_missing() -> None:
+    release = {
+        "assets": [
+            {
+                "name": "opencode-linux-x64.tar.gz",
+                "digest": "sha256:default-x64",
+                "browser_download_url": "https://example.com/opencode-linux-x64.tar.gz",
+            }
+        ]
+    }
     source = agentbinary.opencode_binary_source()
     with patch.object(
-        agentbinary,
-        "_fetch_release_assets",
-        AsyncMock(return_value=_RELEASE_ASSETS),
+        agentbinary, "_fetch_release_assets", AsyncMock(return_value=release)
     ):
         with pytest.raises(RuntimeError, match="No matching asset"):
-            anyio.run(source.resolve_version, "0.42.0", "windows-x64")
+            anyio.run(source.resolve_version, "0.42.0", "linux-arm64")
 
 
 def test_opencode_resolve_version_raises_on_malformed_digest() -> None:

--- a/tests/test_opencode_setup.py
+++ b/tests/test_opencode_setup.py
@@ -1,25 +1,124 @@
 """Tests for the OpenCode agent install/setup utilities."""
 
-import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
 
+import anyio
 import pytest
 from inspect_ai import Task, eval
 from inspect_ai.dataset import Sample
 from inspect_ai.scorer import Score, Scorer, Target, scorer
 from inspect_ai.solver import Generate, Solver, TaskState, solver
 from inspect_ai.util import sandbox
-from inspect_swe._opencode.agentbinary import (
-    ensure_opencode_setup,
-    resolve_opencode_version,
-)
+from inspect_swe._opencode import agentbinary
+from inspect_swe._opencode.agentbinary import ensure_opencode_setup
 
 from tests.conftest import skip_if_no_docker
 
+_RELEASE_ASSETS = {
+    "assets": [
+        {
+            "name": "opencode-linux-x64.tar.gz",
+            "digest": "sha256:aaa",
+            "browser_download_url": "https://example.com/opencode-linux-x64.tar.gz",
+        },
+        {
+            "name": "opencode-linux-arm64.tar.gz",
+            "digest": "sha256:bbb",
+            "browser_download_url": "https://example.com/opencode-linux-arm64.tar.gz",
+        },
+    ]
+}
 
-def test_resolve_version_literal() -> None:
-    """Explicit semver strings are returned as-is without hitting the network."""
-    assert asyncio.run(resolve_opencode_version("1.14.30")) == "1.14.30"
-    assert asyncio.run(resolve_opencode_version("0.42.0")) == "0.42.0"
+
+def test_opencode_resolve_version_matches_platform_asset() -> None:
+    # each platform has its own dynamically-linked build; the resolved asset
+    # must be the one whose name matches the sandbox's detected platform, not
+    # just any asset in the release
+    source = agentbinary.opencode_binary_source()
+    with patch.object(
+        agentbinary,
+        "_fetch_release_assets",
+        AsyncMock(return_value=_RELEASE_ASSETS),
+    ):
+        resolved = anyio.run(source.resolve_version, "0.42.0", "linux-arm64")
+    assert resolved.version == "0.42.0"
+    assert resolved.expected_checksum == "bbb"
+    assert resolved.download_url.endswith("opencode-linux-arm64.tar.gz")
+    assert resolved.package is False
+
+
+def test_opencode_resolve_version_resolves_alias_before_fetching() -> None:
+    # "stable"/"latest" must resolve to a concrete version before the
+    # per-version release lookup, so the asset request targets a real tag
+    source = agentbinary.opencode_binary_source()
+    with (
+        patch.object(
+            agentbinary, "_fetch_latest_version", AsyncMock(return_value="1.14.30")
+        ),
+        patch.object(
+            agentbinary,
+            "_fetch_release_assets",
+            AsyncMock(return_value=_RELEASE_ASSETS),
+        ) as mock_fetch_assets,
+    ):
+        resolved = anyio.run(source.resolve_version, "stable", "linux-x64")
+    mock_fetch_assets.assert_awaited_once_with("1.14.30")
+    assert resolved.version == "1.14.30"
+    assert resolved.expected_checksum == "aaa"
+
+
+def test_opencode_resolve_version_raises_when_platform_asset_missing() -> None:
+    source = agentbinary.opencode_binary_source()
+    with patch.object(
+        agentbinary,
+        "_fetch_release_assets",
+        AsyncMock(return_value=_RELEASE_ASSETS),
+    ):
+        with pytest.raises(RuntimeError, match="No asset"):
+            anyio.run(source.resolve_version, "0.42.0", "windows-x64")
+
+
+def test_opencode_resolve_version_raises_on_malformed_digest() -> None:
+    release = {
+        "assets": [
+            {
+                "name": "opencode-linux-x64.tar.gz",
+                "digest": "md5:not-sha256",
+                "browser_download_url": "https://example.com/opencode-linux-x64.tar.gz",
+            }
+        ]
+    }
+    source = agentbinary.opencode_binary_source()
+    with patch.object(
+        agentbinary, "_fetch_release_assets", AsyncMock(return_value=release)
+    ):
+        with pytest.raises(RuntimeError, match="Invalid digest format"):
+            anyio.run(source.resolve_version, "0.42.0", "linux-x64")
+
+
+def test_opencode_source_caches_by_version_and_platform(tmp_path: Path) -> None:
+    # the standalone binary is not a package archive: no package_entrypoint or
+    # cached_package_path, and cached files are keyed by version + platform so
+    # concurrent samples on different platforms don't collide
+    with patch.object(agentbinary, "package_cache_dir", return_value=tmp_path):
+        source = agentbinary.opencode_binary_source()
+    assert source.package_entrypoint is None
+    assert source.cached_package_path is None
+    cache_path = source.cached_binary_path("0.42.0", "linux-arm64")
+    assert cache_path == tmp_path / "opencode-0.42.0-linux-arm64"
+
+
+def test_opencode_list_cached_binaries(tmp_path: Path) -> None:
+    with patch.object(agentbinary, "package_cache_dir", return_value=tmp_path):
+        source = agentbinary.opencode_binary_source()
+    (tmp_path / "opencode-0.42.0-linux-arm64").write_bytes(b"binary")
+    (tmp_path / "opencode-0.41.0-linux-x64").write_bytes(b"binary")
+    (tmp_path / "unrelated-file").write_bytes(b"noise")
+    assert {p.name for p in source.list_cached_binaries()} == {
+        "opencode-0.42.0-linux-arm64",
+        "opencode-0.41.0-linux-x64",
+    }
 
 
 @solver

--- a/tests/test_opencode_setup.py
+++ b/tests/test_opencode_setup.py
@@ -1,6 +1,7 @@
 """Tests for the OpenCode agent install/setup utilities."""
 
 from pathlib import Path
+from typing import cast
 from unittest.mock import AsyncMock, patch
 
 import anyio
@@ -9,63 +10,131 @@ from inspect_ai import Task, eval
 from inspect_ai.dataset import Sample
 from inspect_ai.scorer import Score, Scorer, Target, scorer
 from inspect_ai.solver import Generate, Solver, TaskState, solver
-from inspect_ai.util import sandbox
+from inspect_ai.util import SandboxEnvironment, sandbox
 from inspect_swe._opencode import agentbinary
 from inspect_swe._opencode.agentbinary import ensure_opencode_setup
+from inspect_swe._util.sandbox import SandboxPlatform
 
 from tests.conftest import skip_if_no_docker
 
+# mirrors the real anomalyco/opencode release shape: every x64 platform ships
+# both an AVX2-optimized default build and a "-baseline" build without it;
+# arm64 has no baseline variant (AVX2 is an x86 extension).
 _RELEASE_ASSETS = {
+    "tag_name": "v1.14.30",
     "assets": [
         {
             "name": "opencode-linux-x64.tar.gz",
-            "digest": "sha256:aaa",
+            "digest": "sha256:default-x64",
             "browser_download_url": "https://example.com/opencode-linux-x64.tar.gz",
         },
         {
+            "name": "opencode-linux-x64-baseline.tar.gz",
+            "digest": "sha256:baseline-x64",
+            "browser_download_url": "https://example.com/opencode-linux-x64-baseline.tar.gz",
+        },
+        {
+            "name": "opencode-linux-x64-musl.tar.gz",
+            "digest": "sha256:default-x64-musl",
+            "browser_download_url": "https://example.com/opencode-linux-x64-musl.tar.gz",
+        },
+        {
+            "name": "opencode-linux-x64-baseline-musl.tar.gz",
+            "digest": "sha256:baseline-x64-musl",
+            "browser_download_url": "https://example.com/opencode-linux-x64-baseline-musl.tar.gz",
+        },
+        {
             "name": "opencode-linux-arm64.tar.gz",
-            "digest": "sha256:bbb",
+            "digest": "sha256:arm64",
             "browser_download_url": "https://example.com/opencode-linux-arm64.tar.gz",
         },
-    ]
+        {
+            "name": "opencode-linux-arm64-musl.tar.gz",
+            "digest": "sha256:arm64-musl",
+            "browser_download_url": "https://example.com/opencode-linux-arm64-musl.tar.gz",
+        },
+    ],
 }
 
 
-def test_opencode_resolve_version_matches_platform_asset() -> None:
-    # each platform has its own dynamically-linked build; the resolved asset
-    # must be the one whose name matches the sandbox's detected platform, not
-    # just any asset in the release
+@pytest.mark.parametrize(
+    "platform,expected_checksum,expected_url_suffix",
+    [
+        ("linux-x64", "baseline-x64", "opencode-linux-x64-baseline.tar.gz"),
+        (
+            "linux-x64-musl",
+            "baseline-x64-musl",
+            "opencode-linux-x64-baseline-musl.tar.gz",
+        ),
+        ("linux-arm64", "arm64", "opencode-linux-arm64.tar.gz"),
+        ("linux-arm64-musl", "arm64-musl", "opencode-linux-arm64-musl.tar.gz"),
+    ],
+)
+def test_opencode_resolve_version_prefers_baseline_asset_on_x64(
+    platform: SandboxPlatform, expected_checksum: str, expected_url_suffix: str
+) -> None:
+    # x64 platforms must resolve to the AVX2-baseline asset: we install
+    # host-side, before any in-sandbox CPU probe runs, and can't reliably
+    # read the underlying host's CPU flags from out here, so the baseline
+    # build is the only choice that can't SIGILL crash on a pre-AVX2 host.
+    # arm64 has no baseline variant and resolves its single asset unchanged.
     source = agentbinary.opencode_binary_source()
     with patch.object(
         agentbinary,
         "_fetch_release_assets",
         AsyncMock(return_value=_RELEASE_ASSETS),
     ):
-        resolved = anyio.run(source.resolve_version, "0.42.0", "linux-arm64")
+        resolved = anyio.run(source.resolve_version, "0.42.0", platform)
     assert resolved.version == "0.42.0"
-    assert resolved.expected_checksum == "bbb"
-    assert resolved.download_url.endswith("opencode-linux-arm64.tar.gz")
-    assert resolved.package is False
+    assert resolved.expected_checksum == expected_checksum
+    assert resolved.download_url.endswith(expected_url_suffix)
+    assert resolved.package is True
 
 
-def test_opencode_resolve_version_resolves_alias_before_fetching() -> None:
-    # "stable"/"latest" must resolve to a concrete version before the
-    # per-version release lookup, so the asset request targets a real tag
+def test_opencode_resolve_version_falls_back_without_baseline_asset() -> None:
+    # an older release that never published a baseline asset still resolves
+    # for x64 — the candidate list falls back to the default build rather
+    # than failing outright.
+    release = {
+        "assets": [
+            {
+                "name": "opencode-linux-x64.tar.gz",
+                "digest": "sha256:default-only",
+                "browser_download_url": "https://example.com/opencode-linux-x64.tar.gz",
+            }
+        ]
+    }
+    source = agentbinary.opencode_binary_source()
+    with patch.object(
+        agentbinary, "_fetch_release_assets", AsyncMock(return_value=release)
+    ):
+        resolved = anyio.run(source.resolve_version, "0.10.0", "linux-x64")
+    assert resolved.expected_checksum == "default-only"
+    assert resolved.download_url.endswith("opencode-linux-x64.tar.gz")
+
+
+def test_opencode_resolve_version_resolves_alias_with_a_single_api_call() -> None:
+    # /releases/latest returns both the tag name and the full asset list in
+    # one response, so "stable"/"latest" must resolve with exactly one API
+    # call — a tag lookup followed by a second, per-tag lookup would double
+    # the request count and how often a sample queued behind a rate-limited
+    # neighbor repeats the exact call that just failed.
     source = agentbinary.opencode_binary_source()
     with (
         patch.object(
-            agentbinary, "_fetch_latest_version", AsyncMock(return_value="1.14.30")
-        ),
-        patch.object(
             agentbinary,
-            "_fetch_release_assets",
+            "_fetch_latest_release",
             AsyncMock(return_value=_RELEASE_ASSETS),
+        ) as mock_fetch_latest,
+        patch.object(
+            agentbinary, "_fetch_release_assets", AsyncMock()
         ) as mock_fetch_assets,
     ):
         resolved = anyio.run(source.resolve_version, "stable", "linux-x64")
-    mock_fetch_assets.assert_awaited_once_with("1.14.30")
+    mock_fetch_latest.assert_awaited_once()
+    mock_fetch_assets.assert_not_awaited()
     assert resolved.version == "1.14.30"
-    assert resolved.expected_checksum == "aaa"
+    assert resolved.expected_checksum == "baseline-x64"
 
 
 def test_opencode_resolve_version_raises_when_platform_asset_missing() -> None:
@@ -75,7 +144,7 @@ def test_opencode_resolve_version_raises_when_platform_asset_missing() -> None:
         "_fetch_release_assets",
         AsyncMock(return_value=_RELEASE_ASSETS),
     ):
-        with pytest.raises(RuntimeError, match="No asset"):
+        with pytest.raises(RuntimeError, match="No matching asset"):
             anyio.run(source.resolve_version, "0.42.0", "windows-x64")
 
 
@@ -97,28 +166,83 @@ def test_opencode_resolve_version_raises_on_malformed_digest() -> None:
             anyio.run(source.resolve_version, "0.42.0", "linux-x64")
 
 
-def test_opencode_source_caches_by_version_and_platform(tmp_path: Path) -> None:
-    # the standalone binary is not a package archive: no package_entrypoint or
-    # cached_package_path, and cached files are keyed by version + platform so
-    # concurrent samples on different platforms don't collide
+def test_opencode_source_uses_package_archive_caching(tmp_path: Path) -> None:
+    # the release asset is a tar.gz wrapping the binary: it is staged as a
+    # "package" archive (cached verbatim, checksum and all, extracted in the
+    # sandbox at install time) rather than transformed host-side into a blob
+    # a later cache hit can no longer verify against the release digest.
+    # cache paths stay keyed by version + platform so concurrent samples on
+    # different platforms don't collide.
     with patch.object(agentbinary, "package_cache_dir", return_value=tmp_path):
         source = agentbinary.opencode_binary_source()
-    assert source.package_entrypoint is None
-    assert source.cached_package_path is None
-    cache_path = source.cached_binary_path("0.42.0", "linux-arm64")
-    assert cache_path == tmp_path / "opencode-0.42.0-linux-arm64"
+    assert source.package_entrypoint == "opencode"
+    assert source.post_download is None
+    assert source.cached_package_path is not None
+    package_path = source.cached_package_path("0.42.0", "linux-arm64")
+    assert package_path == tmp_path / "opencode-package-0.42.0-linux-arm64.tar.gz"
+    # the legacy single-binary layout still resolves, as an offline-fallback
+    # read path for caches written before opencode moved to package-archive
+    # caching
+    legacy_path = source.cached_binary_path("0.42.0", "linux-arm64")
+    assert legacy_path == tmp_path / "opencode-0.42.0-linux-arm64"
 
 
 def test_opencode_list_cached_binaries(tmp_path: Path) -> None:
     with patch.object(agentbinary, "package_cache_dir", return_value=tmp_path):
         source = agentbinary.opencode_binary_source()
     (tmp_path / "opencode-0.42.0-linux-arm64").write_bytes(b"binary")
-    (tmp_path / "opencode-0.41.0-linux-x64").write_bytes(b"binary")
+    (tmp_path / "opencode-package-0.41.0-linux-x64.tar.gz").write_bytes(b"archive")
     (tmp_path / "unrelated-file").write_bytes(b"noise")
     assert {p.name for p in source.list_cached_binaries()} == {
         "opencode-0.42.0-linux-arm64",
-        "opencode-0.41.0-linux-x64",
+        "opencode-package-0.41.0-linux-x64.tar.gz",
     }
+
+
+def test_ensure_opencode_setup_delegates_to_ensure_agent_binary_installed() -> None:
+    # ensure_opencode_setup must install opencode through the shared
+    # host-side AgentBinarySource path (ensure_agent_binary_installed), not
+    # reimplement its own sandbox-side install/download logic.
+    sbox = cast(SandboxEnvironment, object())
+    fake_source = object()
+
+    async def fake_detect_sandbox_platform(sandbox: object) -> str:
+        return "linux-x64"
+
+    async def fake_ensure_node_available(
+        sandbox: object, platform: object, user: object
+    ) -> str:
+        return "/usr/local/bin/node"
+
+    async def fake_ensure_ripgrep_available(
+        sandbox: object, platform: object, user: object
+    ) -> str:
+        return "/usr/local/bin"
+
+    mock_ensure_installed = AsyncMock(return_value="/opt/opencode/opencode")
+    with (
+        patch.object(
+            agentbinary, "detect_sandbox_platform", fake_detect_sandbox_platform
+        ),
+        patch.object(agentbinary, "ensure_node_available", fake_ensure_node_available),
+        patch.object(
+            agentbinary, "ensure_ripgrep_available", fake_ensure_ripgrep_available
+        ),
+        patch.object(
+            agentbinary, "opencode_binary_source", return_value=fake_source
+        ) as mock_source,
+        patch.object(
+            agentbinary, "ensure_agent_binary_installed", mock_ensure_installed
+        ),
+    ):
+        binary, dependency_bin_dirs = anyio.run(
+            ensure_opencode_setup, sbox, "stable", None
+        )
+
+    mock_source.assert_called_once()
+    mock_ensure_installed.assert_awaited_once_with(fake_source, "stable", None, sbox)
+    assert binary == "/opt/opencode/opencode"
+    assert dependency_bin_dirs == ["/usr/local/bin", "/usr/local/bin"]
 
 
 @solver

--- a/tests/test_version_cache.py
+++ b/tests/test_version_cache.py
@@ -11,7 +11,6 @@ from unittest.mock import AsyncMock, patch
 import anyio
 import pytest
 from inspect_swe._gemini_cli import agentbinary as gemini_agentbinary
-from inspect_swe._opencode import agentbinary as opencode_agentbinary
 from inspect_swe._util import versioncache
 from inspect_swe._util.versioncache import cached_version_resolution
 
@@ -62,7 +61,6 @@ def _const(value: str) -> Any:
     "module,resolve_name,cache_key",
     [
         (gemini_agentbinary, "resolve_gemini_version", "gemini-cli"),
-        (opencode_agentbinary, "resolve_opencode_version", "opencode"),
     ],
 )
 def test_latest_resolution_fetches_once_across_calls(
@@ -85,7 +83,6 @@ def test_latest_resolution_fetches_once_across_calls(
     "module,resolve_name",
     [
         (gemini_agentbinary, "resolve_gemini_version"),
-        (opencode_agentbinary, "resolve_opencode_version"),
     ],
 )
 def test_version_aliases_share_a_cache_entry(module: Any, resolve_name: str) -> None:
@@ -106,7 +103,6 @@ def test_version_aliases_share_a_cache_entry(module: Any, resolve_name: str) -> 
     "module,resolve_name",
     [
         (gemini_agentbinary, "resolve_gemini_version"),
-        (opencode_agentbinary, "resolve_opencode_version"),
     ],
 )
 def test_explicit_version_never_fetches(module: Any, resolve_name: str) -> None:
@@ -127,7 +123,6 @@ def test_explicit_version_never_fetches(module: Any, resolve_name: str) -> None:
     "module,resolve_name",
     [
         (gemini_agentbinary, "resolve_gemini_version"),
-        (opencode_agentbinary, "resolve_opencode_version"),
     ],
 )
 def test_concurrent_resolution_makes_one_request(
@@ -165,7 +160,6 @@ def test_concurrent_resolution_makes_one_request(
     "module,resolve_name",
     [
         (gemini_agentbinary, "resolve_gemini_version"),
-        (opencode_agentbinary, "resolve_opencode_version"),
     ],
 )
 def test_concurrent_failure_is_shared(module: Any, resolve_name: str) -> None:
@@ -215,7 +209,6 @@ def test_concurrent_failure_is_shared(module: Any, resolve_name: str) -> None:
     "module,resolve_name",
     [
         (gemini_agentbinary, "resolve_gemini_version"),
-        (opencode_agentbinary, "resolve_opencode_version"),
     ],
 )
 def test_failed_resolution_is_not_cached(module: Any, resolve_name: str) -> None:


### PR DESCRIPTION

## Summary

`opencode` (the coding agent, run as an `inspect_swe` solver) currently fails to
install in a network-isolated sandbox: `ensure_opencode_installed` runs `npm`
*inside* the sandbox to fetch `opencode-ai`, and that install hangs waiting on
egress to the npm registry that a locked-down sandbox will never grant.

This brings `opencode` onto the same acquisition path `claude_code` and
`codex_cli` already use — `ensure_agent_binary_installed` /
`AgentBinarySource` — because OpenCode ships a standalone, self-contained
binary per platform on its GitHub releases. The runner:

1. Probes the sandbox with `which opencode` and reuses whatever is already
   installed/overlaid there (unchanged behavior for `version="auto"`/`"sandbox"`).
2. Otherwise resolves the requested version (`stable`/`latest`/an explicit
   semver) against the GitHub Releases API, downloads the matching
   platform-specific release tarball **host-side**, verifies its sha256
   checksum, unwraps the tarball to the bare binary, and writes it into the
   sandbox.

No step requires the sandbox to reach any external host, so `opencode` now
installs correctly in a network-isolated sandbox exactly like `claude_code`
and `codex_cli` already do.

## Why not keep npm as a fallback

OpenCode's GitHub releases publish a binary for every platform
`detect_sandbox_platform` can report (glibc and musl builds per arch), so
there is no platform this repo supports that lacks a standalone asset.
Keeping the npm path alongside it would mean carrying two acquisition
mechanisms for zero coverage gain, so it is removed rather than kept as a
fallback — matching `claude_code`, which has no npm path at all.

## Changes

- `src/inspect_swe/_opencode/agentbinary.py`: replace the npm-bundle install
  (`create_npm_bundle`/`install_npm_bundle`, `resolve_opencode_version`,
  `ensure_opencode_installed`, `_run_opencode_postinstall`) with
  `opencode_binary_source()` + `ensure_agent_binary_installed`, matching the
  `codex_cli_binary_source()` / `claude_code_binary_source()` pattern. Version
  resolution (`stable`/`latest` -> GitHub Releases API), checksum extraction,
  and the sandbox `which`-probe / caching all now flow through the shared
  `_util/agentbinary.py` machinery instead of bespoke opencode-only logic.
  `node` and `ripgrep` acquisition (dependency bin dirs) are unchanged.
- `tests/test_opencode_setup.py`: drop the npm-era `test_resolve_version_literal`
  test (the function it covered no longer exists) and add unit coverage for
  `opencode_binary_source()`: platform-matched asset selection, alias
  resolution before the release fetch, the "no asset for this platform" and
  "malformed digest" error paths, and cache-path/cache-listing behavior. The
  existing docker-sandbox integration test (`test_install_opencode_in_docker_sandbox`)
  is unchanged.
- `tests/test_version_cache.py`: drop opencode from the
  `versioncache.cached_version_resolution` parametrized cases — that shared
  cache belonged to the old `resolve_opencode_version` function, which no
  longer exists; version-resolution caching for opencode is now handled by
  `_util/agentbinary.py`'s own in-process cache, the same as `claude_code` and
  `codex_cli` (neither of which was ever in this parametrization).

## Testing

```
uv run pytest tests/test_opencode_setup.py tests/test_version_cache.py -v
```

14 passed, 1 skipped (`test_install_opencode_in_docker_sandbox` skips without
a docker daemon). The 6 new/changed `test_opencode_setup.py` unit tests fail
against the pre-change implementation with `AttributeError: module
'inspect_swe._opencode.agentbinary' has no attribute 'opencode_binary_source'`
(and similarly for `package_cache_dir`), confirming they exercise the new
code path rather than passing vacuously.