### PR TITLE
chore: fix terminal_bench_test example (Task no longer accepts tools)

### DIFF
--- a/examples/terminal_bench_test/task.py
+++ b/examples/terminal_bench_test/task.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
 from inspect_ai import Task, task
-from inspect_ai.tool import bash, python
 from inspect_swe import mini_swe_agent
 
 
@@ -86,5 +85,4 @@ def terminal_bench_task(
         dataset=dataset,
         solver=solver,
         scorer=terminal_bench_2_scorer(),
-        tools=[bash(timeout=60), python(timeout=60)],
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,3 +114,10 @@ python_executable = ".venv/bin/python"
 [[tool.mypy.overrides]]
 module = ["google.antigravity.*"]
 ignore_missing_imports = true
+
+# inspect_cyber is only used by examples/ (guarded by a try/except with install
+# instructions) and is not a project dependency; tell mypy not to require types
+# for it when checking examples on the host.
+[[tool.mypy.overrides]]
+module = ["inspect_cyber.*"]
+ignore_missing_imports = true


### PR DESCRIPTION
## Summary

The `terminal_bench_test` example passes `tools=[bash(...), python(...)]` to inspect_ai's `Task`, but `Task` has no `tools` parameter — the argument is silently swallowed by the deprecated-args `**kwargs` and dropped, so it has never done anything. The example's solver is `mini_swe_agent`, which drives the sandbox directly and never reads Inspect tools, so the list was redundant as well as dead. This removes the argument and the now-unused import.

Also adds a mypy `ignore_missing_imports` override for `inspect_cyber` (example-only optional dependency whose import is already guarded by a try/except with install instructions), mirroring the existing `google.antigravity` override, so `mypy examples` runs clean. Note that CI's mypy gate only covers `src`/`tests`, which is why neither issue surfaced there.

### Agent review
- Reviewer: Claude Fable 5 code-reviewer subagent (fresh context, same model family as author), 1 pass
- Findings: no defects. One factual correction adopted into this description: the stray `tools=` argument is silently discarded by `Task.__init__`'s `**kwargs` rather than raising at runtime, so the pre-fix behavior was a silent no-op, not a crash. Reviewer verified `mini_swe_agent` never consumes Inspect tools and that the mypy override scope matches the existing pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)