### PR TITLE
feat: resolve "stable"/"latest" to the agent version that will be installed

### DIFF
--- a/docs/reference/index.qmd
+++ b/docs/reference/index.qmd
@@ -17,6 +17,7 @@ reference: inspect_swe
 
 ### download_agent_binary
 ### cached_agent_binaries
+### resolve_agent_version
 ### download_wheels_tarball
 ### AgentBinary
 ### SandboxPlatform

--- a/src/inspect_swe/__init__.py
+++ b/src/inspect_swe/__init__.py
@@ -6,7 +6,12 @@ from ._gemini_cli.gemini_cli import gemini_cli
 from ._kimi_code.kimi_code import kimi_code
 from ._mini_swe_agent.mini_swe_agent import mini_swe_agent
 from ._opencode.opencode import opencode
-from ._tools.download import AgentBinary, cached_agent_binaries, download_agent_binary
+from ._tools.download import (
+    AgentBinary,
+    cached_agent_binaries,
+    download_agent_binary,
+    resolve_agent_version,
+)
 from ._util.agentwheel import download_wheels_tarball
 from ._util.centaur import CentaurOptions
 from ._util.sandbox import SandboxPlatform
@@ -38,6 +43,7 @@ __all__ = [
     "interactive_gemini_cli",
     "download_agent_binary",
     "cached_agent_binaries",
+    "resolve_agent_version",
     "AgentBinary",
     "SandboxPlatform",
     "CentaurOptions",

--- a/src/inspect_swe/_tools/download.py
+++ b/src/inspect_swe/_tools/download.py
@@ -151,23 +151,17 @@ def resolve_agent_version(
 
     Args:
         agent: Agent whose version to resolve.
-        version: Version to resolve ("stable", "latest", or an explicit version number). "auto" and "sandbox" refer to whatever is installed in the sandbox and cannot be resolved on the host, so they raise `ValueError`.
+        version: Version to resolve. "stable" and "latest" are resolved against the agent's release manifest. Any other value is returned unchanged: an explicit version number is already concrete, and "auto" / "sandbox" refer to whatever is installed in the sandbox and cannot be resolved on the host, so they pass through for the agent function to handle at install time.
         platform: Target platform ("linux-x64", "linux-arm64", "linux-x64-musl", or "linux-arm64-musl"). The version string is the same on every platform, but resolution (and its per-process cache) is per platform and consults that platform's release manifest, which may not exist for every platform.
 
     Returns:
-        The concrete version string.
+        The concrete version string for "stable" / "latest"; otherwise `version` unchanged.
     """
     source = _agent_binary_source(agent)
     if platform not in get_args(SandboxPlatform):
         raise ValueError(
             f"Unsupported platform: {platform} "
             f"(expected one of {', '.join(get_args(SandboxPlatform))})"
-        )
-    if version in ["auto", "sandbox"]:
-        raise ValueError(
-            f"Cannot resolve version '{version}' on the host: it refers to the "
-            f"{source.agent} installed in the sandbox. Pass 'stable', 'latest', "
-            "or an explicit version number."
         )
     if version not in ["stable", "latest"]:
         return version

--- a/src/inspect_swe/_tools/download.py
+++ b/src/inspect_swe/_tools/download.py
@@ -101,8 +101,9 @@ def cached_agent_binaries(
 
     def parse_name(name: str) -> tuple[str, str, int, int, int]:
         # artifact names are either "<agent>-<version>-<platform>" (single
-        # binary) or "<agent>-package-<version>-<platform>.tar.gz" (package)
-        match = re.match(r"([a-z_]+(?:-package)?)-(\d+)\.(\d+)\.(\d+)", name)
+        # binary) or "<agent>-package-<version>-<platform>.tar.gz" (package);
+        # the agent prefix may itself be hyphenated ("kimi-code")
+        match = re.match(r"([a-z_-]+?)-(\d+)\.(\d+)\.(\d+)", name)
         if match:
             return (
                 match.group(1),  # agent type
@@ -151,7 +152,7 @@ def resolve_agent_version(
     Args:
         agent: Agent whose version to resolve.
         version: Version to resolve ("stable", "latest", or an explicit version number).
-        platform: Target platform ("linux-x64", "linux-arm64", "linux-x64-musl", or "linux-arm64-musl"). The version does not vary by platform, but resolution consults the platform's release manifest and may fail for a platform the release does not ship.
+        platform: Target platform ("linux-x64", "linux-arm64", "linux-x64-musl", or "linux-arm64-musl"). The version string is the same on every platform, but resolution (and its per-process cache) is per platform and consults that platform's release manifest, which may not exist for every platform.
 
     Returns:
         The concrete version string.

--- a/src/inspect_swe/_tools/download.py
+++ b/src/inspect_swe/_tools/download.py
@@ -9,8 +9,8 @@ from .._opencode.agentbinary import opencode_binary_source
 from .._util._async import run_coroutine
 from .._util.agentbinary import (
     AgentBinarySource,
-    resolve_agent_binary_version,
     download_agent_binary_async,
+    resolve_agent_binary_version,
 )
 from .._util.sandbox import SandboxPlatform
 

--- a/src/inspect_swe/_tools/download.py
+++ b/src/inspect_swe/_tools/download.py
@@ -151,7 +151,7 @@ def resolve_agent_version(
 
     Args:
         agent: Agent whose version to resolve.
-        version: Version to resolve ("stable", "latest", or an explicit version number).
+        version: Version to resolve ("stable", "latest", or an explicit version number). "auto" and "sandbox" refer to whatever is installed in the sandbox and cannot be resolved on the host, so they raise `ValueError`.
         platform: Target platform ("linux-x64", "linux-arm64", "linux-x64-musl", or "linux-arm64-musl"). The version string is the same on every platform, but resolution (and its per-process cache) is per platform and consults that platform's release manifest, which may not exist for every platform.
 
     Returns:
@@ -162,6 +162,12 @@ def resolve_agent_version(
         raise ValueError(
             f"Unsupported platform: {platform} "
             f"(expected one of {', '.join(get_args(SandboxPlatform))})"
+        )
+    if version in ["auto", "sandbox"]:
+        raise ValueError(
+            f"Cannot resolve version '{version}' on the host: it refers to the "
+            f"{source.agent} installed in the sandbox. Pass 'stable', 'latest', "
+            "or an explicit version number."
         )
     if version not in ["stable", "latest"]:
         return version

--- a/src/inspect_swe/_tools/download.py
+++ b/src/inspect_swe/_tools/download.py
@@ -4,10 +4,12 @@ from typing import Literal, NamedTuple
 
 from .._claude_code.agentbinary import claude_code_binary_source
 from .._codex_cli.agentbinary import codex_cli_binary_source
+from .._kimi_code.agentbinary import kimi_code_binary_source
 from .._opencode.agentbinary import opencode_binary_source
 from .._util._async import run_coroutine
 from .._util.agentbinary import (
     AgentBinarySource,
+    _resolve_agent_binary_version,
     download_agent_binary_async,
 )
 from .._util.sandbox import SandboxPlatform
@@ -16,7 +18,7 @@ from .._util.sandbox import SandboxPlatform
 class AgentBinary(NamedTuple):
     """Agent binary."""
 
-    agent: Literal["claude_code", "codex_cli", "opencode"]
+    agent: Literal["claude_code", "codex_cli", "kimi_code", "opencode"]
     """Agent type."""
 
     version: str
@@ -52,7 +54,7 @@ class AgentBinaries(list[AgentBinary]):
 
 
 def download_agent_binary(
-    binary: Literal["claude_code", "codex_cli", "opencode"],
+    binary: Literal["claude_code", "codex_cli", "kimi_code", "opencode"],
     version: Literal["stable", "latest"] | str,
     platform: SandboxPlatform,
 ) -> None:
@@ -73,7 +75,7 @@ def download_agent_binary(
 
 
 def cached_agent_binaries(
-    binary: Literal["claude_code", "codex_cli", "opencode"] | None = None,
+    binary: Literal["claude_code", "codex_cli", "kimi_code", "opencode"] | None = None,
     quiet: bool = False,
 ) -> AgentBinaries:
     """List the agent binaries which have been cached on this system.
@@ -90,6 +92,7 @@ def cached_agent_binaries(
         return AgentBinaries(
             cached_agent_binaries("claude_code")
             + cached_agent_binaries("codex_cli")
+            + cached_agent_binaries("kimi_code")
             + cached_agent_binaries("opencode")
         )
 
@@ -136,15 +139,45 @@ def cached_agent_binaries(
     )
 
 
+def resolve_agent_version(
+    agent: Literal["claude_code", "codex_cli", "kimi_code", "opencode"],
+    version: Literal["stable", "latest"] | str,
+    platform: SandboxPlatform = "linux-x64",
+) -> str:
+    """Resolve the version of an agent binary that would be installed.
+
+    Resolves "stable" or "latest" to the concrete version `agent` would install in this process (an explicit version number is returned unchanged). Use this to pin a version once at setup time so every sample in a run installs the same binary and the run records which version actually ran.
+
+    Args:
+        agent: Agent whose version to resolve.
+        version: Version to resolve ("stable", "latest", or an explicit version number).
+        platform: Target platform ("linux-x64", "linux-arm64", "linux-x64-musl", or "linux-arm64-musl"). The version does not vary by platform, but resolution consults the platform's release manifest and may fail for a platform the release does not ship.
+
+    Returns:
+        The concrete version string.
+    """
+    source = _agent_binary_source(agent)
+    if version not in ["stable", "latest"]:
+        return version
+
+    resolved = run_coroutine(_resolve_agent_binary_version(source, version, platform))
+    return resolved.version
+
+
 def _agent_binary_source(
-    binary: Literal["claude_code", "codex_cli", "opencode"],
+    binary: Literal["claude_code", "codex_cli", "kimi_code", "opencode"],
 ) -> AgentBinarySource:
     match binary:
         case "claude_code":
             return claude_code_binary_source()
         case "codex_cli":
             return codex_cli_binary_source()
+        case "kimi_code":
+            return kimi_code_binary_source()
         case "opencode":
             return opencode_binary_source()
         case _:
-            raise ValueError(f"Unsuported agent binary type: {binary}")
+            raise ValueError(
+                f"Unsupported agent binary type: {binary} "
+                "(expected one of claude_code, codex_cli, kimi_code, opencode)"
+            )

--- a/src/inspect_swe/_tools/download.py
+++ b/src/inspect_swe/_tools/download.py
@@ -1,6 +1,6 @@
 import re
 from pathlib import Path
-from typing import Literal, NamedTuple
+from typing import Literal, NamedTuple, get_args
 
 from .._claude_code.agentbinary import claude_code_binary_source
 from .._codex_cli.agentbinary import codex_cli_binary_source
@@ -9,7 +9,7 @@ from .._opencode.agentbinary import opencode_binary_source
 from .._util._async import run_coroutine
 from .._util.agentbinary import (
     AgentBinarySource,
-    _resolve_agent_binary_version,
+    resolve_agent_binary_version,
     download_agent_binary_async,
 )
 from .._util.sandbox import SandboxPlatform
@@ -158,10 +158,15 @@ def resolve_agent_version(
         The concrete version string.
     """
     source = _agent_binary_source(agent)
+    if platform not in get_args(SandboxPlatform):
+        raise ValueError(
+            f"Unsupported platform: {platform} "
+            f"(expected one of {', '.join(get_args(SandboxPlatform))})"
+        )
     if version not in ["stable", "latest"]:
         return version
 
-    resolved = run_coroutine(_resolve_agent_binary_version(source, version, platform))
+    resolved = run_coroutine(resolve_agent_binary_version(source, version, platform))
     return resolved.version
 
 

--- a/src/inspect_swe/_util/agentbinary.py
+++ b/src/inspect_swe/_util/agentbinary.py
@@ -68,7 +68,7 @@ _resolved_versions: dict[tuple[str, str, SandboxPlatform], AgentBinaryVersion] =
 _failed_resolutions: dict[tuple[str, str, SandboxPlatform], tuple[int, Exception]] = {}
 
 
-async def _resolve_agent_binary_version(
+async def resolve_agent_binary_version(
     source: AgentBinarySource,
     version: Literal["stable", "latest"] | str,
     platform: SandboxPlatform,
@@ -261,7 +261,7 @@ async def download_agent_binary_async(
     # repeat upstream API calls that may be rate-limited, sharing a failure
     # too so a queue of samples behind a rate-limited call doesn't each
     # retry it in turn)
-    resolved = await _resolve_agent_binary_version(source, version, platform)
+    resolved = await resolve_agent_binary_version(source, version, platform)
     version = resolved.version
     expected_checksum = resolved.expected_checksum
     download_url = resolved.download_url

--- a/tests/test_agentbinary_install.py
+++ b/tests/test_agentbinary_install.py
@@ -367,7 +367,7 @@ def test_concurrent_version_resolution_shares_one_request(tmp_path: Path) -> Non
     async def run() -> None:
         async def one() -> None:
             results.append(
-                await agentbinary._resolve_agent_binary_version(
+                await agentbinary.resolve_agent_binary_version(
                     source, "9.5.1", "linux-x64"
                 )
             )
@@ -410,7 +410,7 @@ def test_concurrent_version_resolution_failure_is_shared(tmp_path: Path) -> None
     async def run() -> None:
         async def one() -> None:
             try:
-                await agentbinary._resolve_agent_binary_version(
+                await agentbinary.resolve_agent_binary_version(
                     source, "9.5.2", "linux-x64"
                 )
             except RuntimeError as ex:
@@ -443,6 +443,6 @@ def test_concurrent_version_resolution_failure_is_shared(tmp_path: Path) -> None
         post_install=None,
     )
     resolved = anyio.run(
-        agentbinary._resolve_agent_binary_version, retry_source, "9.5.2", "linux-x64"
+        agentbinary.resolve_agent_binary_version, retry_source, "9.5.2", "linux-x64"
     )
     assert resolved.version == "9.5.2"

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -77,6 +77,16 @@ def test_cached_agent_binaries_lists_opencode(tmp_path: Path) -> None:
     assert [(b.agent, b.version) for b in cached] == [("opencode", "1.14.30")]
 
 
+def test_cached_agent_binaries_lists_kimi_code(tmp_path: Path) -> None:
+    from inspect_swe._kimi_code import agentbinary as kimi_agentbinary
+
+    with patch.object(kimi_agentbinary, "package_cache_dir", return_value=tmp_path):
+        (tmp_path / "kimi-code-1.2.3-linux-x64").write_bytes(b"x")
+        cached = cached_agent_binaries("kimi_code")
+
+    assert [(b.agent, b.version) for b in cached] == [("kimi_code", "1.2.3")]
+
+
 def test_resolve_agent_version_passes_through_pinned_version() -> None:
     # an explicit version needs no network: it is returned unchanged
     assert resolve_agent_version("codex_cli", "0.50.0") == "0.50.0"

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -10,6 +10,7 @@ from inspect_swe import (
     cached_agent_binaries,
     download_agent_binary,
     download_wheels_tarball,
+    resolve_agent_version,
 )
 from inspect_swe._util.download import download_file
 
@@ -74,6 +75,17 @@ def test_cached_agent_binaries_lists_opencode(tmp_path: Path) -> None:
         cached = cached_agent_binaries("opencode")
 
     assert [(b.agent, b.version) for b in cached] == [("opencode", "1.14.30")]
+
+
+def test_resolve_agent_version_passes_through_pinned_version() -> None:
+    # an explicit version needs no network: it is returned unchanged
+    assert resolve_agent_version("codex_cli", "0.50.0") == "0.50.0"
+
+
+@pytest.mark.parametrize("version", ["stable", "1.2.3"])
+def test_resolve_agent_version_rejects_unknown_agent(version: str) -> None:
+    with pytest.raises(ValueError, match="claude_code, codex_cli, kimi_code"):
+        resolve_agent_version("gemini_cli", version)  # type: ignore[arg-type]
 
 
 @pytest.mark.slow

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -362,8 +362,7 @@ def test_ensure_pip_available_raises_on_failure() -> None:
 
 
 @pytest.mark.parametrize("version", ["auto", "sandbox"])
-def test_resolve_agent_version_rejects_sandbox_aliases(version: str) -> None:
-    with pytest.raises(
-        ValueError, match="cannot be resolved on the host|Cannot resolve"
-    ):
-        resolve_agent_version("claude_code", version)
+def test_resolve_agent_version_passes_sandbox_aliases_through(version: str) -> None:
+    # "auto" / "sandbox" cannot be resolved on the host; they are returned unchanged
+    # so a task that pins with resolve_agent_version() behaves as if it had not.
+    assert resolve_agent_version("claude_code", version) == version

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -359,3 +359,11 @@ def test_ensure_pip_available_raises_on_failure() -> None:
             _ensure_pip_available()
 
         assert "ensurepip disabled" in str(exc_info.value)
+
+
+@pytest.mark.parametrize("version", ["auto", "sandbox"])
+def test_resolve_agent_version_rejects_sandbox_aliases(version: str) -> None:
+    with pytest.raises(
+        ValueError, match="cannot be resolved on the host|Cannot resolve"
+    ):
+        resolve_agent_version("claude_code", version)

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -92,6 +92,11 @@ def test_resolve_agent_version_passes_through_pinned_version() -> None:
     assert resolve_agent_version("codex_cli", "0.50.0") == "0.50.0"
 
 
+def test_resolve_agent_version_rejects_unknown_platform() -> None:
+    with pytest.raises(ValueError, match="Unsupported platform"):
+        resolve_agent_version("codex_cli", "0.50.0", "win-x64")  # type: ignore[arg-type]
+
+
 @pytest.mark.parametrize("version", ["stable", "1.2.3"])
 def test_resolve_agent_version_rejects_unknown_agent(version: str) -> None:
     with pytest.raises(ValueError, match="claude_code, codex_cli, kimi_code"):


### PR DESCRIPTION
## Motivation

When I select version "stable" or "latest" I'd like to have a way to know which versions that resolves without actually having to start an agent in a sandbox. Currently this happens at install time in the sandbox.
This would be helpful on evals I want to run with multiple samples with a fixed agent. I can at setup know which version is resolved, stamp it on my run, and then at setup time for each sample use the already derived version.


# LLM implementation details and reviews.

## Summary

Adds `resolve_agent_version(agent, version, platform="linux-x64") -> str` to the public download tools and exports it from `inspect_swe`.

- `"stable"` / `"latest"` resolve to the concrete version `agent` would install in this process; an explicit version is returned unchanged. `agent` and `platform` are validated up front against their `Literal`s, so an unknown value raises before any network access.
- Reuses the shared resolver (now `resolve_agent_binary_version`, previously underscore-private with a single consumer), so it shares the per-process resolution cache the agents themselves use (one upstream lookup per process and platform, and the same answer the agent would get).
- Sync via `run_coroutine`, matching `download_agent_binary` and `cached_agent_binaries`.
- `kimi_code` is added to the download tools' agent `Literal`s and to `cached_agent_binaries()`'s aggregate branch; it already had an `AgentBinarySource` but was missing from the dispatcher. The cache filename parser is widened to accept its hyphenated `kimi-code-` prefix, without which `cached_agent_binaries("kimi_code")` returned nothing. `gemini_cli`, `mini_swe_agent` and `antigravity` install via npm/wheels/pip and have no binary source, so they are intentionally absent.

## Checks

- `ruff format` / `ruff check`: clean
- `mypy` (strict): no issues in 124 source files
- `pytest tests/test_download.py tests/test_agentbinary_install.py`: 26 passed, 8 skipped (slow gate). New tests cover the pinned-version pass-through, rejection of an unknown agent on both the `"stable"` and pinned paths, rejection of an unknown platform, and kimi cache listing; no network-dependent test added.
- Manual: `resolve_agent_version("claude_code", "stable")` → `2.1.236`, `("kimi_code", "stable")` → `0.41.0`, `("codex_cli", "stable")` → `0.153.2` at time of writing.

### Agent review
- Reviewer: Claude Fable 5.1 subagents, each in a fresh context that had not seen the authoring conversation. 4 passes, one per revision, until a pass returned no findings.
- Pass 1 (initial diff): 6 findings — 6 fixed, 0 dismissed.
  - bug: an unknown agent with a pinned version passed straight through (validation ran after the short-circuit) → dispatch first, test added for both paths.
  - convention: `kimi_code` in the dispatcher but not in the sibling public `Literal`s / aggregate listing → widened.
  - convention: only public async function in a module of sync siblings → made sync via `run_coroutine`.
  - docstring: "would install right now" overstated given the per-process cache → "in this process".
  - docstring: `platform` default can succeed where the real platform's release is missing → noted.
  - nit: unknown-agent test only exercised the `"stable"` path → parametrized.
- Pass 2 (after pass 1 fixes): 2 findings — 2 fixed, 0 dismissed.
  - bug: the `kimi_code` widening of `cached_agent_binaries` was a no-op because the filename parser rejected the hyphenated `kimi-code-` prefix (reviewer reproduced it) → parser accepts hyphenated agent prefixes, kimi cache test added.
  - nit: docstring said the version "does not vary by platform" while the cache is keyed per platform → reworded.
- Pass 3 (after pass 2 fixes): 4 findings, no bugs — 2 fixed, 2 dismissed.
  - convention: `platform` had no runtime validation, against the Literal-with-runtime-validation rule → validated via `get_args(SandboxPlatform)`, test added.
  - nit: cross-module import of underscore-private `_resolve_agent_binary_version`, now with two consumers → underscore dropped; call sites and tests updated.
  - nit, dismissed: validating `agent` on the pass-through path builds the source and so creates the cache directory. Same as the sibling `download_agent_binary`; avoiding it would duplicate the agent list.
  - nit, dismissed: the agent `Literal` is spelled out in several signatures plus the error message. Pre-existing pattern in this module; consolidating it is a separate refactor.
- Pass 4 (after pass 3 fixes): no findings. Verified every path of the new function, the parser against every cache filename the four sources produce, rename completeness, `__all__` and docs reference, the `# type: ignore` comments under strict mypy, docstring accuracy, and commit titles. One out-of-scope observation: the docs reference Agents section does not list `kimi_code`, pre-existing.