### PR TITLE
fix(claude_code): disable auto-memory so sandboxed agents use task-provided memory tools

### DIFF
--- a/docs/claude_code.qmd
+++ b/docs/claude_code.qmd
@@ -34,7 +34,7 @@ The following options are supported for customizing the behavior of the agent:
 | `retry_refusals` | Should refusals be retried? Defaults to 3. |
 | `retry_uncaught_errors` | Should uncaught errors (unexpected crashes of Claude Code) be retried? Defaults to 3. |
 | `cwd` | Working directory for {{< meta agent_name >}} session. |
-| `env` | Environment variables to set for {{< meta agent_name >}} (applied last, so they override the defaults inspect_swe sets). |
+| `env` | Environment variables to set for {{< meta agent_name >}}. |
 | `version` | Version of {{< meta agent_name >}} to use (see [Installation](#installation) below for details) |
 
 : {tbl-colwidths=\[25,75\]}

--- a/docs/claude_code.qmd
+++ b/docs/claude_code.qmd
@@ -34,7 +34,7 @@ The following options are supported for customizing the behavior of the agent:
 | `retry_refusals` | Should refusals be retried? Defaults to 3. |
 | `retry_uncaught_errors` | Should uncaught errors (unexpected crashes of Claude Code) be retried? Defaults to 3. |
 | `cwd` | Working directory for {{< meta agent_name >}} session. |
-| `env` | Environment variables to set for {{< meta agent_name >}}. Applied last, so they override the sandbox defaults inspect_swe sets (blocking MCP startup, `CLAUDE_CODE_DISABLE_AUTO_MEMORY=1`); e.g. pass `{"CLAUDE_CODE_DISABLE_AUTO_MEMORY": "0"}` to re-enable auto-memory. |
+| `env` | Environment variables to set for {{< meta agent_name >}} (applied last, so they override the defaults inspect_swe sets). |
 | `version` | Version of {{< meta agent_name >}} to use (see [Installation](#installation) below for details) |
 
 : {tbl-colwidths=\[25,75\]}

--- a/docs/claude_code.qmd
+++ b/docs/claude_code.qmd
@@ -34,7 +34,7 @@ The following options are supported for customizing the behavior of the agent:
 | `retry_refusals` | Should refusals be retried? Defaults to 3. |
 | `retry_uncaught_errors` | Should uncaught errors (unexpected crashes of Claude Code) be retried? Defaults to 3. |
 | `cwd` | Working directory for {{< meta agent_name >}} session. |
-| `env` | Environment variables to set for {{< meta agent_name >}}. |
+| `env` | Environment variables to set for {{< meta agent_name >}}. Applied last, so they override the sandbox defaults inspect_swe sets (blocking MCP startup, `CLAUDE_CODE_DISABLE_AUTO_MEMORY=1`); e.g. pass `{"CLAUDE_CODE_DISABLE_AUTO_MEMORY": "0"}` to re-enable auto-memory. |
 | `version` | Version of {{< meta agent_name >}} to use (see [Installation](#installation) below for details) |
 
 : {tbl-colwidths=\[25,75\]}

--- a/src/inspect_swe/_claude_code/claude_code.py
+++ b/src/inspect_swe/_claude_code/claude_code.py
@@ -226,7 +226,10 @@ def claude_code(
         retry_refusals: Should refusals be retried? Defaults to retrying up to 3 times.
         retry_uncaught_errors: Should uncaught errors (unexpected crashes of Claude Code) be retried. Defaults to retrying up to 3 times.
         cwd: Working directory to run claude code within.
-        env: Environment variables to set for claude code.
+        env: Environment variables to set for claude code. Applied last, so
+            they override the sandbox defaults inspect_swe sets (see
+            `_claude_code/env.py`); e.g. `CLAUDE_CODE_DISABLE_AUTO_MEMORY="0"`
+            re-enables auto-memory.
         user: User to execute claude code with.
         sandbox: Optional sandbox environment name.
         version: Version of claude code to use. One of:

--- a/src/inspect_swe/_claude_code/env.py
+++ b/src/inspect_swe/_claude_code/env.py
@@ -36,6 +36,10 @@ from .model import ClaudeCodeModels
 #: it block.
 FALSY_ENV_VALUES: Final = frozenset({"0", "false", "no", "off"})
 
+#: Values Claude Code treats as an explicit "true" for boolean env vars
+#: (transcribed from the bundled source alongside ``FALSY_ENV_VALUES``).
+TRUTHY_ENV_VALUES: Final = frozenset({"1", "true", "yes", "on"})
+
 #: Make MCP connection blocking, with a budget that covers a slow sandbox.
 #:
 #: The blocking wait is bounded, so blocking alone is not sufficient on every
@@ -47,6 +51,27 @@ BLOCKING_MCP_ENV: Final = {
     "MCP_CONNECTION_NONBLOCKING": "false",
     "MCP_TIMEOUT": "300000",
     "MCP_CONNECT_TIMEOUT_MS": "300000",
+}
+
+#: Turn off Claude Code's auto-memory.
+#:
+#: Auto-memory exists to carry knowledge across *future conversations*: the
+#: agent writes markdown memory files under its config directory and the index
+#: is loaded into context at the start of the next session. A sample's sandbox
+#: normally has no next session -- it starts empty and is destroyed with the
+#: sample -- so the feature cannot pay off here. It still costs: the system
+#: prompt gains an ``# auto memory`` section (~3k input tokens, cached after
+#: the first call) telling the model to persist memory as files with the file
+#: tools, and the model can spend turns doing so. Left on, it also collides
+#: with task-provided memory tooling: in ``examples/mcp`` the model wrote
+#: memory files with ``Write`` instead of calling the ``memory`` MCP server.
+#:
+#: Claude Code reads the variable with a truthy check, so only a
+#: ``TRUTHY_ENV_VALUES`` token disables. An explicit falsy token *enables*,
+#: overriding even ``settings.json``, which gives callers who deliberately
+#: study memory persistence a clean opt-in via ``env``.
+DISABLE_AUTO_MEMORY_ENV: Final = {
+    "CLAUDE_CODE_DISABLE_AUTO_MEMORY": "1",
 }
 
 
@@ -63,7 +88,7 @@ def claude_code_agent_env(
         models: Resolved presented identities (cosmetic; the bridge routes to
             the real model).
         env: Caller overrides, applied last so any default here can be
-            replaced -- including the MCP startup defaults.
+            replaced -- including the MCP startup and auto-memory defaults.
 
     Returns:
         The merged environment, caller values winning on conflict.
@@ -81,4 +106,5 @@ def claude_code_agent_env(
         "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
         "IS_SANDBOX": "1",
         **BLOCKING_MCP_ENV,
+        **DISABLE_AUTO_MEMORY_ENV,
     } | (env or {})

--- a/src/inspect_swe/acp/_agents/claude_code/claude_code.py
+++ b/src/inspect_swe/acp/_agents/claude_code/claude_code.py
@@ -12,6 +12,7 @@ from inspect_ai.util import ExecRemoteProcess, ExecRemoteStreamingOptions, store
 from inspect_ai.util import sandbox as sandbox_env
 from typing_extensions import Unpack
 
+from inspect_swe._claude_code.env import DISABLE_AUTO_MEMORY_ENV
 from inspect_swe._util.path import join_path
 from inspect_swe._util.websearch import web_search_tool_disallowed
 from inspect_swe.acp import ACPAgent
@@ -56,6 +57,9 @@ _BRIDGE_SAFE_ENV: dict[str, str] = {
     # No telemetry or update checks from inside the sandbox
     "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
     "DISABLE_AUTOUPDATER": "1",
+    # Auto-memory targets future conversations a sandbox never has, and its
+    # system-prompt section diverts the model from task-provided memory tools
+    **DISABLE_AUTO_MEMORY_ENV,
 }
 
 

--- a/tests/test_claude_code_env.py
+++ b/tests/test_claude_code_env.py
@@ -16,6 +16,7 @@ against a value that reintroduces the bug.
 from inspect_swe._claude_code.env import (
     BLOCKING_MCP_ENV,
     FALSY_ENV_VALUES,
+    TRUTHY_ENV_VALUES,
     claude_code_agent_env,
 )
 from inspect_swe._claude_code.model import resolve_claude_code_models
@@ -84,3 +85,32 @@ def test_caller_can_override_the_mcp_defaults() -> None:
 def test_blocking_mcp_env_is_applied_verbatim() -> None:
     env = _env()
     assert {k: env[k] for k in BLOCKING_MCP_ENV} == dict(BLOCKING_MCP_ENV)
+
+
+def test_auto_memory_is_disabled_by_default() -> None:
+    """See ``DISABLE_AUTO_MEMORY_ENV`` for why a sandboxed agent wants this off."""
+    value = _env()["CLAUDE_CODE_DISABLE_AUTO_MEMORY"]
+    # Claude Code reads this with a truthy check: only these tokens disable.
+    # Asserting membership (not just presence) catches a regression to a value
+    # like "false" that would silently re-enable auto-memory.
+    assert value in TRUTHY_ENV_VALUES, (
+        f"CLAUDE_CODE_DISABLE_AUTO_MEMORY={value!r} does not disable "
+        f"auto-memory; it must be one of {sorted(TRUTHY_ENV_VALUES)}"
+    )
+
+
+def test_caller_can_re_enable_auto_memory() -> None:
+    """Escape hatch for tasks that deliberately study memory persistence.
+
+    Claude Code treats an explicit falsy token as "enabled" (overriding even
+    ``settings.json``), so a caller opts back in with ``"0"``.
+    """
+    env = _env(CLAUDE_CODE_DISABLE_AUTO_MEMORY="0")
+    assert env["CLAUDE_CODE_DISABLE_AUTO_MEMORY"] == "0"
+
+
+def test_acp_claude_code_disables_auto_memory_too() -> None:
+    """The ACP adapter builds its own env; keep it from drifting."""
+    from inspect_swe.acp._agents.claude_code.claude_code import _BRIDGE_SAFE_ENV
+
+    assert _BRIDGE_SAFE_ENV["CLAUDE_CODE_DISABLE_AUTO_MEMORY"] in TRUTHY_ENV_VALUES


### PR DESCRIPTION
Companion to #144, which fixed `tests/test_mcp.py::test_claude_code_mcp` by naming the `memory` MCP server in the example prompt after it failed in both 2026-09-03 nightlies ([08:26](https://github.com/meridianlabs-ai/actions/actions/runs/33733358898), [13:04](https://github.com/meridianlabs-ai/actions/actions/runs/33758955210)). That resolved the test. This PR addresses the agent default that made a plain "memory tools" instruction ambiguous in the first place, so real tasks that provide their own memory tooling are not affected the same way.

**Root cause.** Claude Code's system prompt has an `# auto memory` section that tells the model it has a persistent file-based memory and should write memory files with the file tools. The example task's "use the memory tools to record what you found" now resolves to that instead of the `memory` MCP server. The MCP server was connected in every run (all nine `mcp__memory__*` tools were in the request); the model simply chose the file-based interpretation its system prompt describes.

**Why it surfaced now.** inspect_ai 0.3.262 ([#4893](https://github.com/UKGovernmentBEIS/inspect_ai/pull/4893)) stopped concatenating Anthropic `system` blocks in the bridge. Before that, the concatenated block began with Claude Code's `x-anthropic-billing-header:` line, which the Anthropic API treats as metadata and drops along with the rest of the block. Token accounting on the 0.3.261 log bears this out: the system block counts as 6,322 tokens via `count_tokens`, but the first call billed only 2,089 uncached tokens beyond the cached tool prefix, i.e. roughly the user message alone. So bridged Claude Code has been running without its own system prompt (and without inspect_swe's `--append-system-prompt`) until 0.3.262. The test passed only because the model never saw the competing instruction.

**Fix.** Set `CLAUDE_CODE_DISABLE_AUTO_MEMORY=1` by default in the agent env (`_claude_code/env.py`, and the ACP adapter's `_BRIDGE_SAFE_ENV`, which builds its own env). Auto-memory targets future conversations a sandbox never has, and it costs ~3k system-prompt tokens plus the turns spent writing files. Claude Code's gate treats `1/true/yes/on` as disable and an explicit `0/false/no/off` as enable (overriding `settings.json`; verified in the 2.1.236 binary CI uses), so callers who deliberately study memory persistence opt back in with `env={"CLAUDE_CODE_DISABLE_AUTO_MEMORY": "0"}`. Documented in the `env` docstring. This is not a return to pre-0.3.262 behavior: the model now sees Claude Code's full system prompt minus one section that cannot function in a sandbox.

**Verification** (main, Claude Code stable 2.1.236, Sonnet 4.5, docker):

| inspect_ai | agent env | tool calls | result |
|---|---|---|---|
| 0.3.261 | default | Bash, Bash, create_entities, add_observations, create_relations | pass |
| 0.3.262 | default | Bash, Write, Write | fail |
| 0.3.262 | this PR | Bash, create_entities, open_nodes | pass |

Fast suite: 331 passed, 48 skipped. `ruff`, `ruff format --check`, `mypy src tests` clean.

Worth noting for the team: every bridged Claude Code eval on inspect_ai < 0.3.262 ran without Claude Code's system prompt. Other behavior shifts in upcoming nightlies may trace back to the same change.

### Agent review
- Pass 1: Claude Fable 5.1 code-reviewer subagent (fresh context, same model family as author). Findings: 0. Flagged as unverifiable the claim that an explicit falsy value overrides `settings.json`; verified by the author against the 2.1.236 binary's gate (env check precedes the settings lookup).
- Pass 2: Claude Fable 5.1 adversarial design-review subagent (fresh context), which independently verified the binary gate, the bridge diff, and the three repro logs. Findings: 9 — 6 fixed (section header is `# auto memory`, not `# Memory`; "per request" token cost softened to "cached after the first call"; "has no next session" softened to "normally"; trimmed the env.py comment and test docstring that restated the commit message; simplified the `env` Args entry; ACP Claude Code agent had the same gap and now shares `DISABLE_AUTO_MEMORY_ENV`; dropped the redundant verbatim-dict test) and 3 dismissed (a docs `env` row addition was tried and then dropped as stating what the feature already implies; also importing `BLOCKING_MCP_ENV` into the ACP agent is an unrelated refactor, its values and comments differ; exporting `TRUTHY_ENV_VALUES` only for tests matches the existing `FALSY_ENV_VALUES` precedent). Recommended keeping an env-only opt-in over a new parameter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

