### PR TITLE
feat: let centaur sessions customize commands and run as a non-root user

### DIFF
--- a/src/inspect_swe/_claude_code/claude_code.py
+++ b/src/inspect_swe/_claude_code/claude_code.py
@@ -44,7 +44,7 @@ from inspect_swe._claude_code._events.stream import (
     StderrEvent,
     claude_code_event_stream,
 )
-from inspect_swe._util.centaur import CentaurOptions, run_centaur
+from inspect_swe._util.centaur import CentaurOptions, CommandsFilter, run_centaur
 from inspect_swe._util.mcp_ready import (
     DEFAULT_MCP_READY_TIMEOUT,
     wait_for_mcp_endpoints,
@@ -136,6 +136,7 @@ def claude_code(
     haiku_model: str | None = None,
     subagent_model: str | None = None,
     filter: GenerateFilter | None = None,
+    commands_filter: CommandsFilter | None = None,
     permission_mode: ClaudeCodePermissionMode | None = None,
     retry_refusals: int | None = 3,
     retry_uncaught_errors: int | None = 3,
@@ -214,6 +215,9 @@ def claude_code(
         haiku_model: The model to use for haiku, or [background functionality](https://code.claude.com/docs/en/costs#background-token-usage). Defaults to `model`.
         subagent_model: The model to use for [subagents](https://code.claude.com/docs/en/sub-agents). Defaults to `model`.
         filter: Filter for intercepting bridged model requests.
+        commands_filter: In centaur mode only, filter or augment the human agent's
+            task commands (for example to install project-specific submit/score
+            commands). Ignored outside centaur mode.
         permission_mode: Claude Code `--permission-mode`. The complete CLI set is
             `"acceptEdits"`, `"auto"`, `"bypassPermissions"`, `"default"`,
             `"dontAsk"`, and `"plan"`. `"bypassPermissions"` is near-equivalent
@@ -452,6 +456,8 @@ def claude_code(
                     claude_cmd=[claude_binary] + cmd,
                     agent_env=agent_env,
                     state=state,
+                    user=user,
+                    commands_filter=commands_filter,
                 )
             else:
                 # execute the agent (track debug output)
@@ -749,6 +755,8 @@ async def run_claude_code_centaur(
     claude_cmd: list[str],
     agent_env: dict[str, str],
     state: AgentState,
+    user: str | None = None,
+    commands_filter: CommandsFilter | None = None,
 ) -> None:
     instructions = "Claude Code:\n\n - You may also use Claude Code via the 'claude' command.\n - Use 'claude --resume' if you need to resume a previous claude session."
 
@@ -767,7 +775,9 @@ async def run_claude_code_centaur(
     )
 
     # run the human cli
-    await run_centaur(options, instructions, bashrc, state)
+    await run_centaur(
+        options, instructions, bashrc, state, user=user, commands_filter=commands_filter
+    )
 
 
 class ClaudeCodeDebug(StoreModel):

--- a/src/inspect_swe/_codex_cli/codex_cli.py
+++ b/src/inspect_swe/_codex_cli/codex_cli.py
@@ -104,7 +104,6 @@ def codex_cli(
     goals: bool = True,
     auto_review: bool | CodexAutoReview = False,
     centaur: bool | CentaurOptions = False,
-    commands_filter: CommandsFilter | None = None,
     attempts: int | AgentAttempts = 1,
     model: str | None = None,
     model_aliases: dict[str, str | Model] | None = None,
@@ -123,6 +122,8 @@ def codex_cli(
     approval_policy: CodexApprovalPolicy = "never",
     network_access: bool = True,
     approve_static_mcp_tools: bool = False,
+    *,
+    commands_filter: CommandsFilter | None = None,
     **deprecated_args: Unpack[CodexDeprecatedArgs],
 ) -> Agent:
     """Codex CLI.

--- a/src/inspect_swe/_codex_cli/codex_cli.py
+++ b/src/inspect_swe/_codex_cli/codex_cli.py
@@ -36,7 +36,7 @@ from inspect_ai.util._sandbox import ExecRemoteAwaitableOptions
 from typing_extensions import Unpack
 
 from inspect_swe._util._async import is_callable_coroutine
-from inspect_swe._util.centaur import CentaurOptions, run_centaur
+from inspect_swe._util.centaur import CentaurOptions, CommandsFilter, run_centaur
 from inspect_swe._util.mcp_ready import (
     DEFAULT_MCP_READY_TIMEOUT,
     wait_for_mcp_endpoints,
@@ -104,6 +104,7 @@ def codex_cli(
     goals: bool = True,
     auto_review: bool | CodexAutoReview = False,
     centaur: bool | CentaurOptions = False,
+    commands_filter: CommandsFilter | None = None,
     attempts: int | AgentAttempts = 1,
     model: str | None = None,
     model_aliases: dict[str, str | Model] | None = None,
@@ -163,6 +164,8 @@ def codex_cli(
             Pass `CodexAutoReview` to customize the guardian policy and model.
             Requires Codex CLI >= 0.137.0. Defaults to `False`.
         centaur: Run in 'centaur' mode, which makes Codex CLI available to an Inspect `human_cli()` agent rather than running it unattended.
+        commands_filter: In centaur mode only, filter or augment the human agent's
+            command list (e.g. to add task-specific commands). Ignored outside centaur mode.
         attempts: Configure agent to make multiple attempts. When this is specified, the task will be scored when the agent stops calling tools. If the scoring is successful, execution will stop. Otherwise, the agent will be prompted to pick up where it left off for another attempt.
         model: Model name to use (defaults to main model for task).
         model_aliases: Optional mapping of model names to Model instances or model name strings.
@@ -665,6 +668,8 @@ def codex_cli(
                     image_files=image_files,
                     agent_env=agent_env,
                     state=state,
+                    user=user,
+                    commands_filter=commands_filter,
                 )
             else:
                 # execute the agent (track debug output)
@@ -875,6 +880,8 @@ async def _run_codex_cli_centaur(
     image_files: list[str],
     agent_env: dict[str, str],
     state: AgentState,
+    user: str | None = None,
+    commands_filter: CommandsFilter | None = None,
 ) -> None:
     instructions = "Codex CLI:\n\n - You may also use Codex CLI via the 'codex' command.\n - Use 'codex resume' if you need to resume a previous codex session."
 
@@ -918,7 +925,9 @@ async def _run_codex_cli_centaur(
     bashrc = "\n".join(agent_env_vars + ["", codex_cmd_def])
 
     # run the human cli
-    await run_centaur(options, instructions, bashrc, state)
+    await run_centaur(
+        options, instructions, bashrc, state, user=user, commands_filter=commands_filter
+    )
 
 
 async def _last_rollout(

--- a/src/inspect_swe/_gemini_cli/gemini_cli.py
+++ b/src/inspect_swe/_gemini_cli/gemini_cli.py
@@ -22,7 +22,7 @@ from inspect_ai.util import store
 from inspect_ai.util._sandbox import ExecRemoteAwaitableOptions
 
 from inspect_swe._util._async import is_callable_coroutine
-from inspect_swe._util.centaur import CentaurOptions, run_centaur
+from inspect_swe._util.centaur import CentaurOptions, CommandsFilter, run_centaur
 from inspect_swe._util.mcp_ready import (
     DEFAULT_MCP_READY_TIMEOUT,
     wait_for_mcp_endpoints,
@@ -49,6 +49,7 @@ def gemini_cli(
     mcp_ready_timeout: float = DEFAULT_MCP_READY_TIMEOUT,
     web_search: bool = True,
     centaur: bool | CentaurOptions = False,
+    commands_filter: CommandsFilter | None = None,
     attempts: int | AgentAttempts = 1,
     model: str | None = None,
     model_aliases: dict[str, str | Model] | None = None,
@@ -81,6 +82,8 @@ def gemini_cli(
             tools before the agent launch errors.
         web_search: Enable the agent's web search tool (defaults to `True`).
         centaur: Run in 'centaur' mode, which makes Gemini CLI available to an Inspect `human_cli()` agent rather than running it unattended.
+        commands_filter: In centaur mode only, filter or augment the human agent's
+            command list (e.g. to add task-specific commands). Ignored outside centaur mode.
         attempts: Configure agent to make multiple attempts
         model: Model name to use for inspect bridge (defaults to main model for task)
         model_aliases: Optional mapping of model names to Model instances or model name strings.
@@ -237,6 +240,8 @@ def gemini_cli(
                     gemini_cmd=cmd,
                     agent_env=agent_env,
                     state=state,
+                    user=user,
+                    commands_filter=commands_filter,
                 )
             else:
                 # execute the agent (track debug output)
@@ -383,6 +388,8 @@ async def _run_gemini_cli_centaur(
     gemini_cmd: list[str],
     agent_env: dict[str, str],
     state: AgentState,
+    user: str | None = None,
+    commands_filter: CommandsFilter | None = None,
 ) -> None:
     instructions = "Gemini CLI:\n\n - You may also use Gemini CLI via the 'gemini' command.\n - Use 'gemini --resume latest' if you need to resume a previous gemini session."
 
@@ -395,4 +402,6 @@ async def _run_gemini_cli_centaur(
     bashrc = "\n".join(agent_env_vars + ["", alias_cmd])
 
     # run the human cli
-    await run_centaur(options, instructions, bashrc, state)
+    await run_centaur(
+        options, instructions, bashrc, state, user=user, commands_filter=commands_filter
+    )

--- a/src/inspect_swe/_gemini_cli/gemini_cli.py
+++ b/src/inspect_swe/_gemini_cli/gemini_cli.py
@@ -49,7 +49,6 @@ def gemini_cli(
     mcp_ready_timeout: float = DEFAULT_MCP_READY_TIMEOUT,
     web_search: bool = True,
     centaur: bool | CentaurOptions = False,
-    commands_filter: CommandsFilter | None = None,
     attempts: int | AgentAttempts = 1,
     model: str | None = None,
     model_aliases: dict[str, str | Model] | None = None,
@@ -62,6 +61,8 @@ def gemini_cli(
     sandbox: str | None = None,
     version: Literal["auto", "sandbox", "stable", "latest"] | str = "auto",
     debug: bool | None = None,
+    *,
+    commands_filter: CommandsFilter | None = None,
 ) -> Agent:
     """Gemini CLI agent.
 

--- a/src/inspect_swe/_kimi_code/kimi_code.py
+++ b/src/inspect_swe/_kimi_code/kimi_code.py
@@ -46,7 +46,7 @@ from inspect_ai.util import store
 from inspect_ai.util._sandbox import ExecRemoteAwaitableOptions
 
 from inspect_swe._util._async import is_callable_coroutine
-from inspect_swe._util.centaur import CentaurOptions, run_centaur
+from inspect_swe._util.centaur import CentaurOptions, CommandsFilter, run_centaur
 from inspect_swe._util.mcp_ready import (
     DEFAULT_MCP_READY_TIMEOUT,
     wait_for_mcp_endpoints,
@@ -117,6 +117,7 @@ def kimi_code(
     bridged_tools: Sequence[BridgedToolsSpec] | None = None,
     mcp_ready_timeout: float = DEFAULT_MCP_READY_TIMEOUT,
     centaur: bool | CentaurOptions = False,
+    commands_filter: CommandsFilter | None = None,
     attempts: int | AgentAttempts = 1,
     model: str | None = None,
     max_context_size: int | None = None,
@@ -154,6 +155,8 @@ def kimi_code(
         mcp_ready_timeout: Seconds to wait for bridged MCP endpoints to serve
             tools before the agent launch errors.
         centaur: Run in 'centaur' mode, which makes Kimi Code available to an Inspect `human_cli()` agent rather than running it unattended.
+        commands_filter: In centaur mode only, filter or augment the human agent's
+            command list (e.g. to add task-specific commands). Ignored outside centaur mode.
         attempts: Configure agent to make multiple attempts
         model: Model name to use for inspect bridge (defaults to main model for task)
         max_context_size: Context window to configure for Kimi. Defaults to the
@@ -329,6 +332,8 @@ def kimi_code(
                     kimi_cmd=cmd,
                     agent_env=agent_env,
                     state=state,
+                    user=user,
+                    commands_filter=commands_filter,
                 )
             else:
                 debug_output: list[str] = []
@@ -596,6 +601,8 @@ async def _run_kimi_code_centaur(
     kimi_cmd: list[str],
     agent_env: dict[str, str],
     state: AgentState,
+    user: str | None = None,
+    commands_filter: CommandsFilter | None = None,
 ) -> None:
     instructions = (
         "Kimi Code:\n\n"
@@ -610,4 +617,6 @@ async def _run_kimi_code_centaur(
     alias_cmd = "alias kimi='" + alias_cmd.replace("'", "'\\''") + "'"
     bashrc = "\n".join(agent_env_vars + ["", alias_cmd])
 
-    await run_centaur(options, instructions, bashrc, state)
+    await run_centaur(
+        options, instructions, bashrc, state, user=user, commands_filter=commands_filter
+    )

--- a/src/inspect_swe/_kimi_code/kimi_code.py
+++ b/src/inspect_swe/_kimi_code/kimi_code.py
@@ -117,7 +117,6 @@ def kimi_code(
     bridged_tools: Sequence[BridgedToolsSpec] | None = None,
     mcp_ready_timeout: float = DEFAULT_MCP_READY_TIMEOUT,
     centaur: bool | CentaurOptions = False,
-    commands_filter: CommandsFilter | None = None,
     attempts: int | AgentAttempts = 1,
     model: str | None = None,
     max_context_size: int | None = None,
@@ -131,6 +130,8 @@ def kimi_code(
     sandbox: str | None = None,
     version: Literal["auto", "sandbox", "stable", "latest"] | str = "auto",
     debug: bool = False,
+    *,
+    commands_filter: CommandsFilter | None = None,
 ) -> Agent:
     """Kimi Code agent.
 

--- a/src/inspect_swe/_opencode/opencode.py
+++ b/src/inspect_swe/_opencode/opencode.py
@@ -22,7 +22,7 @@ from inspect_ai.util import store
 from inspect_ai.util._sandbox import ExecRemoteAwaitableOptions
 
 from inspect_swe._util._async import is_callable_coroutine
-from inspect_swe._util.centaur import CentaurOptions, run_centaur
+from inspect_swe._util.centaur import CentaurOptions, CommandsFilter, run_centaur
 from inspect_swe._util.mcp_ready import (
     DEFAULT_MCP_READY_TIMEOUT,
     wait_for_mcp_endpoints,
@@ -48,6 +48,7 @@ def opencode(
     bridged_tools: Sequence[BridgedToolsSpec] | None = None,
     mcp_ready_timeout: float = DEFAULT_MCP_READY_TIMEOUT,
     centaur: bool | CentaurOptions = False,
+    commands_filter: CommandsFilter | None = None,
     attempts: int | AgentAttempts = 1,
     model: str | None = None,
     model_aliases: dict[str, str | Model] | None = None,
@@ -79,6 +80,8 @@ def opencode(
         mcp_ready_timeout: Seconds to wait for bridged MCP endpoints to serve
             tools before the agent launch errors.
         centaur: Run in 'centaur' mode, which makes OpenCode available to an Inspect `human_cli()` agent rather than running it unattended.
+        commands_filter: In centaur mode only, filter or augment the human agent's
+            command list (e.g. to add task-specific commands). Ignored outside centaur mode.
         attempts: Configure agent to make multiple attempts
         model: Model name to use for inspect bridge (defaults to main model for task)
         model_aliases: Optional mapping of model names to Model instances or model name strings.
@@ -263,6 +266,8 @@ def opencode(
                     opencode_cmd=cmd,
                     agent_env=agent_env,
                     state=state,
+                    user=user,
+                    commands_filter=commands_filter,
                 )
             else:
                 debug_output: list[str] = []
@@ -396,6 +401,8 @@ async def _run_opencode_centaur(
     opencode_cmd: list[str],
     agent_env: dict[str, str],
     state: AgentState,
+    user: str | None = None,
+    commands_filter: CommandsFilter | None = None,
 ) -> None:
     instructions = (
         "OpenCode:\n\n"
@@ -411,4 +418,6 @@ async def _run_opencode_centaur(
     alias_cmd = "alias opencode='" + alias_cmd.replace("'", "'\\''") + "'"
     bashrc = "\n".join(agent_env_vars + ["", alias_cmd])
 
-    await run_centaur(options, instructions, bashrc, state)
+    await run_centaur(
+        options, instructions, bashrc, state, user=user, commands_filter=commands_filter
+    )

--- a/src/inspect_swe/_opencode/opencode.py
+++ b/src/inspect_swe/_opencode/opencode.py
@@ -48,7 +48,6 @@ def opencode(
     bridged_tools: Sequence[BridgedToolsSpec] | None = None,
     mcp_ready_timeout: float = DEFAULT_MCP_READY_TIMEOUT,
     centaur: bool | CentaurOptions = False,
-    commands_filter: CommandsFilter | None = None,
     attempts: int | AgentAttempts = 1,
     model: str | None = None,
     model_aliases: dict[str, str | Model] | None = None,
@@ -61,6 +60,8 @@ def opencode(
     sandbox: str | None = None,
     version: Literal["auto", "sandbox", "stable", "latest"] | str = "auto",
     debug: bool | None = None,
+    *,
+    commands_filter: CommandsFilter | None = None,
 ) -> Agent:
     """OpenCode agent.
 

--- a/src/inspect_swe/_util/centaur.py
+++ b/src/inspect_swe/_util/centaur.py
@@ -1,6 +1,8 @@
+import inspect
 from collections.abc import Callable
+from typing import cast
 
-from inspect_ai.agent import AgentState, human_cli, run
+from inspect_ai.agent import Agent, AgentState, human_cli, run
 from inspect_ai.agent._human.commands.command import HumanAgentCommand
 from pydantic import BaseModel, Field
 
@@ -32,7 +34,53 @@ async def run_centaur(
     user: str | None = None,
     commands_filter: CommandsFilter | None = None,
 ) -> None:
-    agent = human_cli(
+    if commands_filter is not None:
+        try:
+            signature = inspect.signature(human_cli)
+        except (TypeError, ValueError) as error:
+            raise RuntimeError(
+                "commands_filter requires an inspect_ai human_cli() signature "
+                "that can be inspected."
+            ) from error
+
+        commands_filter_parameter = signature.parameters.get("commands_filter")
+        supports_commands_filter = (
+            commands_filter_parameter is not None
+            and commands_filter_parameter.kind is not inspect.Parameter.POSITIONAL_ONLY
+        ) or any(
+            parameter.kind is inspect.Parameter.VAR_KEYWORD
+            for parameter in signature.parameters.values()
+        )
+        if not supports_commands_filter:
+            raise RuntimeError(
+                "commands_filter requires an inspect_ai version whose "
+                "human_cli() accepts commands_filter=."
+            )
+
+        agent = _human_cli_with_commands_filter(
+            options, instructions, bashrc, user, commands_filter
+        )
+    else:
+        agent = human_cli(
+            answer=options.answer,
+            intermediate_scoring=options.intermediate_scoring,
+            record_session=options.record_session,
+            instructions=instructions,
+            bashrc=bashrc,
+            user=user,
+        )
+
+    await run(agent, state)
+
+
+def _human_cli_with_commands_filter(
+    options: CentaurOptions,
+    instructions: str,
+    bashrc: str,
+    user: str | None,
+    commands_filter: CommandsFilter,
+) -> Agent:
+    return cast(Callable[..., Agent], human_cli)(
         answer=options.answer,
         intermediate_scoring=options.intermediate_scoring,
         record_session=options.record_session,
@@ -41,4 +89,3 @@ async def run_centaur(
         user=user,
         commands_filter=commands_filter,
     )
-    await run(agent, state)

--- a/src/inspect_swe/_util/centaur.py
+++ b/src/inspect_swe/_util/centaur.py
@@ -1,5 +1,10 @@
+from collections.abc import Callable
+
 from inspect_ai.agent import AgentState, human_cli, run
+from inspect_ai.agent._human.commands.command import HumanAgentCommand
 from pydantic import BaseModel, Field
+
+CommandsFilter = Callable[[list[HumanAgentCommand]], list[HumanAgentCommand]]
 
 
 class CentaurOptions(BaseModel):
@@ -20,7 +25,12 @@ class CentaurOptions(BaseModel):
 
 
 async def run_centaur(
-    options: CentaurOptions, instructions: str, bashrc: str, state: AgentState
+    options: CentaurOptions,
+    instructions: str,
+    bashrc: str,
+    state: AgentState,
+    user: str | None = None,
+    commands_filter: CommandsFilter | None = None,
 ) -> None:
     agent = human_cli(
         answer=options.answer,
@@ -28,5 +38,7 @@ async def run_centaur(
         record_session=options.record_session,
         instructions=instructions,
         bashrc=bashrc,
+        user=user,
+        commands_filter=commands_filter,
     )
     await run(agent, state)

--- a/tests/test_centaur_commands.py
+++ b/tests/test_centaur_commands.py
@@ -1,0 +1,82 @@
+"""`run_centaur` must forward `user` and `commands_filter` to `human_cli`.
+
+Centaur makes Claude Code available to an Inspect `human_cli()` session. Without these
+two forwarded, a hosted human+agent session lands as root and exposes only the stock
+task commands -- so a project cannot install a non-root worker or its own submit/score
+commands. `human_cli` accepts both; centaur used to drop them.
+
+`human_cli` is mocked here, so the test does not depend on the host `inspect_ai`
+carrying the `commands_filter` parameter (added by inspect_ai's human-cli
+customize-commands change); it asserts only that `run_centaur` passes both through.
+"""
+
+import asyncio
+
+import pytest
+from inspect_ai.agent import AgentState
+from inspect_ai.agent._human.commands.command import HumanAgentCommand
+from inspect_swe._util import centaur as centaur_mod
+from inspect_swe._util.centaur import CentaurOptions, run_centaur
+
+
+def _commands_filter(commands: list[HumanAgentCommand]) -> list[HumanAgentCommand]:
+    return commands
+
+
+def test_run_centaur_forwards_user_and_commands_filter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_human_cli(**kwargs: object) -> str:
+        captured.update(kwargs)
+        return "human-cli-agent"
+
+    async def fake_run(agent: object, state: object) -> None:
+        captured["ran"] = agent
+
+    monkeypatch.setattr(centaur_mod, "human_cli", fake_human_cli)
+    monkeypatch.setattr(centaur_mod, "run", fake_run)
+
+    asyncio.run(
+        run_centaur(
+            CentaurOptions(),
+            instructions="instr",
+            bashrc="bashrc",
+            state=AgentState(messages=[]),
+            user="agent",
+            commands_filter=_commands_filter,
+        )
+    )
+
+    assert captured["user"] == "agent"
+    assert captured["commands_filter"] is _commands_filter
+    assert captured["ran"] == "human-cli-agent"
+
+
+def test_run_centaur_defaults_leave_user_and_commands_filter_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_human_cli(**kwargs: object) -> str:
+        captured.update(kwargs)
+        return "human-cli-agent"
+
+    async def fake_run(agent: object, state: object) -> None:
+        return None
+
+    monkeypatch.setattr(centaur_mod, "human_cli", fake_human_cli)
+    monkeypatch.setattr(centaur_mod, "run", fake_run)
+
+    asyncio.run(
+        run_centaur(
+            CentaurOptions(),
+            instructions="instr",
+            bashrc="bashrc",
+            state=AgentState(messages=[]),
+        )
+    )
+
+    assert captured["user"] is None
+    assert captured["commands_filter"] is None

--- a/tests/test_centaur_commands.py
+++ b/tests/test_centaur_commands.py
@@ -1,20 +1,22 @@
-"""`run_centaur` must forward `user` and `commands_filter` to `human_cli`.
+"""Centaur must forward commands filters only to compatible human CLI versions.
 
-Centaur makes Claude Code available to an Inspect `human_cli()` session. Without these
-two forwarded, a hosted human+agent session lands as root and exposes only the stock
-task commands -- so a project cannot install a non-root worker or its own submit/score
-commands. `human_cli` accepts both; centaur used to drop them.
-
-`human_cli` is mocked here, so the test does not depend on the host `inspect_ai`
-carrying the `commands_filter` parameter (added by inspect_ai's human-cli
-customize-commands change); it asserts only that `run_centaur` passes both through.
+Centaur makes a CLI available to an Inspect ``human_cli()`` session. The supplied
+user must reach that session so it runs as the intended non-root account. A custom
+commands filter requires the optional Inspect AI API, while sessions without one
+must retain compatibility with the declared lower dependency bound.
 """
 
 import asyncio
+import inspect
+from collections.abc import Callable
 
 import pytest
 from inspect_ai.agent import AgentState
 from inspect_ai.agent._human.commands.command import HumanAgentCommand
+from inspect_swe._codex_cli.codex_cli import codex_cli
+from inspect_swe._gemini_cli.gemini_cli import gemini_cli
+from inspect_swe._kimi_code.kimi_code import kimi_code
+from inspect_swe._opencode.opencode import opencode
 from inspect_swe._util import centaur as centaur_mod
 from inspect_swe._util.centaur import CentaurOptions, run_centaur
 
@@ -28,8 +30,22 @@ def test_run_centaur_forwards_user_and_commands_filter(
 ) -> None:
     captured: dict[str, object] = {}
 
-    def fake_human_cli(**kwargs: object) -> str:
-        captured.update(kwargs)
+    def fake_human_cli(
+        *,
+        answer: object,
+        intermediate_scoring: bool,
+        record_session: bool,
+        instructions: str,
+        bashrc: str,
+        user: str | None,
+        commands_filter: object,
+    ) -> str:
+        captured.update(
+            {
+                "user": user,
+                "commands_filter": commands_filter,
+            }
+        )
         return "human-cli-agent"
 
     async def fake_run(agent: object, state: object) -> None:
@@ -54,13 +70,21 @@ def test_run_centaur_forwards_user_and_commands_filter(
     assert captured["ran"] == "human-cli-agent"
 
 
-def test_run_centaur_defaults_leave_user_and_commands_filter_none(
+def test_run_centaur_omits_commands_filter_when_none(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     captured: dict[str, object] = {}
 
-    def fake_human_cli(**kwargs: object) -> str:
-        captured.update(kwargs)
+    def fake_human_cli(
+        *,
+        answer: object,
+        intermediate_scoring: bool,
+        record_session: bool,
+        instructions: str,
+        bashrc: str,
+        user: str | None,
+    ) -> str:
+        captured["user"] = user
         return "human-cli-agent"
 
     async def fake_run(agent: object, state: object) -> None:
@@ -79,4 +103,44 @@ def test_run_centaur_defaults_leave_user_and_commands_filter_none(
     )
 
     assert captured["user"] is None
-    assert captured["commands_filter"] is None
+
+
+def test_run_centaur_requires_human_cli_command_filter_support(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_human_cli(
+        *,
+        answer: object,
+        intermediate_scoring: bool,
+        record_session: bool,
+        instructions: str,
+        bashrc: str,
+        user: str | None,
+    ) -> str:
+        return "human-cli-agent"
+
+    monkeypatch.setattr(centaur_mod, "human_cli", fake_human_cli)
+
+    with pytest.raises(RuntimeError, match="inspect_ai.*human_cli.*commands_filter"):
+        asyncio.run(
+            run_centaur(
+                CentaurOptions(),
+                instructions="instr",
+                bashrc="bashrc",
+                state=AgentState(messages=[]),
+                commands_filter=_commands_filter,
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [codex_cli, gemini_cli, kimi_code, opencode],
+)
+def test_centaur_commands_filter_is_keyword_only(
+    factory: Callable[..., object],
+) -> None:
+    parameters = inspect.signature(factory).parameters
+
+    assert parameters["attempts"].kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+    assert parameters["commands_filter"].kind is inspect.Parameter.KEYWORD_ONLY

--- a/tests/test_kimi_setup.py
+++ b/tests/test_kimi_setup.py
@@ -7,6 +7,8 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import anyio
 import pytest
+from inspect_ai.agent import AgentState
+from inspect_ai.agent._human.commands.command import HumanAgentCommand
 from inspect_ai.model import (
     ChatMessage,
     ChatMessageAssistant,
@@ -32,8 +34,10 @@ from inspect_swe._kimi_code.kimi_code import (
     _mcp_json,
     _resolve_max_context_size,
     _resolve_model,
+    _run_kimi_code_centaur,
     _strip_repeat_reminders,
 )
+from inspect_swe._util.centaur import CentaurOptions
 
 from tests.conftest import skip_if_github_action
 
@@ -417,6 +421,40 @@ def test_is_legacy_str_filter_dispatch() -> None:
 
     assert _is_legacy_str_filter(legacy) is True
     assert _is_legacy_str_filter(modern) is False
+
+
+def test_run_kimi_code_centaur_forwards_user_and_commands_filter() -> None:
+    captured: dict[str, object] = {}
+
+    def _commands_filter(
+        commands: list[HumanAgentCommand],
+    ) -> list[HumanAgentCommand]:
+        return commands
+
+    async def fake_run_centaur(
+        options: CentaurOptions,
+        instructions: str,
+        bashrc: str,
+        state: AgentState,
+        user: str | None = None,
+        commands_filter: object = None,
+    ) -> None:
+        captured["user"] = user
+        captured["commands_filter"] = commands_filter
+
+    with patch.object(_KIMI_CODE_MODULE, "run_centaur", fake_run_centaur):
+        anyio.run(
+            _run_kimi_code_centaur,
+            CentaurOptions(),
+            ["kimi"],
+            {},
+            AgentState(messages=[]),
+            "agent",
+            _commands_filter,
+        )
+
+    assert captured["user"] == "agent"
+    assert captured["commands_filter"] is _commands_filter
 
 
 @skip_if_github_action

--- a/tests/test_kimi_setup.py
+++ b/tests/test_kimi_setup.py
@@ -2,7 +2,10 @@
 
 import json
 import re
+from contextlib import asynccontextmanager
 from importlib import import_module
+from types import SimpleNamespace
+from typing import AsyncIterator
 from unittest.mock import AsyncMock, Mock, patch
 
 import anyio
@@ -36,6 +39,7 @@ from inspect_swe._kimi_code.kimi_code import (
     _resolve_model,
     _run_kimi_code_centaur,
     _strip_repeat_reminders,
+    kimi_code,
 )
 from inspect_swe._util.centaur import CentaurOptions
 
@@ -452,6 +456,78 @@ def test_run_kimi_code_centaur_forwards_user_and_commands_filter() -> None:
             "agent",
             _commands_filter,
         )
+
+    assert captured["user"] == "agent"
+    assert captured["commands_filter"] is _commands_filter
+
+
+def test_kimi_code_factory_forwards_user_and_commands_filter_to_centaur_dispatch() -> (
+    None
+):
+    """Coverage gap in the dispatch call site.
+
+    The test above exercises `_run_kimi_code_centaur` directly, so it would
+    still pass even if the public `kimi_code()` factory stopped passing
+    `user=`/`commands_filter=` at its `_run_kimi_code_centaur(...)` call site
+    -- the line the original bug lived on. Drive the actual factory through
+    to that dispatch with every sandbox/bridge dependency mocked.
+    """
+    captured: dict[str, object] = {}
+
+    def _commands_filter(
+        commands: list[HumanAgentCommand],
+    ) -> list[HumanAgentCommand]:
+        return commands
+
+    async def fake_run_kimi_code_centaur(
+        *,
+        options: CentaurOptions,
+        kimi_cmd: list[str],
+        agent_env: dict[str, str],
+        state: AgentState,
+        user: str | None = None,
+        commands_filter: object = None,
+    ) -> None:
+        captured["user"] = user
+        captured["commands_filter"] = commands_filter
+
+    sbox = Mock()
+    sbox.exec = AsyncMock(return_value=SimpleNamespace(stdout="/root\n"))
+    sbox.write_file = AsyncMock()
+
+    @asynccontextmanager
+    async def fake_bridge(
+        state: AgentState, **kwargs: object
+    ) -> AsyncIterator[SimpleNamespace]:
+        yield SimpleNamespace(port=3100, mcp_server_configs=[], state=state)
+
+    with (
+        patch.object(
+            _KIMI_CODE_MODULE, "_run_kimi_code_centaur", fake_run_kimi_code_centaur
+        ),
+        patch.object(_KIMI_CODE_MODULE, "sandbox_agent_bridge", fake_bridge),
+        patch.object(_KIMI_CODE_MODULE, "sandbox_env", Mock(return_value=sbox)),
+        patch.object(
+            _KIMI_CODE_MODULE, "resolve_agent_cwd", AsyncMock(return_value="/work")
+        ),
+        patch.object(
+            _KIMI_CODE_MODULE,
+            "ensure_agent_binary_installed",
+            AsyncMock(return_value="/usr/local/bin/kimi"),
+        ),
+        patch.object(
+            _KIMI_CODE_MODULE,
+            "resolve_inspect_model",
+            Mock(return_value=Mock(spec=Model)),
+        ),
+    ):
+        agent_fn = kimi_code(
+            centaur=True,
+            user="agent",
+            commands_filter=_commands_filter,
+            max_context_size=100_000,
+        )
+        anyio.run(agent_fn, AgentState(messages=[]))
 
     assert captured["user"] == "agent"
     assert captured["commands_filter"] is _commands_filter


### PR DESCRIPTION
## Summary

Threads `commands_filter` and `user` through the `codex_cli`, `gemini_cli`, `kimi_code`, and `opencode` Centaur modes, so a human-and-agent Centaur session can carry custom task commands and run as a non-root worker.

**Draft on purpose:** `human_cli(commands_filter=...)` from [UKGovernmentBEIS/inspect_ai#4895](https://github.com/UKGovernmentBEIS/inspect_ai/pull/4895) is not released. This PR does not raise Inspect SWE's `inspect_ai>=0.3.255` lower bound. At that dependency floor, sessions without `commands_filter` invoke `human_cli` without the keyword; requesting custom command filtering fails before launch with a clear error until a supporting Inspect AI version is installed.

## Behavior

- `commands_filter` is keyword-only in all four public CLI factories, preserving their existing positional argument order.
- When a supplied `commands_filter` is supported by the installed `human_cli` signature, Centaur forwards it to the human session.
- `user=` is forwarded on the same paths, so the Centaur session runs as the specified unprivileged user rather than root.

## Testing

- `uv run --frozen pytest tests/test_centaur_commands.py tests/test_kimi_setup.py -q` reports `34 passed`.
- Targeted `ruff check` and `ruff format --check` pass for the five changed source files and the changed test file.
- `mypy` passes for the five changed source files.
- Regression coverage verifies legacy `human_cli` compatibility, the unsupported custom-filter error, supported filter forwarding, and keyword-only factory signatures.

### Agent review

Authored by Claude on @sjawhar's behalf. An independent fresh-context deep review found two issues; both are fixed in the current commit.
