### PR TITLE
fix(codex_cli): "latest" catalog slug ignores hidden models, matching Codex's picker

### DIFF
--- a/src/inspect_swe/_codex_cli/_bundled_catalog.py
+++ b/src/inspect_swe/_codex_cli/_bundled_catalog.py
@@ -5,12 +5,16 @@ fetched (offline, rate-limited ``raw.githubusercontent.com``, or a pre-
 ``models-manager`` Codex). We only consult the catalog to *decide* the ``--model``
 slug — Codex supplies the actual prompt/tools from its own bundled catalog — so a
 trimmed snapshot of the fields the resolver reads
-(``slug``/``priority``/``apply_patch_tool_type``/``supports_search_tool``) is
-sufficient.
+(``slug``/``priority``/``visibility``/``apply_patch_tool_type``/
+``supports_search_tool``) is sufficient. Hidden entries are kept: they are still
+valid ``--model`` slugs for prefix matching, they just never count as "latest"
+(see ``latest_openai_slug``).
 
 Snapshot source: ``openai/codex`` ``codex-rs/models-manager/models.json``
-(``rust-v0.145.0``, July 2026). Refresh when bumping the default Codex version;
-the live fetch keeps this exact when ``raw.githubusercontent.com`` is reachable.
+(``rust-v0.153.2``, September 2026). Refresh when bumping the default Codex
+version; the live fetch keeps this exact when ``raw.githubusercontent.com`` is
+reachable, and ``tests/test_codex_agentbinary.py::test_bundled_catalog_tracks_live_latest``
+flags drift.
 """
 
 from typing import Any
@@ -18,50 +22,79 @@ from typing import Any
 BUNDLED_CODEX_CATALOG: dict[str, Any] = {
     "models": [
         {
-            "slug": "gpt-5.6-sol",
+            "slug": "gpt-6-astra",
             "priority": 1,
+            "visibility": "hide",
+            "apply_patch_tool_type": "freeform",
+            "supports_search_tool": True,
+        },
+        {
+            "slug": "gpt-5.6-sol",
+            "priority": 6,
+            "visibility": "list",
             "apply_patch_tool_type": "freeform",
             "supports_search_tool": True,
         },
         {
             "slug": "gpt-5.6-terra",
-            "priority": 2,
+            "priority": 7,
+            "visibility": "list",
             "apply_patch_tool_type": "freeform",
             "supports_search_tool": True,
         },
         {
             "slug": "gpt-5.6-luna",
-            "priority": 3,
+            "priority": 8,
+            "visibility": "list",
+            "apply_patch_tool_type": "freeform",
+            "supports_search_tool": True,
+        },
+        {
+            "slug": "gpt-daybreak-blue-latest",
+            "priority": 10,
+            "visibility": "hide",
+            "apply_patch_tool_type": "freeform",
+            "supports_search_tool": True,
+        },
+        {
+            "slug": "gpt-daybreak-red-latest",
+            "priority": 11,
+            "visibility": "hide",
             "apply_patch_tool_type": "freeform",
             "supports_search_tool": True,
         },
         {
             "slug": "gpt-5.5",
-            "priority": 7,
+            "priority": 12,
+            "visibility": "list",
             "apply_patch_tool_type": "freeform",
             "supports_search_tool": True,
         },
         {
             "slug": "gpt-5.4",
             "priority": 16,
+            "visibility": "hide",
             "apply_patch_tool_type": "freeform",
             "supports_search_tool": True,
         },
         {
             "slug": "gpt-5.4-mini",
             "priority": 23,
+            "visibility": "hide",
             "apply_patch_tool_type": "freeform",
             "supports_search_tool": True,
         },
         {
             "slug": "gpt-5.2",
             "priority": 29,
+            "visibility": "list",
             "apply_patch_tool_type": "freeform",
             "supports_search_tool": True,
         },
         {
             "slug": "codex-auto-review",
             "priority": 43,
+            "visibility": "hide",
             "apply_patch_tool_type": "freeform",
             "supports_search_tool": True,
         },

--- a/src/inspect_swe/_codex_cli/model_catalog.py
+++ b/src/inspect_swe/_codex_cli/model_catalog.py
@@ -116,14 +116,23 @@ def _catalog_models(catalog: dict[str, Any] | None) -> list[dict[str, Any]]:
 def latest_openai_slug(catalog: dict[str, Any] | None) -> str | None:
     """Return the "latest" general coding slug in the catalog.
 
-    "Latest" is the entry with the highest priority (lowest ``priority`` value),
-    excluding ``-mini`` variants when any non-mini entry exists. Returns ``None``
-    if the catalog has no usable entries.
+    "Latest" is the entry with the highest priority (lowest ``priority`` value)
+    among the entries Codex itself would offer: those whose ``visibility`` is not
+    ``"hide"`` (Codex's picker filters hidden entries out and only marks a
+    visible one as its default -- ``ModelPreset::mark_default_by_picker_visibility``
+    in ``codex-rs/models-manager``). Hidden entries are staged rollouts, retired
+    models with an ``upgrade`` pointer, codenames, and the auto-review guardian;
+    a slug the user could not pick in Codex is not "latest" for aliasing
+    purposes either. ``-mini`` variants are likewise excluded when any non-mini
+    entry exists. Each filter falls back to the unfiltered list when it would
+    leave nothing (a catalog with only hidden or only mini entries). Returns
+    ``None`` if the catalog has no usable entries.
     """
     models = _catalog_models(catalog)
     if not models:
         return None
-    preferred = [m for m in models if not m["slug"].endswith("-mini")] or models
+    visible = [m for m in models if m.get("visibility") != "hide"] or models
+    preferred = [m for m in visible if not m["slug"].endswith("-mini")] or visible
     preferred.sort(key=lambda m: m.get("priority", 1_000_000))
     return str(preferred[0]["slug"])
 

--- a/tests/test_codex_model_catalog.py
+++ b/tests/test_codex_model_catalog.py
@@ -286,3 +286,36 @@ def test_openai_service_model_name_falls_back_when_not_openai() -> None:
 def test_openai_service_model_name_falls_back_when_method_absent() -> None:
     # OpenAI-derived but without service_model_name() (defensive) -> fallback
     assert openai_service_model_name(OpenAIAPI(), "gpt-5") == "gpt-5"
+
+
+def test_latest_openai_slug_skips_hidden_entries() -> None:
+    """A hidden higher-priority entry (staged rollout, codename) is not "latest".
+
+    Mirrors Codex's picker, which filters ``visibility: "hide"`` entries out
+    before marking a default; e.g. rust-v0.153.2 lists ``gpt-6-astra`` at
+    priority 1 but hidden, with ``gpt-5.6-sol`` the first visible entry.
+    """
+    catalog = {
+        "models": [
+            {"slug": "gpt-6-astra", "priority": 1, "visibility": "hide"},
+            {"slug": "gpt-5.6-sol", "priority": 6, "visibility": "list"},
+            {"slug": "gpt-daybreak-blue-latest", "priority": 10, "visibility": "hide"},
+        ]
+    }
+    assert latest_openai_slug(catalog) == "gpt-5.6-sol"
+
+
+def test_latest_openai_slug_falls_back_to_hidden_when_nothing_is_visible() -> None:
+    catalog = {"models": [{"slug": "gpt-6-astra", "priority": 1, "visibility": "hide"}]}
+    assert latest_openai_slug(catalog) == "gpt-6-astra"
+
+
+def test_latest_openai_slug_treats_missing_visibility_as_visible() -> None:
+    """Older snapshots/catalogs without the field keep their previous behaviour."""
+    catalog = {
+        "models": [
+            {"slug": "gpt-5.6-sol", "priority": 1},
+            {"slug": "gpt-5.5", "priority": 12, "visibility": "list"},
+        ]
+    }
+    assert latest_openai_slug(catalog) == "gpt-5.6-sol"


### PR DESCRIPTION
`latest_openai_slug` chose the highest-priority Codex catalog entry regardless of `visibility`. Codex rust-v0.153.2 (2026-09-03) added `gpt-6-astra` at priority 1 with `visibility: "hide"`, a staged rollout. With the live catalog fetch succeeding, an OpenAI model absent from the catalog (a codename or a newer snapshot) was aliased to `gpt-6-astra` for Codex's prompt and tool selection, a slug Codex's own picker never offers as a default.

**How it surfaced.** `tests/test_codex_agentbinary.py::test_bundled_catalog_tracks_live_latest` fails locally: live latest `gpt-6-astra` vs bundled `gpt-5.6-sol`. The test is `@skip_if_github_action`, so neither PR CI nor the nightly runs it; it only fires on a developer machine. In this case the snapshot's answer was the right one and the live rule was wrong.

**Fix.** Mirror Codex: `codex-rs/models-manager` sorts presets by priority, filters hidden entries out of the picker, and marks the default only among visible ones (`ModelPreset::mark_default_by_picker_visibility`, `default_model_from_available`). `latest_openai_slug` now skips `visibility: "hide"` entries, falling back to hidden ones only if nothing is visible; catalogs without the field behave as before. Hidden entries stay in the catalog for prefix matching, since they remain valid `--model` slugs (e.g. a real `openai/gpt-6-astra` still resolves to its own entry).

**Snapshot.** `_bundled_catalog.py` regenerated from rust-v0.153.2 with the `visibility` field added to the trimmed fields, so the drift test compares like with like: `gpt-6-astra`, the `gpt-daybreak-*` codenames, and the `gpt-5.4` retirement are now present; the snapshot's latest is `gpt-5.6-sol`, which is also Codex's visible latest.

**Tests.** Three new unit tests (hidden higher-priority entry skipped; all-hidden fallback; missing field treated as visible). The first fails on the previous rule. Codex test files plus the live drift test: 103 passed, 1 skipped (docker). ruff and strict mypy clean.

Observation, not changed here: gating the drift test entirely out of CI means drift is only noticed when someone runs the fast suite locally. Running it in the nightly as a warning-level check would surface it without blocking PRs.

### Agent review
- Reviewer: Claude Fable 5.1 code-reviewer subagent (fresh context, same model family as author), 1 pass, static read of the diff cross-checked against the raw rust-v0.153.2 `models.json` and all catalog consumers in `src/inspect_swe/_codex_cli/`.
- Findings: 0. Confirmed the visible-then-mini fallback ordering is behaviour-preserving for catalogs without the field, that `_matched_entry` prefix matching still sees hidden entries (intended), and that all 11 snapshot entries match the live file for the trimmed fields. The reviewer had no shell; pytest/ruff/mypy were run by the author (103 passed incl. the live drift test; clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

