### PR TITLE
feat(codex_cli): attach input images via codex exec --image

### DIFF
--- a/examples/image_input/task.py
+++ b/examples/image_input/task.py
@@ -1,0 +1,82 @@
+import base64
+import struct
+import zlib
+
+from inspect_ai import Task, task
+from inspect_ai.agent import run
+from inspect_ai.dataset import Sample
+from inspect_ai.model import ChatMessageUser, ContentImage, ContentText
+from inspect_ai.solver import Generate, Solver, TaskState, solver
+from inspect_ai.util import SandboxEnvironmentType
+from inspect_swe import codex_cli
+
+
+def solid_color_image(r: int, g: int, b: int, size: int = 64) -> ContentImage:
+    """A solid-color PNG as image content (stdlib-only, no PIL)."""
+
+    def chunk(tag: bytes, data: bytes) -> bytes:
+        payload = struct.pack(">I", len(data)) + tag + data
+        return payload + struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF)
+
+    ihdr = struct.pack(">IIBBBBB", size, size, 8, 2, 0, 0, 0)
+    raw = b"".join(b"\x00" + bytes([r, g, b]) * size for _ in range(size))
+    png = (
+        b"\x89PNG\r\n\x1a\n"
+        + chunk(b"IHDR", ihdr)
+        + chunk(b"IDAT", zlib.compress(raw))
+        + chunk(b"IEND", b"")
+    )
+    return ContentImage(image=f"data:image/png;base64,{base64.b64encode(png).decode()}")
+
+
+@solver
+def image_input_solver() -> Solver:
+    async def solve(state: TaskState, generate: Generate) -> TaskState:
+        agent = codex_cli(system_prompt="Answer simple questions concisely")
+
+        # first run: image in the sample input (codex exec --image)
+        agent_state = await run(agent, state.messages)
+
+        # second run: image in a follow-up message (codex exec resume --image)
+        agent_state.messages.append(
+            ChatMessageUser(
+                content=[
+                    ContentText(
+                        text="Here is a second image. What solid color is it? "
+                        "Answer with just the color name."
+                    ),
+                    solid_color_image(0, 200, 0),
+                ]
+            )
+        )
+        agent_state = await run(agent, agent_state)
+
+        # transfer state and return
+        state.messages = agent_state.messages
+        state.output = agent_state.output
+        return state
+
+    return solve
+
+
+@task
+def image_input(sandbox: SandboxEnvironmentType | None = "docker") -> Task:
+    return Task(
+        dataset=[
+            Sample(
+                input=[
+                    ChatMessageUser(
+                        content=[
+                            ContentText(
+                                text="What solid color is the attached image? "
+                                "Answer with just the color name."
+                            ),
+                            solid_color_image(255, 0, 255),
+                        ]
+                    )
+                ]
+            )
+        ],
+        solver=image_input_solver(),
+        sandbox=sandbox,
+    )

--- a/src/inspect_swe/_codex_cli/codex_cli.py
+++ b/src/inspect_swe/_codex_cli/codex_cli.py
@@ -504,7 +504,9 @@ def codex_cli(
                     resolved_skills, sbox, user, join_path(codex_home, "skills")
                 )
 
-            prompt, has_assistant_response = build_user_prompt(state.messages)
+            prompt, has_assistant_response = build_user_prompt(
+                state.messages, handled_content=("image",)
+            )
 
             # stage input images as files in the sandbox (`--image` args
             # attach them to the prompt; empty if the input has no images)

--- a/src/inspect_swe/_codex_cli/codex_cli.py
+++ b/src/inspect_swe/_codex_cli/codex_cli.py
@@ -1,9 +1,11 @@
+import mimetypes
 import shlex
 from logging import getLogger
 from pathlib import Path
 from textwrap import dedent
 from typing import Any, Literal, Sequence, cast
 
+from inspect_ai._util.images import file_as_data
 from inspect_ai.agent import (
     Agent,
     AgentAttempts,
@@ -15,6 +17,7 @@ from inspect_ai.agent import (
 )
 from inspect_ai.model import (
     ChatMessageSystem,
+    ContentImage,
     GenerateFilter,
     Model,
     ModelName,
@@ -39,7 +42,7 @@ from inspect_swe._util.mcp_ready import (
     DEFAULT_MCP_READY_TIMEOUT,
     wait_for_mcp_endpoints,
 )
-from inspect_swe._util.messages import build_user_prompt
+from inspect_swe._util.messages import build_user_prompt, collect_user_images
 from inspect_swe._util.path import join_path
 from inspect_swe._util.sandbox import resolve_agent_cwd, sandbox_exec
 from inspect_swe._util.toml import to_toml
@@ -124,6 +127,10 @@ def codex_cli(
     """Codex CLI.
 
     Agent that uses OpenAI [Codex CLI](https://github.com/openai/codex) running in a sandbox.
+
+    Image content in the input is written to files in the sandbox and attached
+    to the prompt via `codex exec --image` (requires a codex version that
+    supports the `--image` option).
 
     Use the `attempts` option to enable additional submissions if the initial
     submission(s) are incorrect (by default, no additional attempts are permitted).
@@ -499,6 +506,12 @@ def codex_cli(
 
             prompt, has_assistant_response = build_user_prompt(state.messages)
 
+            # stage input images as files in the sandbox (`--image` args
+            # attach them to the prompt; empty if the input has no images)
+            image_args = await _stage_prompt_images(
+                collect_user_images(state.messages), sbox, user, codex_home
+            )
+
             # build agent cmd
             cmd = [codex_binary]
 
@@ -637,6 +650,9 @@ def codex_cli(
                 # execute the agent (track debug output)
                 debug_output: list[str] = []
                 agent_prompt = prompt
+                # images accompany the original prompt only (retry attempts
+                # send `incorrect_message`, which is text-only)
+                agent_image_args = image_args
                 attempt_count = cp.track(
                     "codex_attempt_count", lambda: attempt_count, 0
                 )
@@ -652,6 +668,12 @@ def codex_cli(
                         or cp.attempt == "resume"
                     ):
                         agent_cmd.extend(["resume", "--last"])
+
+                    # Image args go LAST: `--image` is multi-value, so a
+                    # following positional (the prompt, or the `resume`
+                    # subcommand) would be swallowed as another image path.
+                    # Trailing, it binds to `exec` or `exec resume` alike.
+                    agent_cmd.extend(agent_image_args)
 
                     # Retry-loop gate: fires ONLY when this loop is actually
                     # retrying (attempt_count > 0 or the checkpoint says
@@ -716,6 +738,7 @@ def codex_cli(
                             )
                         else:
                             agent_prompt = attempts.incorrect_message
+                        agent_image_args = []
 
                 # trace debug info
                 if debug:
@@ -726,6 +749,32 @@ def codex_cli(
         return bridge.state
 
     return agent_with(execute, name=name, description=description)
+
+
+async def _stage_prompt_images(
+    images: list[ContentImage],
+    sandbox: SandboxEnvironment,
+    user: str | None,
+    codex_home: str,
+) -> list[str]:
+    """Write prompt images to files in the sandbox, returning `--image` args.
+
+    `codex exec` cannot accept image content inline in its prompt argument
+    (the prompt is plain argv text), so images ride along as files attached
+    via `--image`, one flag per file.
+    """
+    if not images:
+        return []
+    images_dir = join_path(codex_home, "images")
+    await sandbox_exec(sandbox, f"mkdir -p {images_dir}", user=user)
+    args: list[str] = []
+    for idx, image in enumerate(images):
+        image_bytes, mime_type = await file_as_data(image.image)
+        extension = mimetypes.guess_extension(mime_type, strict=False) or ".png"
+        image_file = join_path(images_dir, f"image-{idx}{extension}")
+        await sandbox.write_file(image_file, image_bytes)
+        args.extend(["--image", image_file])
+    return args
 
 
 async def resolve_codex_model(

--- a/src/inspect_swe/_codex_cli/codex_cli.py
+++ b/src/inspect_swe/_codex_cli/codex_cli.py
@@ -512,7 +512,6 @@ def codex_cli(
             image_files = await _stage_prompt_images(
                 collect_user_images(state.messages), sbox, user, codex_home
             )
-            image_args = [arg for file in image_files for arg in ("--image", file)]
 
             # build agent cmd
             cmd = [codex_binary]
@@ -657,7 +656,11 @@ def codex_cli(
                 # send `incorrect_message` (text-only), and a checkpoint
                 # resume replays a prompt codex already received, with the
                 # images already embedded in its rollout
-                agent_image_args = [] if cp.attempt == "resume" else image_args
+                agent_image_args = (
+                    []
+                    if cp.attempt == "resume"
+                    else [arg for file in image_files for arg in ("--image", file)]
+                )
                 attempt_count = cp.track(
                     "codex_attempt_count", lambda: attempt_count, 0
                 )
@@ -884,7 +887,9 @@ async def _run_codex_cli_centaur(
         instructions += (
             "\n - The task input includes image file(s), which the 'codex' "
             "command attaches to your first invocation automatically: "
-            f"{', '.join(image_files)}"
+            f"{', '.join(image_files)}\n"
+            " - If that first invocation fails before the images are sent, "
+            f"delete {marker} to re-attach them on your next invocation."
         )
     else:
         alias_cmd = shlex.join(codex_cmd)

--- a/src/inspect_swe/_codex_cli/codex_cli.py
+++ b/src/inspect_swe/_codex_cli/codex_cli.py
@@ -762,6 +762,11 @@ async def _stage_prompt_images(
     `codex exec` cannot accept image content inline in its prompt argument
     (the prompt is plain argv text), so images ride along as files attached
     via `--image`, one flag per file.
+
+    Filenames restart at image-0 on each execution, so a follow-up turn
+    overwrites the previous turn's files. This is harmless: codex embeds the
+    image bytes into its rollout history at launch (verified on 0.151.0 --
+    a resumed turn's request still carries the original bytes).
     """
     if not images:
         return []

--- a/src/inspect_swe/_codex_cli/codex_cli.py
+++ b/src/inspect_swe/_codex_cli/codex_cli.py
@@ -645,6 +645,7 @@ def codex_cli(
                 await _run_codex_cli_centaur(
                     options=centaur,
                     codex_cmd=cmd,
+                    image_args=image_args,
                     agent_env=agent_env,
                     state=state,
                 )
@@ -826,10 +827,20 @@ async def resolve_codex_model(
 async def _run_codex_cli_centaur(
     options: CentaurOptions,
     codex_cmd: list[str],
+    image_args: list[str],
     agent_env: dict[str, str],
     state: AgentState,
 ) -> None:
+    # Attach input images inside the alias, spliced right after the binary
+    # rather than trailing: `--image` is multi-value, so tokens the human
+    # types after the alias (a prompt, or `resume`) would be swallowed as
+    # image paths if the alias ended with an `--image` flag.
+    codex_cmd = codex_cmd[:1] + image_args + codex_cmd[1:]
+
     instructions = "Codex CLI:\n\n - You may also use Codex CLI via the 'codex' command.\n - Use 'codex resume' if you need to resume a previous codex session."
+    if image_args:
+        image_files = ", ".join(image_args[1::2])
+        instructions += f"\n - The task input includes image file(s), which the 'codex' alias attaches to your prompt automatically: {image_files}"
 
     # build .bashrc content
     agent_env_vars = [f'export {k}="{v}"' for k, v in agent_env.items()]

--- a/src/inspect_swe/_codex_cli/codex_cli.py
+++ b/src/inspect_swe/_codex_cli/codex_cli.py
@@ -1,11 +1,10 @@
 import mimetypes
 import shlex
 from logging import getLogger
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from textwrap import dedent
 from typing import Any, Literal, Sequence, cast
 
-from inspect_ai._util.images import file_as_data
 from inspect_ai.agent import (
     Agent,
     AgentAttempts,
@@ -508,11 +507,12 @@ def codex_cli(
                 state.messages, handled_content=("image",)
             )
 
-            # stage input images as files in the sandbox (`--image` args
-            # attach them to the prompt; empty if the input has no images)
-            image_args = await _stage_prompt_images(
+            # stage input images as files in the sandbox (empty if the input
+            # has no images); attached to the prompt via `--image` below
+            image_files = await _stage_prompt_images(
                 collect_user_images(state.messages), sbox, user, codex_home
             )
+            image_args = [arg for file in image_files for arg in ("--image", file)]
 
             # build agent cmd
             cmd = [codex_binary]
@@ -645,7 +645,7 @@ def codex_cli(
                 await _run_codex_cli_centaur(
                     options=centaur,
                     codex_cmd=cmd,
-                    image_args=image_args,
+                    image_files=image_files,
                     agent_env=agent_env,
                     state=state,
                 )
@@ -653,9 +653,11 @@ def codex_cli(
                 # execute the agent (track debug output)
                 debug_output: list[str] = []
                 agent_prompt = prompt
-                # images accompany the original prompt only (retry attempts
-                # send `incorrect_message`, which is text-only)
-                agent_image_args = image_args
+                # images accompany the original prompt only: retry attempts
+                # send `incorrect_message` (text-only), and a checkpoint
+                # resume replays a prompt codex already received, with the
+                # images already embedded in its rollout
+                agent_image_args = [] if cp.attempt == "resume" else image_args
                 attempt_count = cp.track(
                     "codex_attempt_count", lambda: attempt_count, 0
                 )
@@ -754,17 +756,29 @@ def codex_cli(
     return agent_with(execute, name=name, description=description)
 
 
+# codex derives the request MIME type from the file extension
+# (mime_guess::from_path), and stdlib mimetypes tables vary by Python
+# version and platform (e.g. image/webp is absent before 3.11), so map
+# common image types explicitly rather than trusting guess_extension.
+_IMAGE_EXTENSIONS = {
+    "image/png": ".png",
+    "image/jpeg": ".jpg",
+    "image/gif": ".gif",
+    "image/webp": ".webp",
+}
+
+
 async def _stage_prompt_images(
     images: list[ContentImage],
     sandbox: SandboxEnvironment,
     user: str | None,
     codex_home: str,
 ) -> list[str]:
-    """Write prompt images to files in the sandbox, returning `--image` args.
+    """Write prompt images to files in the sandbox, returning their paths.
 
     `codex exec` cannot accept image content inline in its prompt argument
     (the prompt is plain argv text), so images ride along as files attached
-    via `--image`, one flag per file.
+    via `--image` args built from the returned paths.
 
     Filenames restart at image-0 on each execution, so a follow-up turn
     overwrites the previous turn's files. This is harmless: codex embeds the
@@ -773,16 +787,26 @@ async def _stage_prompt_images(
     """
     if not images:
         return []
+
+    # private inspect_ai API with no public equivalent; imported lazily so
+    # a future rename breaks image staging with a clear error here rather
+    # than failing `import inspect_swe` for every user
+    from inspect_ai._util.images import file_as_data
+
     images_dir = join_path(codex_home, "images")
     await sandbox_exec(sandbox, f"mkdir -p {images_dir}", user=user)
-    args: list[str] = []
+    files: list[str] = []
     for idx, image in enumerate(images):
         image_bytes, mime_type = await file_as_data(image.image)
-        extension = mimetypes.guess_extension(mime_type, strict=False) or ".png"
+        extension = (
+            _IMAGE_EXTENSIONS.get(mime_type)
+            or mimetypes.guess_extension(mime_type, strict=False)
+            or ".png"
+        )
         image_file = join_path(images_dir, f"image-{idx}{extension}")
         await sandbox.write_file(image_file, image_bytes)
-        args.extend(["--image", image_file])
-    return args
+        files.append(image_file)
+    return files
 
 
 async def resolve_codex_model(
@@ -827,26 +851,48 @@ async def resolve_codex_model(
 async def _run_codex_cli_centaur(
     options: CentaurOptions,
     codex_cmd: list[str],
-    image_args: list[str],
+    image_files: list[str],
     agent_env: dict[str, str],
     state: AgentState,
 ) -> None:
-    # Attach input images inside the alias, spliced right after the binary
-    # rather than trailing: `--image` is multi-value, so tokens the human
-    # types after the alias (a prompt, or `resume`) would be swallowed as
-    # image paths if the alias ended with an `--image` flag.
-    codex_cmd = codex_cmd[:1] + image_args + codex_cmd[1:]
-
     instructions = "Codex CLI:\n\n - You may also use Codex CLI via the 'codex' command.\n - Use 'codex resume' if you need to resume a previous codex session."
-    if image_args:
-        image_files = ", ".join(image_args[1::2])
-        instructions += f"\n - The task input includes image file(s), which the 'codex' alias attaches to your prompt automatically: {image_files}"
+
+    if image_files:
+        # Attach input images to the human's first codex invocation only,
+        # via a self-disarming shell function (the marker file survives new
+        # shells re-sourcing .bashrc). A permanent alias would re-attach the
+        # images on every invocation -- codex applies root `--image` args to
+        # `resume` too, duplicating images already embedded in the session
+        # rollout. The flags are spliced right after the binary rather than
+        # trailing: `--image` is multi-value, so tokens the human types after
+        # the command (a prompt, or `resume`) would be swallowed as image
+        # paths if the command ended with an `--image` flag.
+        image_args = [arg for file in image_files for arg in ("--image", file)]
+        marker = shlex.quote(str(PurePosixPath(image_files[0]).parent / ".attached"))
+        first_cmd = shlex.join(codex_cmd[:1] + image_args + codex_cmd[1:])
+        plain_cmd = shlex.join(codex_cmd)
+        codex_cmd_def = dedent(f"""
+            codex() {{
+              if [ ! -e {marker} ]; then
+                touch {marker}
+                {first_cmd} "$@"
+              else
+                {plain_cmd} "$@"
+              fi
+            }}
+        """).strip()
+        instructions += (
+            "\n - The task input includes image file(s), which the 'codex' "
+            "command attaches to your first invocation automatically: "
+            f"{', '.join(image_files)}"
+        )
+    else:
+        alias_cmd = shlex.join(codex_cmd)
+        codex_cmd_def = "alias codex='" + alias_cmd.replace("'", "'\\''") + "'"
 
     # build .bashrc content
     agent_env_vars = [f'export {k}="{v}"' for k, v in agent_env.items()]
-    alias_cmd = shlex.join(codex_cmd)
-    alias_cmd = "alias codex='" + alias_cmd.replace("'", "'\\''") + "'"
-    bashrc = "\n".join(agent_env_vars + ["", alias_cmd])
+    bashrc = "\n".join(agent_env_vars + ["", codex_cmd_def])
 
     # run the human cli
     await run_centaur(options, instructions, bashrc, state)

--- a/src/inspect_swe/_util/messages.py
+++ b/src/inspect_swe/_util/messages.py
@@ -1,4 +1,5 @@
-from typing import NamedTuple
+from logging import getLogger
+from typing import Collection, NamedTuple
 
 from inspect_ai.model import (
     ChatMessage,
@@ -6,6 +7,8 @@ from inspect_ai.model import (
     ChatMessageUser,
     ContentImage,
 )
+
+logger = getLogger(__name__)
 
 
 class UserTurn(NamedTuple):
@@ -40,8 +43,29 @@ def user_turn(messages: list[ChatMessage]) -> UserTurn:
     )
 
 
-def build_user_prompt(messages: list[ChatMessage]) -> tuple[str, bool]:
+def build_user_prompt(
+    messages: list[ChatMessage], handled_content: Collection[str] = ()
+) -> tuple[str, bool]:
+    """Prompt text for the next agent turn.
+
+    The prompt is the text of the user messages after the last assistant
+    response. Non-text content in those messages cannot ride along in the
+    prompt and is dropped with a warning — pass `handled_content` to name
+    content types (e.g. "image") the calling agent delivers by other means.
+    """
     turn = user_turn(messages)
+    dropped = {
+        content.type
+        for m in turn.messages
+        if isinstance(m.content, list)
+        for content in m.content
+        if content.type != "text" and content.type not in handled_content
+    }
+    if dropped:
+        logger.warning(
+            f"Input contains {', '.join(sorted(dropped))} content, which this "
+            "agent does not support; it was dropped from the prompt."
+        )
     prompt = "\n\n".join(m.text for m in turn.messages)
     return prompt, turn.has_assistant_response
 

--- a/src/inspect_swe/_util/messages.py
+++ b/src/inspect_swe/_util/messages.py
@@ -1,7 +1,24 @@
-from inspect_ai.model import ChatMessage, ChatMessageAssistant, ChatMessageUser
+from typing import NamedTuple
+
+from inspect_ai.model import (
+    ChatMessage,
+    ChatMessageAssistant,
+    ChatMessageUser,
+    ContentImage,
+)
 
 
-def build_user_prompt(messages: list[ChatMessage]) -> tuple[str, bool]:
+class UserTurn(NamedTuple):
+    messages: list[ChatMessageUser]
+    has_assistant_response: bool
+
+
+def user_turn(messages: list[ChatMessage]) -> UserTurn:
+    """User messages that form the next prompt to the agent.
+
+    These are the user messages after the last assistant response (or all
+    user messages if there is no assistant response yet).
+    """
     if messages and isinstance(messages[-1], ChatMessageAssistant):
         raise ValueError("Messages input ends with an assistant messages.")
 
@@ -17,8 +34,28 @@ def build_user_prompt(messages: list[ChatMessage]) -> tuple[str, bool]:
     has_assistant_response = last_assistant_idx is not None
     start_idx = (last_assistant_idx + 1) if last_assistant_idx is not None else 0
 
-    prompt = "\n\n".join(
-        m.text for m in messages[start_idx:] if isinstance(m, ChatMessageUser)
+    return UserTurn(
+        [m for m in messages[start_idx:] if isinstance(m, ChatMessageUser)],
+        has_assistant_response,
     )
 
-    return prompt, has_assistant_response
+
+def build_user_prompt(messages: list[ChatMessage]) -> tuple[str, bool]:
+    turn = user_turn(messages)
+    prompt = "\n\n".join(m.text for m in turn.messages)
+    return prompt, turn.has_assistant_response
+
+
+def collect_user_images(messages: list[ChatMessage]) -> list[ContentImage]:
+    """Image content from the user messages that form the next prompt.
+
+    Scoped identically to `build_user_prompt` (i.e. the user messages after
+    the last assistant response).
+    """
+    return [
+        content
+        for m in user_turn(messages).messages
+        if isinstance(m.content, list)
+        for content in m.content
+        if isinstance(content, ContentImage)
+    ]

--- a/tests/test_image_input.py
+++ b/tests/test_image_input.py
@@ -1,0 +1,99 @@
+from typing import Any
+
+import pytest
+from inspect_ai import eval
+from inspect_ai.log import EvalSample, resolve_sample_attachments
+from inspect_ai.model import ChatMessageAssistant, ChatMessageUser
+
+from tests.conftest import (
+    get_available_sandboxes,
+    skip_if_no_docker,
+    skip_if_no_openai,
+)
+
+# color names a model might reasonably use for the two solid-color images in
+# examples/image_input (magenta = rgb(255,0,255), green = rgb(0,200,0))
+MAGENTA_NAMES = ["magenta", "fuchsia", "pink", "purple", "violet"]
+GREEN_NAMES = ["green"]
+
+
+@skip_if_no_openai
+@skip_if_no_docker
+@pytest.mark.parametrize("sandbox", get_available_sandboxes())
+def test_codex_cli_image_input(sandbox: str) -> None:
+    """Images in the input reach codex (via `codex exec --image`).
+
+    Regression test: image content in sample input was silently dropped
+    (`build_user_prompt` keeps only text). Verifies both the initial prompt
+    and a follow-up message after an assistant response (`exec resume`).
+    """
+    log = eval(
+        "examples/image_input",
+        model="openai/gpt-5",
+        limit=1,
+        task_args={"sandbox": sandbox},
+        time_limit=600,
+        token_limit=500_000,
+    )[0]
+    assert log.status == "success", f"eval failed: {log.error}"
+    assert log.samples
+    sample = log.samples[0]
+
+    # mechanism: the raw model requests actually carried image content
+    assert _image_content_counts(sample), (
+        "no model request contained image content: images did not reach codex"
+    )
+
+    # behavior: the model identified the color of each image
+    turn_1_answer, turn_2_answer = _turn_answers(sample)
+    assert any(color in turn_1_answer.lower() for color in MAGENTA_NAMES), (
+        f"first answer did not identify the magenta image: {turn_1_answer!r}"
+    )
+    assert any(color in turn_2_answer.lower() for color in GREEN_NAMES), (
+        f"second answer did not identify the green image: {turn_2_answer!r}"
+    )
+
+
+def _turn_answers(sample: EvalSample) -> tuple[str, str]:
+    """Assistant text for turn 1 (before the second user image) and turn 2."""
+    second_user_idx = [
+        i
+        for i, m in enumerate(sample.messages)
+        if isinstance(m, ChatMessageUser) and "second image" in m.text
+    ][0]
+    turn_1 = " ".join(
+        m.text
+        for m in sample.messages[:second_user_idx]
+        if isinstance(m, ChatMessageAssistant)
+    )
+    turn_2 = " ".join(
+        m.text
+        for m in sample.messages[second_user_idx:]
+        if isinstance(m, ChatMessageAssistant)
+    )
+    return turn_1, turn_2
+
+
+def _image_content_counts(sample: EvalSample) -> list[int]:
+    """Per-model-call count of image content blocks in the raw request."""
+    sample = resolve_sample_attachments(sample, "full")
+
+    def count_images(value: Any) -> int:
+        if isinstance(value, dict):
+            n = 1 if value.get("type") == "input_image" else 0
+            return n + sum(count_images(v) for v in value.values())
+        if isinstance(value, list):
+            return sum(count_images(v) for v in value)
+        return 0
+
+    counts: list[int] = []
+    for event in sample.events:
+        if getattr(event, "event", None) != "model":
+            continue
+        call = getattr(event, "call", None)
+        if call is None:
+            continue
+        n = count_images(call.request)
+        if n:
+            counts.append(n)
+    return counts

--- a/tests/test_image_input.py
+++ b/tests/test_image_input.py
@@ -1,3 +1,5 @@
+import subprocess
+from pathlib import Path
 from typing import Any
 
 import anyio
@@ -44,7 +46,7 @@ def test_codex_cli_image_input(sandbox: str) -> None:
     sample = log.samples[0]
 
     # mechanism: the raw model requests actually carried image content
-    assert _image_content_counts(sample), (
+    assert _any_request_has_images(sample), (
         "no model request contained image content: images did not reach codex"
     )
 
@@ -58,15 +60,17 @@ def test_codex_cli_image_input(sandbox: str) -> None:
     )
 
 
-def test_codex_cli_centaur_alias_attaches_images(
-    monkeypatch: pytest.MonkeyPatch,
+def test_codex_cli_centaur_attaches_images_once(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """The centaur `codex` alias carries the staged `--image` args.
+    """The centaur `codex` command attaches staged images, on first use only.
 
-    Regression test: image args were only consumed by the headless exec
-    branch, so in centaur mode images were staged as files but the alias
-    never attached them -- a silent drop (the image-content warning is
-    suppressed because the content is declared handled).
+    Regression tests, in branch-history order: image files were staged but
+    never attached in centaur mode (silent drop, with the image-content
+    warning suppressed because the content is declared handled); then a
+    permanent alias re-attached the images on every invocation, including
+    `codex resume`, duplicating images codex had already embedded in its
+    rollout. Now a self-disarming shell function attaches them exactly once.
     """
     captured: dict[str, str] = {}
 
@@ -83,32 +87,42 @@ def test_codex_cli_centaur_alias_attaches_images(
         lambda: codex_cli_module._run_codex_cli_centaur(
             options=CentaurOptions(),
             codex_cmd=["/usr/bin/codex", "--model", "gpt-5", "-c", "key=value"],
-            image_args=["--image", image_file],
+            image_files=[image_file],
             agent_env={},
             state=AgentState(messages=[]),
         )
     )
 
-    alias = next(
-        line
-        for line in captured["bashrc"].splitlines()
-        if line.startswith("alias codex=")
-    )
-    assert f"--image {image_file}" in alias
+    bashrc = captured["bashrc"]
+
+    # a self-disarming function, not a permanent alias
+    assert "codex()" in bashrc
+    assert "alias codex=" not in bashrc
+    assert "/home/user/.codex/images/.attached" in bashrc
+
+    # exactly one invocation attaches the images (the marker-guarded branch)
+    assert bashrc.count(f"--image {image_file}") == 1
 
     # image args must be spliced after the binary, not appended: `--image` is
-    # multi-value, so an alias ending with it would swallow whatever the human
-    # types next (`codex resume`, or a prompt) as another image path
-    assert alias.index("--image") < alias.index("--model")
+    # multi-value, so a command ending with it would swallow whatever the
+    # human types next (`codex resume`, or a prompt) as another image path
+    attach_line = next(line for line in bashrc.splitlines() if "--image" in line)
+    assert attach_line.index("--image") < attach_line.index("--model")
+
+    # the generated bashrc is valid bash
+    rc_file = tmp_path / "bashrc"
+    rc_file.write_text(bashrc)
+    subprocess.run(["bash", "-n", str(rc_file)], check=True)
 
     # the human is told about the attached images
     assert image_file in captured["instructions"]
+    assert "first invocation" in captured["instructions"]
 
 
 def test_codex_cli_centaur_alias_without_images(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """No image args: the alias and instructions are unchanged."""
+    """No images: the plain alias and instructions are unchanged."""
     captured: dict[str, str] = {}
 
     async def fake_run_centaur(
@@ -123,12 +137,13 @@ def test_codex_cli_centaur_alias_without_images(
         lambda: codex_cli_module._run_codex_cli_centaur(
             options=CentaurOptions(),
             codex_cmd=["/usr/bin/codex", "--model", "gpt-5"],
-            image_args=[],
+            image_files=[],
             agent_env={},
             state=AgentState(messages=[]),
         )
     )
 
+    assert "alias codex=" in captured["bashrc"]
     assert "--image" not in captured["bashrc"]
     assert "image" not in captured["instructions"].lower()
 
@@ -153,26 +168,23 @@ def _turn_answers(sample: EvalSample) -> tuple[str, str]:
     return turn_1, turn_2
 
 
-def _image_content_counts(sample: EvalSample) -> list[int]:
-    """Per-model-call count of image content blocks in the raw request."""
+def _any_request_has_images(sample: EvalSample) -> bool:
+    """Whether any raw model request contains an image content block."""
     sample = resolve_sample_attachments(sample, "full")
 
-    def count_images(value: Any) -> int:
+    def has_image(value: Any) -> bool:
         if isinstance(value, dict):
-            n = 1 if value.get("type") == "input_image" else 0
-            return n + sum(count_images(v) for v in value.values())
+            return value.get("type") == "input_image" or any(
+                has_image(v) for v in value.values()
+            )
         if isinstance(value, list):
-            return sum(count_images(v) for v in value)
-        return 0
+            return any(has_image(v) for v in value)
+        return False
 
-    counts: list[int] = []
     for event in sample.events:
         if getattr(event, "event", None) != "model":
             continue
         call = getattr(event, "call", None)
-        if call is None:
-            continue
-        n = count_images(call.request)
-        if n:
-            counts.append(n)
-    return counts
+        if call is not None and has_image(call.request):
+            return True
+    return False

--- a/tests/test_image_input.py
+++ b/tests/test_image_input.py
@@ -1,9 +1,13 @@
 from typing import Any
 
+import anyio
 import pytest
 from inspect_ai import eval
+from inspect_ai.agent import AgentState
 from inspect_ai.log import EvalSample, resolve_sample_attachments
 from inspect_ai.model import ChatMessageAssistant, ChatMessageUser
+from inspect_swe._codex_cli import codex_cli as codex_cli_module
+from inspect_swe._util.centaur import CentaurOptions
 
 from tests.conftest import (
     get_available_sandboxes,
@@ -52,6 +56,81 @@ def test_codex_cli_image_input(sandbox: str) -> None:
     assert any(color in turn_2_answer.lower() for color in GREEN_NAMES), (
         f"second answer did not identify the green image: {turn_2_answer!r}"
     )
+
+
+def test_codex_cli_centaur_alias_attaches_images(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The centaur `codex` alias carries the staged `--image` args.
+
+    Regression test: image args were only consumed by the headless exec
+    branch, so in centaur mode images were staged as files but the alias
+    never attached them -- a silent drop (the image-content warning is
+    suppressed because the content is declared handled).
+    """
+    captured: dict[str, str] = {}
+
+    async def fake_run_centaur(
+        options: CentaurOptions, instructions: str, bashrc: str, state: AgentState
+    ) -> None:
+        captured["instructions"] = instructions
+        captured["bashrc"] = bashrc
+
+    monkeypatch.setattr(codex_cli_module, "run_centaur", fake_run_centaur)
+
+    image_file = "/home/user/.codex/images/image-0.png"
+    anyio.run(
+        lambda: codex_cli_module._run_codex_cli_centaur(
+            options=CentaurOptions(),
+            codex_cmd=["/usr/bin/codex", "--model", "gpt-5", "-c", "key=value"],
+            image_args=["--image", image_file],
+            agent_env={},
+            state=AgentState(messages=[]),
+        )
+    )
+
+    alias = next(
+        line
+        for line in captured["bashrc"].splitlines()
+        if line.startswith("alias codex=")
+    )
+    assert f"--image {image_file}" in alias
+
+    # image args must be spliced after the binary, not appended: `--image` is
+    # multi-value, so an alias ending with it would swallow whatever the human
+    # types next (`codex resume`, or a prompt) as another image path
+    assert alias.index("--image") < alias.index("--model")
+
+    # the human is told about the attached images
+    assert image_file in captured["instructions"]
+
+
+def test_codex_cli_centaur_alias_without_images(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No image args: the alias and instructions are unchanged."""
+    captured: dict[str, str] = {}
+
+    async def fake_run_centaur(
+        options: CentaurOptions, instructions: str, bashrc: str, state: AgentState
+    ) -> None:
+        captured["instructions"] = instructions
+        captured["bashrc"] = bashrc
+
+    monkeypatch.setattr(codex_cli_module, "run_centaur", fake_run_centaur)
+
+    anyio.run(
+        lambda: codex_cli_module._run_codex_cli_centaur(
+            options=CentaurOptions(),
+            codex_cmd=["/usr/bin/codex", "--model", "gpt-5"],
+            image_args=[],
+            agent_env={},
+            state=AgentState(messages=[]),
+        )
+    )
+
+    assert "--image" not in captured["bashrc"]
+    assert "image" not in captured["instructions"].lower()
 
 
 def _turn_answers(sample: EvalSample) -> tuple[str, str]:

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -44,6 +44,41 @@ def test_build_user_prompt_rejects_trailing_assistant() -> None:
         build_user_prompt(messages)
 
 
+def test_build_user_prompt_warns_on_dropped_content(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    messages: list[ChatMessage] = [
+        ChatMessageUser(content=[ContentText(text="describe this"), IMAGE_1]),
+    ]
+    with caplog.at_level("WARNING"):
+        prompt, _ = build_user_prompt(messages)
+    assert prompt == "describe this"
+    assert any("image" in r.message for r in caplog.records)
+
+
+def test_build_user_prompt_no_warning_for_handled_content(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    messages: list[ChatMessage] = [
+        ChatMessageUser(content=[ContentText(text="describe this"), IMAGE_1]),
+    ]
+    with caplog.at_level("WARNING"):
+        build_user_prompt(messages, handled_content=("image",))
+    assert not caplog.records
+
+
+def test_build_user_prompt_no_warning_for_text_only(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    messages: list[ChatMessage] = [
+        ChatMessageUser(content="plain"),
+        ChatMessageUser(content=[ContentText(text="structured")]),
+    ]
+    with caplog.at_level("WARNING"):
+        build_user_prompt(messages)
+    assert not caplog.records
+
+
 def test_collect_user_images_initial_turn() -> None:
     messages: list[ChatMessage] = [
         ChatMessageUser(content=[ContentText(text="look at these"), IMAGE_1, IMAGE_2]),

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1,0 +1,67 @@
+import pytest
+from inspect_ai.model import (
+    ChatMessage,
+    ChatMessageAssistant,
+    ChatMessageSystem,
+    ChatMessageUser,
+    ContentImage,
+    ContentText,
+)
+from inspect_swe._util.messages import build_user_prompt, collect_user_images
+
+IMAGE_1 = ContentImage(image="data:image/png;base64,aW1hZ2Ux")
+IMAGE_2 = ContentImage(image="data:image/png;base64,aW1hZ2Uy")
+
+
+def test_build_user_prompt_initial_turn() -> None:
+    messages: list[ChatMessage] = [
+        ChatMessageSystem(content="be helpful"),
+        ChatMessageUser(content="first"),
+        ChatMessageUser(content="second"),
+    ]
+    prompt, has_assistant_response = build_user_prompt(messages)
+    assert prompt == "first\n\nsecond"
+    assert has_assistant_response is False
+
+
+def test_build_user_prompt_after_assistant() -> None:
+    messages: list[ChatMessage] = [
+        ChatMessageUser(content="first"),
+        ChatMessageAssistant(content="answer"),
+        ChatMessageUser(content="follow up"),
+    ]
+    prompt, has_assistant_response = build_user_prompt(messages)
+    assert prompt == "follow up"
+    assert has_assistant_response is True
+
+
+def test_build_user_prompt_rejects_trailing_assistant() -> None:
+    messages: list[ChatMessage] = [
+        ChatMessageUser(content="first"),
+        ChatMessageAssistant(content="answer"),
+    ]
+    with pytest.raises(ValueError):
+        build_user_prompt(messages)
+
+
+def test_collect_user_images_initial_turn() -> None:
+    messages: list[ChatMessage] = [
+        ChatMessageUser(content=[ContentText(text="look at these"), IMAGE_1, IMAGE_2]),
+    ]
+    assert collect_user_images(messages) == [IMAGE_1, IMAGE_2]
+
+
+def test_collect_user_images_str_content() -> None:
+    messages: list[ChatMessage] = [ChatMessageUser(content="no images here")]
+    assert collect_user_images(messages) == []
+
+
+def test_collect_user_images_scoped_to_current_turn() -> None:
+    # images before the last assistant response belong to an already-delivered
+    # turn and must not be re-collected
+    messages: list[ChatMessage] = [
+        ChatMessageUser(content=[ContentText(text="first"), IMAGE_1]),
+        ChatMessageAssistant(content="answer"),
+        ChatMessageUser(content=[ContentText(text="second"), IMAGE_2]),
+    ]
+    assert collect_user_images(messages) == [IMAGE_2]


### PR DESCRIPTION
A user running a multimodal eval through the agent bridge reported that their images never reached the agent. The cause is `build_user_prompt()`, which joins only the text parts of the user messages, so a `[ContentText, ContentImage]` input reached codex as plain text. Nothing warned about the drop, which is the part that bothered me most: the eval scored as if the task were text-only and everything looked fine.

## What this does

`codex_cli` now stages each image from the current user turn as a file in the sandbox, under `CODEX_HOME/images`, and attaches it with `codex exec --image <file>`. This covers the initial launch and follow-up turns, since `codex exec resume` accepts `--image` for the resumed prompt. In centaur mode a self-disarming shell function attaches the images to the human's first codex invocation only. Images are not re-attached on retry attempts under `attempts`, which resend text-only `incorrect_message`, nor on checkpoint resume: codex embeds the image bytes into its rollout at launch, so re-attaching would duplicate them. I verified the embedding on 0.151.0 by inspecting the raw turn 2 request, which still carried turn 1's bytes after the staged file had been overwritten.

The other agents still drop images, so `build_user_prompt()` now warns and names the dropped content types. An agent that delivers a type by other means declares it with `handled_content`, which codex_cli does for images. I think most of the others can get native support later. Claude Code's print mode accepts image blocks over `--input-format stream-json`, and gemini expands `@file` references. The warning is the tripwire until then. For the changelog:

fix: warn when unsupported input content is dropped from the agent prompt

One codex quirk shaped the argv layout. `--image` is a multi-value option and swallows whatever positional follows it. My first local test, `codex exec -i img.png "say hi"`, consumed the prompt as a second image path and fell back to reading the prompt from stdin. So headless invocations append the image flags last, after the prompt and the `resume` subcommand, while the centaur function splices them right after the binary because the human types their prompt after the command.

## Testing

- `tests/test_messages.py` covers the prompt scope, image collection, and the drop warning.
- `tests/test_image_input.py` has centaur unit tests, including a `bash -n` syntax check of the generated bashrc, plus a live end-to-end test gated on docker and `OPENAI_API_KEY`. The live test runs the new `examples/image_input` with `openai/gpt-5`: a magenta image in the sample input, then a green image in a follow-up message, so both the `exec --image` and `exec resume --image` paths run.
- The live test passes locally in ~45s against codex 0.151.0, linux-arm64 in docker. Both turns answered with the right color, and the raw model requests carried the actual bytes: one `input_image` block in turn 1, two in turn 2.
- I also simulated the centaur function directly in bash. Images attach on the first invocation; `codex resume` and later calls run clean.
- `make check` is clean and the fast suite passes, 282 passed / 64 skipped. `tests/test_trajectory_parsing.py` doesn't collect in my venv because `minisweagent` isn't installed there; same on main.

## Agent involvement

Built with Claude Code (Claude Fable 5), driven and reviewed by Matt. One adversarial review pass ran in a fresh context (Fable 5, /code-review) against the branch diff before the final commit. It reported 9 findings. 6 were fixed in 316ff2b: the centaur alias re-attaching images on every invocation including `codex resume`; image duplication on checkpoint resume; webp extension mislabeling on Python 3.10, where stdlib mimetypes lacks image/webp; the private `inspect_ai._util.images` import executing at package import time; the staging helper returning argv pairs the centaur path had to un-parse; and a test helper returning counts its caller used as a boolean. 3 were dismissed: a codex version floor for `--image` (the failure without one is a RuntimeError carrying codex's own "unexpected argument" message, and I can't pin the exact release that added `resume --image`); the stdin fallback when a turn has images but no text (verified harmless on 0.151.0); and the convention coupling between the warning suppression and the staging call (six lines apart in the same function; worth revisiting when a second agent grows image support).
