### PR TITLE
docs: add credential boundary and public-API evolution guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ This file provides guidance to AI coding agents working in this repository.
 
 ## Agent Guardrails
 
-- **Credential boundary**: treat the evaluated sandbox as untrusted. Real model-provider credentials never enter it—only dummy keys reach model inference. Other real credentials (e.g. MCP auth headers) may enter the sandbox for transport, but must stay outside every model- and tool-readable path.
+- **Credential boundary**: treat the evaluated sandbox as untrusted. By default, bridge-owned model-provider credentials never enter it—only the dummy key used to authenticate with the in-sandbox model bridge reaches inference. A `claude_code(env=...)` caller can explicitly override its environment, including `ANTHROPIC_AUTH_TOKEN`, so caller-provided credentials must be treated as sandbox-exposed. Other real credentials (e.g. MCP auth headers) may enter the sandbox for transport, but must stay outside every model- and tool-readable path.
 - **Public API evolution**: add new parameters at the end of the signature, using `Literal` types with runtime validation for constrained options. Renaming or removing a released parameter needs a `**deprecated_args: Unpack[...]` shim; new public surface needs a concrete use case first.
 
 ## Agent Review Disclosure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,3 +7,8 @@
 - Body lines starting with `<type>:` are parsed as extra changelog entries—don't begin description lines with a conventional-commit prefix unless that's intended
 - Never edit `CHANGELOG.md`, version numbers, or `.release-please-manifest.json`—Release Please owns them
 - See [CONTRIBUTING.md](CONTRIBUTING.md) for full guidelines
+
+## Agent Guardrails
+
+- **Credential boundary**: treat the evaluated sandbox as untrusted. Real model-provider credentials never enter it—only dummy keys reach model inference. Other real credentials (e.g. MCP auth headers) may enter the sandbox for transport, but must stay outside every model- and tool-readable path.
+- **Public API evolution**: add new parameters at the end of the signature, using `Literal` types with runtime validation for constrained options. Renaming or removing a released parameter needs a `**deprecated_args: Unpack[...]` shim; new public surface needs a concrete use case first.


### PR DESCRIPTION
## Summary

Adds a short `## Agent Guardrails` section to AGENTS.md with two rules that are review-enforced in this repo but were not written down: the sandbox credential boundary and how public function signatures evolve without breaking callers.

## Placement

AGENTS.md here is deliberately minimal (#87), so this keeps to two bullets. The reasoning for putting them here rather than CONTRIBUTING.md is #87's own: coding agents read AGENTS.md automatically and do not read CONTRIBUTING.md, and these are the rules an agent preparing a PR needs in front of it.

## Why credential boundary

The sandbox is untrusted. By default, `claude_code()` supplies a bridge-owned dummy token for its in-sandbox model bridge. A caller can override that environment through `claude_code(env=...)`, including `ANTHROPIC_AUTH_TOKEN`; a caller-provided credential is therefore sandbox-exposed. Other real credentials needed for in-sandbox transport, such as MCP headers, must remain outside model- and tool-readable paths.

## Why public API evolution

#88 was blocked in round 1 for the unshimmed removal of `auto_mode`, which had been public since 0.2.56. The merged fix is the `ClaudeCodeDeprecatedArgs` / `resolve_claude_code_deprecated_args` / `**deprecated_args: Unpack[...]` pattern still in `claude_code.py` today. #124 was closed on the use-case gate: "Want to understand the use base before we extend the public API." This names both as the standing convention.

### Agent review
- Reviewer: Claude (same model as the authoring sessions); the final deep-review pass used fresh context.
- Passes: 4. The final pass checked the documented credential boundary against the current `claude_code(env=...)` path.
- Findings: two credential-boundary overstatements were fixed. The rule now distinguishes bridge-owned defaults from caller overrides and treats caller-provided credentials as sandbox-exposed. The heading and rule-first phrasing were also reviewed for fit with AGENTS.md's deliberately minimal scope.
