### PR TITLE
test: name the memory MCP server in the mcp example prompt

### DIFF
--- a/examples/mcp/task.py
+++ b/examples/mcp/task.py
@@ -15,7 +15,10 @@ def mcp_memory(
     sandbox: SandboxEnvironmentType | None = "docker",
 ) -> Task:
     # setup agent
-    system_prompt = "You MUST use the memory tools to keep track of your work. Please note all findings using the memory tools."
+    # Name the MCP server explicitly: Claude Code's own system prompt describes
+    # a file-based "auto memory" written with the Write tool, so a bare "memory
+    # tools" instruction is ambiguous and the model may write files instead.
+    system_prompt = "You MUST use the `memory` MCP server's tools (e.g. create_entities, add_observations, read_graph) to keep track of your work. Record all findings with those tools, not in files."
     mcp_servers = [
         MCPServerConfigStdio(
             name="memory",
@@ -37,7 +40,7 @@ def mcp_memory(
     return Task(
         dataset=[
             Sample(
-                input=f"List the contents of the current directory, then use the memory tools to record what you found. Then, on the next turn, read from memory your findings and report them. {system_prompt}"
+                input=f"List the contents of the current directory, then record what you found using the `memory` MCP server's tools. Then, on the next turn, read your findings back from the `memory` MCP server and report them. {system_prompt}"
             )
         ],
         solver=solver,


### PR DESCRIPTION
Fixes `tests/test_mcp.py::test_claude_code_mcp`, which failed in both 2026-09-03 nightlies ([scheduled](https://github.com/meridianlabs-ai/actions/actions/runs/33733358898), [post-pr-143 dispatch](https://github.com/meridianlabs-ai/actions/actions/runs/33758955210)) with `Expected 'mcp__memory__create_entities' in tool calls, got: ['Bash', 'Read', 'Write']`. It had not failed in the previous 28 nightlies.

**Root cause.** inspect_ai 0.3.262 (installed by the 09-03 nightlies; 09-02 had 0.3.261) forwards Anthropic `system` blocks intact through the agent bridge. Before that, the whole concatenated system prompt began with Claude Code's `x-anthropic-billing-header:` line and the API discarded it, so the model never saw Claude Code's system prompt. That prompt has an "auto memory" section telling the model to keep memory in files with the Write tool. Now that the model reads it, the example's "use the memory tools" instruction is ambiguous, and claude-sonnet-4-5 writes files instead of calling the `memory` MCP server. The MCP wiring is fine: every request in the failing log offers all 8 `mcp__memory__*` tools.

Isolated locally (Claude Code stable 2.1.236 unless noted):
- inspect_ai 0.3.262: fails (also fails with Claude Code 2.1.229, so the Claude Code version is not the delta)
- inspect_ai 0.3.261: passes
- 0.3.262 + this change: passes 2/2

**Fix.** Name the `memory` MCP server and its tools in the example prompt. Test-only; no `src/` change. `test_opencode_mcp` and `test_codex_cli_mcp` share the prompt and still pass locally.

**Other failures in run 33758955210, not touched:**
- `test_gemini_cli_multi_call[docker]` (`assert 1 >= 4`): 3 of the last 30 nightlies (08-25, 08-31, 09-03), each with many HTTP retries against `google/gemini-3.1-pro-preview` pushing the 4-turn run past the 600s eval limit (603s today vs 70s on the green 09-02 run). API-side slowness under concurrent gemini tests, not a code change; passes locally in 197s with 0 retries. Options: move the gemini tests to a GA model, or mark this test flaky. Left for a decision.
- `test_kimi_code_bridged_tools` (`'error' == 'success'`): 2 of 30 (08-19 ReadTimeout, 09-03 ConnectTimeout, both fetching `code.kimi.com/kimi-code/latest.json` from the runner, 4 attempts over 140s). Passes locally. Infra flake.

### Agent review
- Reviewer: Claude Fable 5.1 subagent (fresh context, same model family as author), 1 pass, test-only diff so no second-model pass
- Findings: 2 nits, both pre-existing and dismissed (the prompt is interpolated into the sample input as well as the system prompt; "on the next turn" wording). Reviewer confirmed the test still fails if MCP wiring breaks.
