### PR TITLE
test: capture all bridged system messages in model-config live tests

### DIFF
--- a/tests/test_model_config_live.py
+++ b/tests/test_model_config_live.py
@@ -60,8 +60,12 @@ class _CaptureDisplay:
         *_: object,  # bridge also passes tools, tool_choice, config
     ) -> ModelOutput:
         if self.system_prompt is None:
-            self.system_prompt = next(
-                (m.text for m in messages if isinstance(m, ChatMessageSystem)), ""
+            # Claude Code sends its system prompt as several blocks (one of which
+            # is just an `x-anthropic-billing-header:` line) and the bridge keeps one
+            # ChatMessageSystem per block, so join them rather than taking the
+            # first.
+            self.system_prompt = "\n\n".join(
+                m.text for m in messages if isinstance(m, ChatMessageSystem)
             )
             self.resolved_model = model.canonical_name()
         return ModelOutput.from_content(


### PR DESCRIPTION
Fixes the 4 `tests/test_model_config_live.py` failures in the 2026-09-03 nightly ([run](https://github.com/meridianlabs-ai/actions/actions/runs/33733358898)).

**Root cause.** inspect_ai 0.3.262 ([UKGovernmentBEIS/inspect_ai#4893](https://github.com/UKGovernmentBEIS/inspect_ai/pull/4893)) changed the agent bridge to emit one `ChatMessageSystem` per Anthropic `system` block instead of concatenating them (the Anthropic API drops any system block that begins with an `x-anthropic-*-header:` line, so concatenation was silently discarding instructions). Claude Code's first system block is `x-anthropic-billing-header: cc_version=...; cc_entrypoint=sdk-cli;`. The test's `_CaptureDisplay` took only the *first* system message, so it captured just that header and the "powered by the model named ..." assertions failed. Nightly 09-02 installed 0.3.261 and passed; 09-03 installed 0.3.262 and failed. No `src/` change needed — the agent never reads bridged system messages.

**Fix.** Join all system messages' text in `_CaptureDisplay` instead of taking the first. Reproduced locally with inspect_ai 0.3.262 + Claude Code stable 2.1.236 (fails before, all 4 pass after).

The 5th failure in that run, `test_mcp.py::test_claude_code_mcp` (model used Bash/Read/Write instead of the memory MCP tools), passes locally on the same versions and had not failed in the previous 30 nightlies; treating as a single-sample model-behavior flake, no change.

### Agent review
- Reviewer: Claude Fable 5.1 subagent (fresh context, same model family as author), 1 pass
- Findings: 1 nit (comment wording tied to Claude Code's current block order) — fixed. Reviewer also verified `src/inspect_swe/_claude_code/claude_code.py` system-message collection is unaffected: bridged system messages are only re-sent when `not is_resume`, and every re-invocation after a bridged turn is a resume.
