### PR TITLE
test: give gemini_cli example tests a 600s time limit

### DIFF
--- a/src/inspect_swe/_util/platform.py
+++ b/src/inspect_swe/_util/platform.py
@@ -4,7 +4,7 @@ from typing import no_type_check
 @no_type_check
 def running_in_notebook() -> bool:
     try:
-        from IPython import get_ipython  # type: ignore
+        from IPython.core.getipython import get_ipython
 
         if "IPKernelApp" not in get_ipython().config:
             return False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -200,12 +200,19 @@ def run_example(
     # reads count toward it -- they were 1.4M of that 1.68M -- so a tight cap
     # would clip honest runs. 500k still trips a runaway inside ~3 minutes,
     # ahead of the time limit, while sitting well clear of real usage.
+    #
+    # gemini_cli gets double the time: its healthy multi-turn runs (multi_call,
+    # skills) already take ~300s, so any burst of Gemini API retries pushes it
+    # over the limit and fails the run with a truncated transcript rather than
+    # an obvious timeout (e.g. meridianlabs-ai/actions run 33373083766, where 8
+    # HTTP retries left only 1 of the expected 4+ user messages). 600s still
+    # sits well under the 900s pytest --timeout backstop in the nightly.
     return eval(
         example_file,
         model=model,
         limit=1,
         task_args=task_args,
-        time_limit=300,
+        time_limit=600 if agent == "gemini_cli" else 300,
         token_limit=500_000,
     )
 


### PR DESCRIPTION
## What

Raises the eval `time_limit` for `gemini_cli` in the shared `run_example` test helper from 300s to 600s. All other agents keep the 300s limit.

Also fixes a pre-existing mypy failure on main (`platform.py`: unused `type: ignore` under CI's freshly-released mypy 2.3.1) by importing `get_ipython` from its defining module — verified clean under both mypy 1.17.1/ipython 9.5.0 and mypy 2.3.1/ipython 9.17.0, no ignore needed.

## Why

The nightly tests fail intermittently on gemini tests because Gemini's healthy multi-turn runs already take nearly the full 300s (`multi_call` and `skills` both clock ~304s on green nights), so any burst of Gemini API retries runs the clock out. When that happens the sample is killed mid-conversation and the test fails on a confusing truncated-transcript assertion rather than an obvious timeout.

Most recent example: [nightly run 33373083766](https://github.com/meridianlabs-ai/actions/actions/runs/33373083766) — 8 HTTP retries against `google/gemini-3.1-pro-preview`, sample killed at 5:05, and `test_gemini_cli_multi_call[docker]` failed with `assert 1 >= 4` user messages. Same signature on the 8/25 nightly.

600s still sits well under the nightly's 900s pytest `--timeout` backstop, so a genuinely wedged run is still killed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)