### PR TITLE
fix(opencode): prompts containing double quotes no longer surface the session title as the answer

### DIFF
--- a/src/inspect_swe/_opencode/opencode.py
+++ b/src/inspect_swe/_opencode/opencode.py
@@ -1,6 +1,5 @@
 import json
 import shlex
-import uuid
 from pathlib import Path
 from textwrap import dedent
 from typing import Any, Literal, Sequence
@@ -266,13 +265,6 @@ def opencode(
                     state=state,
                 )
             else:
-                # per-invocation prompt file (see opencode_stdin_prompt_cmd); unique
-                # so concurrent opencode agents sharing a sandbox can't clobber each
-                # other, in a user-owned dir so the wrapper can unlink it
-                prompt_dir = f"{sandbox_home}/.inspect_swe/opencode"
-                prompt_path = f"{prompt_dir}/prompt-{uuid.uuid4().hex}.txt"
-                await sbox.exec(["mkdir", "-p", prompt_dir], user=user)
-
                 debug_output: list[str] = []
                 agent_prompt = prompt
                 attempt_count = 0
@@ -284,10 +276,6 @@ def opencode(
                     # the inbound state already carries an assistant turn)
                     if has_assistant_response or attempt_count > 0:
                         agent_cmd.append("--continue")
-
-                    # deliver the prompt on stdin rather than as a positional
-                    # argument (see opencode_stdin_prompt_cmd)
-                    await sbox.write_file(prompt_path, agent_prompt)
 
                     # Retry-loop gate: fires ONLY when this loop is actually
                     # retrying (attempt_count > 0), so the cold-start
@@ -302,9 +290,24 @@ def opencode(
                             required=True,
                         )
 
+                    # Deliver the prompt on stdin rather than as a positional
+                    # argument. `opencode run` quote-wraps a positional message
+                    # that contains spaces and backslash-escapes the double
+                    # quotes inside it (packages/opencode/src/cli/cmd/run.ts),
+                    # so a prompt passed as an argument reaches the model -- and
+                    # crosses the agent bridge -- as `"..."` with `\"` inside
+                    # rather than as the task input. The bridge anchors
+                    # main-thread tracking on the task input, and for prompts
+                    # containing `"` that mismatch let opencode's session-title
+                    # generation call displace the agent's answer as the sample
+                    # output. Piped stdin is used verbatim (`resolveRunInput`),
+                    # and also sidesteps argv length limits for long prompts.
+                    # exec_remote closes stdin after writing `input`, giving
+                    # opencode the EOF it needs.
                     result = await sbox.exec_remote(
-                        cmd=opencode_stdin_prompt_cmd(agent_cmd, prompt_path),
+                        cmd=agent_cmd,
                         options=ExecRemoteAwaitableOptions(
+                            input=agent_prompt,
                             cwd=agent_cwd,
                             env=agent_env,
                             user=user,
@@ -351,30 +354,6 @@ def opencode(
         return bridge.state
 
     return agent_with(execute, name=name, description=description)
-
-
-def opencode_stdin_prompt_cmd(opencode_cmd: list[str], prompt_path: str) -> list[str]:
-    r"""Command that runs `opencode_cmd` with the prompt at `prompt_path` on stdin.
-
-    `opencode run` quote-wraps a positional message that contains spaces and
-    backslash-escapes the double quotes inside it (`packages/opencode/src/cli/
-    cmd/run.ts`), so a prompt passed as an argument reaches the model — and
-    crosses the agent bridge — as `"..."` with `\"` inside rather than as the
-    task input. The bridge anchors main-thread tracking on the task input, and
-    for prompts containing `"` that mismatch let opencode's session-title
-    generation call displace the agent's answer as the sample output. Piped
-    stdin is used verbatim (`resolveRunInput`), and also sidesteps argv length
-    limits for long prompts. The file is unlinked once the redirect holds it
-    open, so nothing is left behind in the sandbox.
-    """
-    return [
-        "bash",
-        "-c",
-        'exec 0<"$1"; rm -f -- "$1"; shift; exec "$@"',
-        "bash",
-        prompt_path,
-        *opencode_cmd,
-    ]
 
 
 def resolve_mcp_servers(

--- a/src/inspect_swe/_opencode/opencode.py
+++ b/src/inspect_swe/_opencode/opencode.py
@@ -1,5 +1,6 @@
 import json
 import shlex
+import uuid
 from pathlib import Path
 from textwrap import dedent
 from typing import Any, Literal, Sequence
@@ -183,15 +184,19 @@ def opencode(
 
             opencode_config_dir = f"{sandbox_home}/.config/opencode"
             opencode_config_path = f"{opencode_config_dir}/opencode.json"
-            await sbox.exec(["mkdir", "-p", opencode_config_dir], user=user)
+            # per-invocation prompt file (see opencode_stdin_prompt_cmd); unique so
+            # concurrent opencode agents sharing a sandbox can't clobber each other
+            prompt_dir = f"{sandbox_home}/.inspect_swe/opencode"
+            prompt_path = f"{prompt_dir}/prompt-{uuid.uuid4().hex}.txt"
+            await sbox.exec(["mkdir", "-p", opencode_config_dir, prompt_dir], user=user)
             if resolved_skills is not None:
                 await install_skills(
                     resolved_skills, sbox, user, f"{opencode_config_dir}/skills"
                 )
             await sbox.write_file(opencode_config_path, json.dumps(opencode_config))
 
-            # build system prompt (opencode run takes a single positional message
-            # and has no separate --system-prompt flag, so we prepend)
+            # build system prompt (opencode run takes a single message and has no
+            # separate --system-prompt flag, so we prepend)
             system_messages = [
                 m.text for m in state.messages if isinstance(m, ChatMessageSystem)
             ]
@@ -277,8 +282,9 @@ def opencode(
                     if has_assistant_response or attempt_count > 0:
                         agent_cmd.append("--continue")
 
-                    # add prompt as positional argument at the end
-                    agent_cmd.append(agent_prompt)
+                    # deliver the prompt on stdin rather than as a positional
+                    # argument (see opencode_stdin_prompt_cmd)
+                    await sbox.write_file(prompt_path, agent_prompt)
 
                     # Retry-loop gate: fires ONLY when this loop is actually
                     # retrying (attempt_count > 0), so the cold-start
@@ -294,8 +300,7 @@ def opencode(
                         )
 
                     result = await sbox.exec_remote(
-                        cmd=["bash", "-c", 'exec 0</dev/null; "$@"', "bash"]
-                        + agent_cmd,
+                        cmd=opencode_stdin_prompt_cmd(agent_cmd, prompt_path),
                         options=ExecRemoteAwaitableOptions(
                             cwd=agent_cwd,
                             env=agent_env,
@@ -343,6 +348,29 @@ def opencode(
         return bridge.state
 
     return agent_with(execute, name=name, description=description)
+
+
+def opencode_stdin_prompt_cmd(opencode_cmd: list[str], prompt_path: str) -> list[str]:
+    r"""Command that runs `opencode_cmd` with the prompt at `prompt_path` on stdin.
+
+    `opencode run` quote-wraps a positional message that contains spaces and
+    backslash-escapes the double quotes inside it (`packages/opencode/src/cli/
+    cmd/run.ts`), so a prompt passed as an argument reaches the model — and
+    crosses the agent bridge — as `"..."` with `\"` inside rather than as the
+    task input. The bridge anchors main-thread tracking on the task input, and
+    for prompts containing `"` that mismatch let opencode's session-title
+    generation call displace the agent's answer as the sample output. Piped
+    stdin is used verbatim (`resolveRunInput`), and also sidesteps argv length
+    limits for long prompts.
+    """
+    return [
+        "bash",
+        "-c",
+        'exec 0<"$1"; shift; exec "$@"',
+        "bash",
+        prompt_path,
+        *opencode_cmd,
+    ]
 
 
 def resolve_mcp_servers(

--- a/src/inspect_swe/_opencode/opencode.py
+++ b/src/inspect_swe/_opencode/opencode.py
@@ -184,11 +184,7 @@ def opencode(
 
             opencode_config_dir = f"{sandbox_home}/.config/opencode"
             opencode_config_path = f"{opencode_config_dir}/opencode.json"
-            # per-invocation prompt file (see opencode_stdin_prompt_cmd); unique so
-            # concurrent opencode agents sharing a sandbox can't clobber each other
-            prompt_dir = f"{sandbox_home}/.inspect_swe/opencode"
-            prompt_path = f"{prompt_dir}/prompt-{uuid.uuid4().hex}.txt"
-            await sbox.exec(["mkdir", "-p", opencode_config_dir, prompt_dir], user=user)
+            await sbox.exec(["mkdir", "-p", opencode_config_dir], user=user)
             if resolved_skills is not None:
                 await install_skills(
                     resolved_skills, sbox, user, f"{opencode_config_dir}/skills"
@@ -270,6 +266,13 @@ def opencode(
                     state=state,
                 )
             else:
+                # per-invocation prompt file (see opencode_stdin_prompt_cmd); unique
+                # so concurrent opencode agents sharing a sandbox can't clobber each
+                # other, in a user-owned dir so the wrapper can unlink it
+                prompt_dir = f"{sandbox_home}/.inspect_swe/opencode"
+                prompt_path = f"{prompt_dir}/prompt-{uuid.uuid4().hex}.txt"
+                await sbox.exec(["mkdir", "-p", prompt_dir], user=user)
+
                 debug_output: list[str] = []
                 agent_prompt = prompt
                 attempt_count = 0
@@ -361,12 +364,13 @@ def opencode_stdin_prompt_cmd(opencode_cmd: list[str], prompt_path: str) -> list
     for prompts containing `"` that mismatch let opencode's session-title
     generation call displace the agent's answer as the sample output. Piped
     stdin is used verbatim (`resolveRunInput`), and also sidesteps argv length
-    limits for long prompts.
+    limits for long prompts. The file is unlinked once the redirect holds it
+    open, so nothing is left behind in the sandbox.
     """
     return [
         "bash",
         "-c",
-        'exec 0<"$1"; shift; exec "$@"',
+        'exec 0<"$1"; rm -f -- "$1"; shift; exec "$@"',
         "bash",
         prompt_path,
         *opencode_cmd,

--- a/tests/test_opencode_prompt.py
+++ b/tests/test_opencode_prompt.py
@@ -41,6 +41,8 @@ def test_prompt_reaches_the_agent_verbatim_on_stdin(tmp_path: Path) -> None:
     result = subprocess.run(cmd, capture_output=True, text=True, check=True)
 
     assert result.stdout == PROMPT
+    # the file is unlinked once it is held open on stdin
+    assert not prompt_file.exists()
 
 
 def test_stdin_redirection_tolerates_spaces_in_the_prompt_path(

--- a/tests/test_opencode_prompt.py
+++ b/tests/test_opencode_prompt.py
@@ -1,0 +1,56 @@
+"""opencode receives its prompt on stdin, not as a positional argument.
+
+``opencode run`` quote-wraps a positional message that contains spaces and
+backslash-escapes the double quotes inside it (``packages/opencode/src/cli/cmd/
+run.ts``), so the prompt the model saw -- and the user message crossing the
+agent bridge -- differed from the task input. The bridge anchors main-thread
+tracking on the task input, and for prompts containing ``"`` the mismatch let
+opencode's session-title generation call be surfaced as the sample's final
+answer (GAIA level 1, opencode 1.18.29 + gpt-5.5: 4 of 10 samples). Piped stdin
+is used verbatim, so the prompt is delivered that way instead.
+"""
+
+import subprocess
+from pathlib import Path
+
+from inspect_swe._opencode.opencode import opencode_stdin_prompt_cmd
+
+# embedded double quotes, blank lines, and no trailing newline
+PROMPT = 'Write the opposite of the word "left".\n\nAnswer with one word'
+OPENCODE_CMD = ["opencode", "run", "--model", "openai/gpt-5.5", "--format", "json"]
+
+
+def test_prompt_is_not_a_positional_argument(tmp_path: Path) -> None:
+    prompt_file = tmp_path / "prompt.txt"
+    prompt_file.write_text(PROMPT)
+
+    cmd = opencode_stdin_prompt_cmd(OPENCODE_CMD, str(prompt_file))
+
+    assert PROMPT not in cmd
+    assert str(prompt_file) in cmd
+    # opencode's own argv is preserved intact at the end (no message appended)
+    assert cmd[-len(OPENCODE_CMD) :] == OPENCODE_CMD
+
+
+def test_prompt_reaches_the_agent_verbatim_on_stdin(tmp_path: Path) -> None:
+    prompt_file = tmp_path / "prompt.txt"
+    prompt_file.write_text(PROMPT)
+
+    # stand in for opencode with a command that echoes its stdin
+    cmd = opencode_stdin_prompt_cmd(["cat"], str(prompt_file))
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+
+    assert result.stdout == PROMPT
+
+
+def test_stdin_redirection_tolerates_spaces_in_the_prompt_path(
+    tmp_path: Path,
+) -> None:
+    prompt_file = tmp_path / "dir with spaces" / "prompt file.txt"
+    prompt_file.parent.mkdir()
+    prompt_file.write_text(PROMPT)
+
+    cmd = opencode_stdin_prompt_cmd(["cat"], str(prompt_file))
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+
+    assert result.stdout == PROMPT

--- a/tests/test_opencode_prompt.py
+++ b/tests/test_opencode_prompt.py
@@ -7,52 +7,145 @@ agent bridge -- differed from the task input. The bridge anchors main-thread
 tracking on the task input, and for prompts containing ``"`` the mismatch let
 opencode's session-title generation call be surfaced as the sample's final
 answer (GAIA level 1, opencode 1.18.29 + gpt-5.5: 4 of 10 samples). Piped stdin
-is used verbatim, so the prompt is delivered that way instead.
+is used verbatim, so the prompt is delivered via ``exec_remote(input=...)``.
+
+The agent's sandbox plumbing is faked at the module level so the test drives
+``execute()`` itself and inspects the exact ``exec_remote`` call it makes.
 """
 
-import subprocess
-from pathlib import Path
+import importlib
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator
 
-from inspect_swe._opencode.opencode import opencode_stdin_prompt_cmd
+import anyio
+import pytest
+from inspect_ai.agent import AgentState
+from inspect_ai.model import ChatMessageAssistant, ChatMessageSystem, ChatMessageUser
+from inspect_ai.util._sandbox import ExecRemoteAwaitableOptions
+
+# the package re-exports the agent function under the module's name
+opencode_module = importlib.import_module("inspect_swe._opencode.opencode")
 
 # embedded double quotes, blank lines, and no trailing newline
 PROMPT = 'Write the opposite of the word "left".\n\nAnswer with one word'
-OPENCODE_CMD = ["opencode", "run", "--model", "openai/gpt-5.5", "--format", "json"]
 
 
-def test_prompt_is_not_a_positional_argument(tmp_path: Path) -> None:
-    prompt_file = tmp_path / "prompt.txt"
-    prompt_file.write_text(PROMPT)
-
-    cmd = opencode_stdin_prompt_cmd(OPENCODE_CMD, str(prompt_file))
-
-    assert PROMPT not in cmd
-    assert str(prompt_file) in cmd
-    # opencode's own argv is preserved intact at the end (no message appended)
-    assert cmd[-len(OPENCODE_CMD) :] == OPENCODE_CMD
+class FakeResult:
+    success = True
+    returncode = 0
+    stdout = ""
+    stderr = ""
 
 
-def test_prompt_reaches_the_agent_verbatim_on_stdin(tmp_path: Path) -> None:
-    prompt_file = tmp_path / "prompt.txt"
-    prompt_file.write_text(PROMPT)
+class FakeSandbox:
+    def __init__(self) -> None:
+        self.exec_remote_calls: list[dict[str, Any]] = []
+        self.written: dict[str, str] = {}
 
-    # stand in for opencode with a command that echoes its stdin
-    cmd = opencode_stdin_prompt_cmd(["cat"], str(prompt_file))
-    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    async def exec(self, cmd: list[str], **kwargs: Any) -> FakeResult:
+        result = FakeResult()
+        if cmd[:2] == ["sh", "-c"] and "HOME" in cmd[2]:
+            result.stdout = "/root\n"
+        return result
 
-    assert result.stdout == PROMPT
-    # the file is unlinked once it is held open on stdin
-    assert not prompt_file.exists()
+    async def write_file(self, path: str, contents: str) -> None:
+        self.written[path] = contents
+
+    async def exec_remote(
+        self, cmd: list[str], options: Any, stream: bool
+    ) -> FakeResult:
+        self.exec_remote_calls.append({"cmd": cmd, "options": options})
+        return FakeResult()
 
 
-def test_stdin_redirection_tolerates_spaces_in_the_prompt_path(
-    tmp_path: Path,
+class FakeBridge:
+    port = 3001
+    mcp_server_configs: list[Any] = []
+
+    def __init__(self, state: AgentState) -> None:
+        self.state = state
+
+
+class FakeStore:
+    def __init__(self) -> None:
+        self.values: dict[str, Any] = {}
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self.values.get(key, default)
+
+    def set(self, key: str, value: Any) -> None:
+        self.values[key] = value
+
+
+def run_opencode(
+    monkeypatch: pytest.MonkeyPatch, messages: list[Any], **kwargs: Any
+) -> FakeSandbox:
+    sbox = FakeSandbox()
+    store = FakeStore()
+
+    @asynccontextmanager
+    async def fake_bridge(state: AgentState, **_: Any) -> AsyncIterator[FakeBridge]:
+        yield FakeBridge(state)
+
+    async def fake_cwd(*_: Any) -> str:
+        return "/root"
+
+    async def fake_setup(*_: Any) -> tuple[str, list[str]]:
+        return "/opt/opencode/opencode", []
+
+    monkeypatch.setattr(opencode_module, "sandbox_env", lambda *_: sbox)
+    monkeypatch.setattr(opencode_module, "sandbox_agent_bridge", fake_bridge)
+    monkeypatch.setattr(opencode_module, "resolve_agent_cwd", fake_cwd)
+    monkeypatch.setattr(opencode_module, "ensure_opencode_setup", fake_setup)
+    monkeypatch.setattr(opencode_module, "store", lambda: store)
+
+    agent = opencode_module.opencode(**kwargs)
+    anyio.run(agent, AgentState(messages=messages))
+    return sbox
+
+
+def test_prompt_is_delivered_on_stdin_not_argv(monkeypatch: pytest.MonkeyPatch) -> None:
+    sbox = run_opencode(monkeypatch, [ChatMessageUser(content=PROMPT)])
+
+    (call,) = sbox.exec_remote_calls
+    options = call["options"]
+    assert isinstance(options, ExecRemoteAwaitableOptions)
+    # verbatim: embedded quotes, blank lines, no trailing newline
+    assert options.input == PROMPT
+    # opencode's own argv, with no message appended (and no shell wrapper)
+    assert call["cmd"][0] == "/opt/opencode/opencode"
+    assert call["cmd"][1] == "run"
+    assert PROMPT not in call["cmd"]
+    assert not any(PROMPT in arg for arg in call["cmd"])
+    # nothing is staged on disk apart from opencode's config
+    assert list(sbox.written) == ["/root/.config/opencode/opencode.json"]
+
+
+def test_system_prompt_is_prepended_within_stdin(
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    prompt_file = tmp_path / "dir with spaces" / "prompt file.txt"
-    prompt_file.parent.mkdir()
-    prompt_file.write_text(PROMPT)
+    sbox = run_opencode(
+        monkeypatch,
+        [ChatMessageSystem(content="Be terse."), ChatMessageUser(content=PROMPT)],
+        system_prompt="Answer in English.",
+    )
 
-    cmd = opencode_stdin_prompt_cmd(["cat"], str(prompt_file))
-    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    (call,) = sbox.exec_remote_calls
+    assert call["options"].input == f"Be terse.\n\nAnswer in English.\n\n{PROMPT}"
+    assert "--continue" not in call["cmd"]
 
-    assert result.stdout == PROMPT
+
+def test_continuation_turn_uses_stdin_too(monkeypatch: pytest.MonkeyPatch) -> None:
+    sbox = run_opencode(
+        monkeypatch,
+        [
+            ChatMessageUser(content="first"),
+            ChatMessageAssistant(content="ok"),
+            ChatMessageUser(content=PROMPT),
+        ],
+    )
+
+    (call,) = sbox.exec_remote_calls
+    assert "--continue" in call["cmd"]
+    assert call["options"].input == PROMPT
+    assert PROMPT not in call["cmd"]


### PR DESCRIPTION
## Problem

Running `opencode` (1.18.29) over the agent bridge on GAIA level 1 with gpt-5.5, ~4/10 samples ended with opencode's auto-generated *session title* as the sample's final answer and transcript. Every affected prompt contained a literal `"`.

## Root cause

`opencode run` wraps a positional message containing spaces in double quotes **and backslash-escapes the double quotes inside it** (`packages/opencode/src/cli/cmd/run.ts`: `` arg.includes(" ") ? `"${arg.replace(/"/g, '\\"')}"` : arg ``). The bridge's main-thread tracking anchors on the task input; it learned to accept the plain quote-wrapped form (UKGovernmentBEIS/inspect_ai#4768) but not the escaped one, so for prompts with `"` neither the answer thread nor the title thread anchored and the longer 4-message title call won in either call order.

## Fix

Deliver the prompt on stdin instead of argv, via `exec_remote(..., ExecRemoteAwaitableOptions(input=prompt))`. opencode uses piped stdin verbatim (`resolveRunInput`), so the task input now crosses the bridge byte-for-byte and anchors exactly, independent of any bridge heuristics for scaffold decorations. `exec_remote` writes `input` to the process's stdin over the sandbox-tools RPC channel and closes it, so opencode sees the EOF it needs; nothing is staged on disk, there is no shell wrapper, and there are no argv/env size limits for long prompts. The `input` option exists in inspect_ai 0.3.255 (our minimum pin) and is sandbox-agnostic. The `--continue` retry path uses the same mechanism; centaur mode is unchanged (the human types the prompt).

**Compatibility:** `resolveRunInput` (piped stdin used verbatim when there is no positional message) first shipped in opencode v1.14.42 (anomalyco/opencode#23557, 2026-05-08). Releases from 1.0.x through 1.14.41 do `message += "\n" + stdin`, so on those the model sees a leading newline before the prompt: prompts of 20+ characters still anchor by containment and beat the title call, quote-free prompts under 20 characters do not. Only reachable with an old opencode pre-installed in the sandbox image (`version="auto"` / `"sandbox"`), since downloads always resolve to a current release. Documented in 28fb331 (docs installation page, `version` docstring, delivery comment); no runtime guard, see that commit message for why.

Companion inspect_ai PR UKGovernmentBEIS/inspect_ai#5284 (bridge side): accepts the escaped rendering for users who run opencode outside inspect_swe, and fixes a second, independent bug where gpt-5.5 tool calls were dropped by opencode (`function_call` items had `id: null`, which the Vercel AI SDK rejects) so the agent stopped after its first tool call with an empty answer. That second bug accounts for the "empty after 1 tool call" samples in the same report and is **not** fixable from inspect_swe.

## Verification

Live runs (docker, gpt-5.5, opencode 1.18.29, inspect_ai main) on the exact 10 GAIA level 1 validation samples from the reported log:

| configuration | accuracy | final state |
|---|---|---|
| baseline (inspect_swe main + inspect_ai main) | 0.1 | 4 title-captured, 5 empty after first tool call, 1 correct |
| this PR only (inspect_ai main unfixed), 2-sample stand-in | | title capture fixed; tool-call drop remains |
| this PR (staged-file version) + companion inspect_ai fix | 0.7 | all 10 surface the real agent thread (3 genuine wrong answers) |
| this PR (final `exec_remote(input=...)` version) + companion inspect_ai fix, fresh run | 0.7 | all 10 surface the real agent thread, prompt verbatim in every bridged call; same 3 wrong answers |

Unit tests (`tests/test_opencode_prompt.py`) drive `execute()` with faked sandbox plumbing and assert the exact `exec_remote` call: the prompt (embedded quotes, blank lines, no trailing newline) is passed verbatim as `input`, is absent from argv, nothing but `opencode.json` is written to the sandbox, and the system-prompt prepend and `--continue` paths go through the same channel. `make check` clean; fast suite: 97 passed, 1 pre-existing failure unrelated to this change (`test_bundled_catalog_tracks_live_latest`: the live Codex catalog's latest moved to `gpt-6-astra`, bundled fallback still says `gpt-5.6-sol`).

### Agent review
- Reviewer: Claude Fable 5.1 via a fresh-context general-purpose subagent (same model as author), 1 pass
- Findings: 4 on the initial (staged-file) version — 2 fixed, 2 dismissed as nits. The automated PR review then flagged the leftover prompt file; that and the reviewer's file-related findings are moot after switching to `exec_remote(input=...)`, which removes the file and the bash wrapper entirely.
- Verification of the final version: 2-sample stand-in 2/2, and the 10 GAIA samples re-run (see table; final row added after the switch).
- Docs-only follow-up 28fb331 (opencode version floor, from ransomr's review note) authored by Claude Fable 5.1 as a CASE pr-developer worker; no separate review pass on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

