### PR TITLE
ci: docs-only PRs report the versioned required build checks

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,16 +12,22 @@ on:
 
 jobs:
   # Detect whether anything outside docs changed, so the build matrix can be
-  # skipped on documentation-only changes. A skipped job-level `if` still
-  # reports a (non-blocking) check, unlike workflow-level `paths-ignore`
-  # which would strand the required checks.
+  # skipped on documentation-only changes.
+  #
+  # The skip lives on the STEPS of each matrix job, not on the job itself. The
+  # `main` ruleset requires the versioned check names (`py-ruff (3.10)`, ...),
+  # and a job skipped by a job-level `if` never expands its matrix: it reports a
+  # single unversioned check (`py-ruff`), so the required contexts stay
+  # "Expected" forever and a docs-only PR can never merge. With the condition on
+  # the steps, every matrix leg runs, skips all its steps in seconds, and
+  # reports its versioned name with a `success` conclusion.
   changes:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
     outputs:
-      code: ${{ steps.filter.outputs.code }}
+      build: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.code == 'true' }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v4
@@ -36,34 +42,38 @@ jobs:
 
   py-ruff:
     needs: changes
-    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.10", "3.11"]
     steps:
-      - uses: actions/checkout@v4
+      - if: needs.changes.outputs.build == 'true'
+        uses: actions/checkout@v4
       - name: Lint with Ruff
+        if: needs.changes.outputs.build == 'true'
         uses: chartboost/ruff-action@v1
       - name: Format with Ruff
+        if: needs.changes.outputs.build == 'true'
         uses: chartboost/ruff-action@v1
         with:
           args: "format --check"
 
   py-mypy:
     needs: changes
-    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.10", "3.11"]
     steps:
-      - uses: actions/checkout@v4
+      - if: needs.changes.outputs.build == 'true'
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
+        if: needs.changes.outputs.build == 'true'
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Cache pip dependencies
+        if: needs.changes.outputs.build == 'true'
         uses: actions/cache@v3
         with:
           path: ~/.cache/pip
@@ -71,27 +81,31 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
       - name: Install dependencies
+        if: needs.changes.outputs.build == 'true'
         run: |
           python -m pip install --upgrade pip
           python -m pip install .[dev]
       - name: Run mypy
+        if: needs.changes.outputs.build == 'true'
         run: |
           mypy --python-executable $(which python)
 
   py-test:
     needs: changes
-    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.10", "3.11"]
     steps:
-      - uses: actions/checkout@v4
+      - if: needs.changes.outputs.build == 'true'
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
+        if: needs.changes.outputs.build == 'true'
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Cache pip dependencies
+        if: needs.changes.outputs.build == 'true'
         uses: actions/cache@v3
         with:
           path: ~/.cache/pip
@@ -99,32 +113,38 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
       - name: Install dependencies
+        if: needs.changes.outputs.build == 'true'
         run: |
           python -m pip install --upgrade pip
           python -m pip install .[dev]
       - name: Run tests
+        if: needs.changes.outputs.build == 'true'
         run: pytest
 
   py-build:
     needs: changes
-    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.10", "3.11"]
     steps:
-      - uses: actions/checkout@v4
+      - if: needs.changes.outputs.build == 'true'
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
+        if: needs.changes.outputs.build == 'true'
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install build dependencies
+        if: needs.changes.outputs.build == 'true'
         run: |
           python -m pip install --upgrade pip
           python -m pip install build
       - name: Build package
+        if: needs.changes.outputs.build == 'true'
         run: python -m build
       - name: Verify package
+        if: needs.changes.outputs.build == 'true'
         run: |
           python -m pip install dist/*.whl
           python -c "import inspect_swe; print('Package imported successfully')"


### PR DESCRIPTION
## Bug

The `main` ruleset requires the versioned matrix check names: `py-ruff (3.10)`, `py-ruff (3.11)`, and the same pair for `py-mypy`, `py-test`, `py-build`. Since pr 104 the four matrix jobs carry a job-level `if` that skips them on docs-only changes. A matrix job skipped at the job level never expands its matrix, so it reports one unversioned check (`py-ruff`) with a `skipped` conclusion. The eight required contexts are never reported and sit at "Expected, waiting for status to be reported" forever, so a docs-only PR cannot merge without an admin override.

Live example: pr 136 (`AGENTS.md` only). Check runs on its head `448278a9` are `changes`, `lint / lint`, and four skipped unversioned jobs `py-ruff`, `py-mypy`, `py-test`, `py-build`. pr 138 hit the same and was admin-merged.

## Fix

Move the docs-only skip from the job to the steps. Each matrix job now always runs, and every step is gated on `needs.changes.outputs.build == 'true'`. On a docs-only PR each leg starts, skips all of its steps, and finishes in a few seconds with a `success` conclusion under its versioned name. On a code PR every step runs exactly as before.

The `changes` job now exposes one output, `build`, which folds in the `workflow_dispatch` case so the condition is written once instead of on every step.

Why this shape and not an aggregate "all green" job: an aggregate job would need the ruleset's required list changed to a single new context. This change needs no ruleset edit and keeps the fast path from pr 104 (no venv install, no tests on docs-only changes).

## Verification

- YAML parsed and checked with a script: no matrix job has a job-level `if`, every step in the four matrix jobs has the gate, and `changes` has no `if` so its output is always defined. No `if: always()` needed anywhere because no upstream job is ever skipped.
- `actionlint` is not installed on this machine, so it was not run.
- This PR changes a workflow file, so the filter reports code and the full matrix runs here. Run 33885441058 reports all eight versioned contexts as passing, and the reviewer confirmed via the jobs API that every step in `py-ruff (3.10)` executed rather than skipped. That proves the code path.
- The docs-only path cannot be proven on this PR, since the workflow diff itself counts as code. The real proof is pr 136 after an update-branch once this merges: its eight required contexts should flip from "Expected" to passing.

### Agent review
- Author: Claude Fable 5.1 (Claude Code worker).
- Reviewer: the `@auto` review loop on this PR (Claude, fresh context, run 33885455078), 1 pass.
- Findings: 0 to fix. Three informational regression notes, all accepted: docs-only changes now start eight short runners instead of none; docs-only PRs show `success` rather than `skipped` on the required checks, which is the intent; the `changes` job stays a single point of failure if the paths filter errors, which is pre-existing and clears on rerun.
