### PR TITLE
feat: add Pi coding agent support

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -19,3 +19,4 @@ inspect-docs:
         - href: opencode.qmd
         - href: mini_swe_agent.qmd
         - href: antigravity.qmd
+        - href: pi.qmd

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -5,7 +5,7 @@ subtitle: Software Engineering Agents for Inspect AI
 
 ## Overview
 
-The `inspect_swe` package makes software engineering agents like [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview), [Codex CLI](https://github.com/openai/codex), [Gemini CLI](https://github.com/google-gemini/gemini-cli), [Kimi Code](https://github.com/MoonshotAI/kimi-code), [OpenCode](https://github.com/anomalyco/opencode), and [Mini SWE Agent](https://github.com/SWE-agent/mini-swe-agent) available as standard Inspect agents. For example, here we use the `claude_code()` agent as the solver in an Inspect task:
+The `inspect_swe` package makes software engineering agents like [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview), [Codex CLI](https://github.com/openai/codex), [Gemini CLI](https://github.com/google-gemini/gemini-cli), [Kimi Code](https://github.com/MoonshotAI/kimi-code), [OpenCode](https://github.com/anomalyco/opencode), [Mini SWE Agent](https://github.com/SWE-agent/mini-swe-agent), and [Pi](https://github.com/earendil-works/pi) available as standard Inspect agents. For example, here we use the `claude_code()` agent as the solver in an Inspect task:
 
 ``` python
 from inspect_ai import Task, task
@@ -47,6 +47,7 @@ Then, try out one or more of the available agents:
 | [`opencode()`](opencode.qmd) | Provider-independent terminal-based coding agent. |
 | [`mini_swe_agent()`](mini_swe_agent.qmd) | SWE-agent's minimal 100-line agent. |
 | [`antigravity()`](antigravity.qmd) | Google's Antigravity SDK agent (`google-antigravity` / localharness). |
+| [`pi()`](pi.qmd) | Terminal coding agent with file editing and shell tools. |
 
 
 : {tbl-colwidths=\[30,70\]}

--- a/docs/pi.qmd
+++ b/docs/pi.qmd
@@ -1,0 +1,59 @@
+---
+title: Pi
+agent: pi
+agent_provider: "Earendil's"
+agent_name: Pi
+agent_url: "https://github.com/earendil-works/pi"
+---
+
+{{< include _snippets/agent_intro.md >}}
+
+## Options
+
+| Option | Description |
+|------------------------------------|------------------------------------|
+| `system_prompt` | Instructions to append to the default system prompt. |
+| `skills` | Additional [skills](https://inspect.aisi.org.uk/tools-standard.html#sec-skill) to make available to the agent. |
+| `centaur` | Run in [centaur mode](#centaur-mode). |
+| `attempts` | Allow multiple scored attempts at solving the task. |
+| `model` | Model to use, defaulting to the task's main model. |
+| `thinking` | Pi thinking level. The default, `"off"`, leaves Inspect and provider reasoning defaults in effect. Other levels require reasoning support. |
+| `max_context_size` | Context window for Pi. Defaults to Inspect model metadata; required when that metadata is unavailable. |
+| `filter` | Filter for intercepting bridged model requests. |
+| `retry_refusals` | Number of times to retry refusals. |
+| `cwd` | Working directory for the Pi session. |
+| `env` | Sandbox environment variables, visible to the agent. Pi's config directory and offline settings cannot be overridden. |
+| `version` | Pi version to use. See [Installation](#installation). |
+
+: {tbl-colwidths=\[25,75\]}
+
+For example, specify a custom system prompt:
+
+```python
+{{< meta agent >}}(
+    system_prompt="Run the relevant tests after changing code."
+)
+```
+
+Pi uses its built-in tools without approval prompts, including in centaur mode. Extensions, MCP servers, bridged tools, and user image input are not supported. Only supplied skills are loaded. See the [API reference](reference/index.qmd#pi) for all options.
+
+## Installation
+
+Pi runs from a standalone release archive. Sandboxes need Linux x64 or arm64 with glibc and Bash, such as Debian or Ubuntu. Alpine is not supported. Node.js and npm are not required.
+
+Use `version` to control installation:
+
+| Option | Description |
+|------------------------------------|------------------------------------|
+| `"auto"` | Use Pi from the sandbox if installed, otherwise download the latest release. This is the default. |
+| `"sandbox"` | Require Pi to be installed in the sandbox. |
+| `"stable"`, `"latest"` | Download and use the latest release. |
+| `"x.x.x"` | Download and use a specific version. |
+
+: {tbl-colwidths=\[25,75\]}
+
+For offline evaluations, pre-install Pi and use `version="sandbox"`, or cache a specific release with [`download_agent_binary()`](reference/index.qmd#download_agent_binary) and use that version.
+
+{{< include _snippets/agent_centaur.md >}}
+
+{{< include _snippets/agent_troubleshooting.md >}}

--- a/docs/reference/index.qmd
+++ b/docs/reference/index.qmd
@@ -12,6 +12,7 @@ reference: inspect_swe
 ### opencode
 ### mini_swe_agent
 ### antigravity
+### pi
 
 ## Binaries
 

--- a/examples/multi_call/task.py
+++ b/examples/multi_call/task.py
@@ -6,13 +6,13 @@ from inspect_ai.dataset import Sample
 from inspect_ai.model import ChatMessageUser
 from inspect_ai.solver import Generate, Solver, TaskState, solver
 from inspect_ai.util import SandboxEnvironmentType
-from inspect_swe import claude_code, codex_cli, gemini_cli, mini_swe_agent, opencode
+from inspect_swe import claude_code, codex_cli, gemini_cli, mini_swe_agent, opencode, pi
 
 
 @solver
 def multi_call_solver(
     agent_type: Literal[
-        "claude_code", "codex_cli", "gemini_cli", "mini_swe_agent", "opencode"
+        "claude_code", "codex_cli", "gemini_cli", "mini_swe_agent", "opencode", "pi"
     ],
 ) -> Solver:
     async def solve(state: TaskState, generate: Generate) -> TaskState:
@@ -29,6 +29,8 @@ def multi_call_solver(
                 agent = mini_swe_agent(system_prompt=system_prompt)
             case "opencode":
                 agent = opencode(system_prompt=system_prompt)
+            case "pi":
+                agent = pi(system_prompt=system_prompt)
 
         # first run
         agent_state = await run(agent, state.messages)
@@ -56,7 +58,7 @@ def multi_call_solver(
 @task
 def multi_call(
     agent: Literal[
-        "claude_code", "codex_cli", "gemini_cli", "mini_swe_agent", "opencode"
+        "claude_code", "codex_cli", "gemini_cli", "mini_swe_agent", "opencode", "pi"
     ] = "claude_code",
     sandbox: SandboxEnvironmentType | None = "docker",
 ) -> Task:

--- a/examples/multiple_attempts/task.py
+++ b/examples/multiple_attempts/task.py
@@ -4,13 +4,13 @@ from inspect_ai import Task, task
 from inspect_ai.dataset import Sample
 from inspect_ai.scorer import includes
 from inspect_ai.util import SandboxEnvironmentType
-from inspect_swe import claude_code, codex_cli, gemini_cli, mini_swe_agent, opencode
+from inspect_swe import claude_code, codex_cli, gemini_cli, mini_swe_agent, opencode, pi
 
 
 @task
 def multiple_attempts(
     agent: Literal[
-        "claude_code", "codex_cli", "gemini_cli", "mini_swe_agent", "opencode"
+        "claude_code", "codex_cli", "gemini_cli", "mini_swe_agent", "opencode", "pi"
     ] = "claude_code",
     sandbox: SandboxEnvironmentType | None = "docker",
 ) -> Task:
@@ -28,6 +28,8 @@ def multiple_attempts(
             solver = mini_swe_agent(system_prompt=system_prompt, attempts=attempts)
         case "opencode":
             solver = opencode(system_prompt=system_prompt, attempts=attempts)
+        case "pi":
+            solver = pi(system_prompt=system_prompt, attempts=attempts)
 
     # create task
     return Task(

--- a/examples/skills/task.py
+++ b/examples/skills/task.py
@@ -6,13 +6,13 @@ from inspect_ai import Task, task
 from inspect_ai.dataset import Sample
 from inspect_ai.scorer import includes
 from inspect_ai.util import SandboxEnvironmentType
-from inspect_swe import claude_code, codex_cli, gemini_cli, opencode
+from inspect_swe import claude_code, codex_cli, gemini_cli, opencode, pi
 
 
 @task
 def agent_skills(
     agent: Literal[
-        "claude_code", "codex_cli", "gemini_cli", "opencode"
+        "claude_code", "codex_cli", "gemini_cli", "opencode", "pi"
     ] = "claude_code",
     sandbox: SandboxEnvironmentType | None = "docker",
 ) -> Task:
@@ -32,6 +32,8 @@ def agent_skills(
             solver = gemini_cli(system_prompt=system_prompt, skills=skills, attempts=2)
         case "opencode":
             solver = opencode(system_prompt=system_prompt, skills=skills, attempts=2)
+        case "pi":
+            solver = pi(system_prompt=system_prompt, skills=skills, attempts=2)
 
     # create task
     return Task(

--- a/examples/system_explorer/task.py
+++ b/examples/system_explorer/task.py
@@ -11,6 +11,7 @@ from inspect_swe import (
     kimi_code,
     mini_swe_agent,
     opencode,
+    pi,
 )
 
 
@@ -23,6 +24,7 @@ def system_explorer(
         "kimi_code",
         "mini_swe_agent",
         "opencode",
+        "pi",
     ] = "claude_code",
     sandbox: SandboxEnvironmentType | None = "docker",
 ) -> Task:
@@ -39,6 +41,8 @@ def system_explorer(
             solver = mini_swe_agent()
         case "opencode":
             solver = opencode()
+        case "pi":
+            solver = pi()
 
     return Task(
         dataset=json_dataset("dataset.json"),

--- a/src/inspect_swe/__init__.py
+++ b/src/inspect_swe/__init__.py
@@ -6,6 +6,7 @@ from ._gemini_cli.gemini_cli import gemini_cli
 from ._kimi_code.kimi_code import kimi_code
 from ._mini_swe_agent.mini_swe_agent import mini_swe_agent
 from ._opencode.opencode import opencode
+from ._pi.pi import pi
 from ._tools.download import (
     AgentBinary,
     cached_agent_binaries,
@@ -38,6 +39,7 @@ __all__ = [
     "kimi_code",
     "mini_swe_agent",
     "opencode",
+    "pi",
     "interactive_claude_code",
     "interactive_codex_cli",
     "interactive_gemini_cli",

--- a/src/inspect_swe/_pi/agentbinary.py
+++ b/src/inspect_swe/_pi/agentbinary.py
@@ -1,0 +1,78 @@
+import json
+from pathlib import Path
+from typing import Any, Literal
+
+from .._util.agentbinary import (
+    AgentBinarySource,
+    AgentBinaryVersion,
+)
+from .._util.appdirs import package_cache_dir
+from .._util.download import download_text_file
+from .._util.sandbox import SandboxPlatform
+
+
+def pi_binary_source() -> AgentBinarySource:
+    """Return the host-downloaded, checksum-verified Pi release source."""
+    cached_package_dir = package_cache_dir("pi-downloads")
+
+    async def resolve_version(
+        version: Literal["stable", "latest"] | str, platform: SandboxPlatform
+    ) -> AgentBinaryVersion:
+        asset_name = _asset_name(platform=platform)
+        release = await _fetch_release(version=version)
+        assets = {asset["name"]: asset for asset in release.get("assets", [])}
+        asset = assets.get(asset_name)
+        if asset is None:
+            raise RuntimeError(
+                f"No matching Pi asset {asset_name!r} in release {version}"
+            )
+        digest = asset.get("digest") or ""
+        if not digest.startswith("sha256:"):
+            raise RuntimeError(f"Invalid Pi release digest: {digest}")
+        return AgentBinaryVersion(
+            version=str(release["tag_name"]).lstrip("v"),
+            expected_checksum=digest[7:],
+            download_url=asset["browser_download_url"],
+            package=True,
+        )
+
+    def cached_binary_path(version: str, platform: SandboxPlatform) -> Path:
+        return cached_package_dir / f"pi-{version}-{platform}"
+
+    def cached_package_path(version: str, platform: SandboxPlatform) -> Path:
+        return cached_package_dir / f"pi-package-{version}-{platform}.tar.gz"
+
+    return AgentBinarySource(
+        agent="pi",
+        binary="pi",
+        resolve_version=resolve_version,
+        cached_binary_path=cached_binary_path,
+        list_cached_binaries=lambda: list(cached_package_dir.glob("pi-*")),
+        post_download=None,
+        post_install=None,
+        package_entrypoint="pi/pi",
+        cached_package_path=cached_package_path,
+    )
+
+
+def _asset_name(platform: SandboxPlatform) -> str:
+    names = {
+        "linux-x64": "pi-linux-x64.tar.gz",
+        "linux-arm64": "pi-linux-arm64.tar.gz",
+    }
+    if platform.endswith("-musl"):
+        raise RuntimeError(
+            "Pi standalone releases require glibc; musl sandboxes are not supported."
+        )
+    try:
+        return names[platform]
+    except KeyError as error:
+        raise ValueError(f"Unsupported platform: {platform}") from error
+
+
+async def _fetch_release(version: str) -> dict[str, Any]:
+    if version in ("stable", "latest"):
+        url = "https://api.github.com/repos/earendil-works/pi/releases/latest"
+    else:
+        url = f"https://api.github.com/repos/earendil-works/pi/releases/tags/v{version}"
+    return dict(json.loads(await download_text_file(url=url)))

--- a/src/inspect_swe/_pi/config.py
+++ b/src/inspect_swe/_pi/config.py
@@ -1,0 +1,65 @@
+import json
+
+
+def pi_models_json(
+    *, port: int, model: str, context_size: int, max_tokens: int, reasoning: bool
+) -> str:
+    """Configure only a dummy-key provider pointing at the Inspect bridge."""
+    return json.dumps(
+        {
+            "providers": {
+                "inspect": {
+                    "baseUrl": f"http://localhost:{port}/v1",
+                    "api": "openai-completions",
+                    "apiKey": "inspect-bridge",
+                    "compat": {"supportsStore": False, "supportsDeveloperRole": False},
+                    "models": [
+                        {
+                            "id": model,
+                            "reasoning": reasoning,
+                            "thinkingLevelMap": {"xhigh": "xhigh", "max": "max"},
+                            "input": ["text", "image"],
+                            "contextWindow": context_size,
+                            "maxTokens": max_tokens,
+                        }
+                    ],
+                }
+            }
+        }
+    )
+
+
+def pi_result_error(*, stdout: str) -> str | None:
+    """Check Pi's final turn; an exit code alone can miss model errors."""
+    final_message = None
+    ended = False
+    for line in stdout.split("\n"):
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            # Startup diagnostics may share stdout with JSON events. Require a
+            # complete terminal event below rather than treating them as success.
+            continue
+        if not isinstance(event, dict):
+            continue
+        if event.get("type") == "agent_start":
+            ended = False
+            final_message = None
+        if event.get("type") == "agent_end":
+            ended = True
+        if event.get("type") == "message_end":
+            message = event.get("message")
+            if isinstance(message, dict) and message.get("role") == "assistant":
+                final_message = message
+    if final_message is not None and final_message.get("stopReason") in (
+        "error",
+        "aborted",
+    ):
+        return str(final_message.get("errorMessage") or final_message["stopReason"])
+    if (
+        not ended
+        or final_message is None
+        or final_message.get("stopReason") not in ("stop", "length")
+    ):
+        return "Pi exited without a completed assistant turn"
+    return None

--- a/src/inspect_swe/_pi/pi.py
+++ b/src/inspect_swe/_pi/pi.py
@@ -1,0 +1,283 @@
+import json
+import shlex
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Literal
+from uuid import uuid4
+
+from inspect_ai.agent import (
+    Agent,
+    AgentAttempts,
+    AgentState,
+    agent,
+    agent_with,
+    sandbox_agent_bridge,
+)
+from inspect_ai.agent._bridge.util import resolve_inspect_model
+from inspect_ai.model import ChatMessageSystem, GenerateFilter, Model, get_model_info
+from inspect_ai.scorer import score
+from inspect_ai.tool import Skill, install_skills, read_skills
+from inspect_ai.util import sandbox as sandbox_env
+from inspect_ai.util import store
+from inspect_ai.util._sandbox import ExecRemoteAwaitableOptions
+
+from inspect_swe._util._async import is_callable_coroutine
+from inspect_swe._util.agentbinary import ensure_agent_binary_installed
+from inspect_swe._util.centaur import CentaurOptions, run_centaur
+from inspect_swe._util.messages import build_user_prompt
+from inspect_swe._util.sandbox import resolve_agent_cwd
+from inspect_swe._util.trace import trace
+
+from .agentbinary import pi_binary_source
+from .config import pi_models_json, pi_result_error
+
+
+@agent
+def pi(
+    name: str = "Pi",
+    description: str = "Terminal coding agent that reads and edits files and runs shell commands.",
+    system_prompt: str | None = None,
+    skills: Sequence[str | Path | Skill] | None = None,
+    centaur: bool | CentaurOptions = False,
+    attempts: int | AgentAttempts = 1,
+    model: str | None = None,
+    model_aliases: dict[str, str | Model] | None = None,
+    filter: GenerateFilter | None = None,
+    retry_refusals: int | None = None,
+    cwd: str | None = None,
+    env: dict[str, str] | None = None,
+    user: str | None = None,
+    sandbox: str | None = None,
+    version: Literal["auto", "sandbox", "stable", "latest"] | str = "auto",
+    debug: bool = False,
+    thinking: Literal[
+        "off", "minimal", "low", "medium", "high", "xhigh", "max"
+    ] = "off",
+    max_context_size: int | None = None,
+) -> Agent:
+    """Pi coding agent running in a sandbox with Inspect model bridging.
+
+    Pi's built-in tools run without approval prompts. Model calls use the
+    Inspect bridge's OpenAI Chat Completions endpoint, not Pi's provider
+    credentials. MCP servers and bridged tools are not supported.
+
+    Args:
+        name: Agent name for multi-agent systems.
+        description: Agent description.
+        system_prompt: Instructions to append to Pi's default system prompt.
+        skills: Additional Inspect skills to install for Pi.
+        centaur: Make Pi available to an Inspect human_cli agent.
+        attempts: Number of scored attempts, or an AgentAttempts configuration.
+        model: Inspect model name; defaults to the task's main model.
+        model_aliases: Mapping of requested model names to Inspect models.
+        filter: Filter for intercepting bridged model requests.
+        retry_refusals: Number of times to retry refusals.
+        cwd: Working directory in the sandbox.
+        env: Additional sandbox environment variables. Pi's config directory
+            and offline settings are reserved and cannot be overridden.
+        user: Sandbox user to run Pi as.
+        sandbox: Optional sandbox environment name.
+        version: "auto" uses an installed Pi or downloads the latest release;
+            "sandbox" requires an installed Pi; "stable" and "latest" download
+            the latest release; a version number pins a release.
+        debug: Include CLI output in the debug trace.
+        thinking: Pi thinking level. "off" sends no reasoning effort, leaving
+            Inspect and provider defaults in effect. Other levels are forwarded
+            through the bridge and require a model that supports reasoning.
+        max_context_size: Context window for Pi's compaction. Defaults to Inspect
+            model metadata; required when the model has no context metadata.
+    """
+    if thinking not in ("off", "minimal", "low", "medium", "high", "xhigh", "max"):
+        raise ValueError(f"Unsupported Pi thinking level: {thinking}")
+    if max_context_size is not None and max_context_size <= 0:
+        raise ValueError("max_context_size must be positive")
+    if centaur is True:
+        centaur = CentaurOptions()
+    resolved_skills = read_skills(skills=skills) if skills is not None else None
+    attempts = (
+        AgentAttempts(attempts=attempts) if isinstance(attempts, int) else attempts
+    )
+    if attempts.attempts < 1:
+        raise ValueError("attempts must be at least 1")
+    requested_model = model or "inspect"
+    bridge_model = f"inspect/{model}" if model is not None else "inspect"
+    session_key = f"pi_session_{uuid4().hex}"
+
+    async def execute(state: AgentState) -> AgentState:
+        prompt, has_assistant_response = build_user_prompt(messages=state.messages)
+        sbox = sandbox_env(name=sandbox)
+        agent_cwd = await resolve_agent_cwd(sandbox=sbox, user=user, cwd=cwd)
+        resolved_model = resolve_inspect_model(
+            model_name=requested_model,
+            model_aliases=model_aliases,
+            fallback_model=bridge_model,
+        )
+        model_info = get_model_info(model=resolved_model)
+        context_size = max_context_size or (
+            model_info.context_length if model_info else None
+        )
+        if context_size is None or context_size <= 0:
+            raise ValueError(
+                "Context length metadata is unavailable; pass max_context_size to pi()."
+            )
+        max_tokens = min(
+            resolved_model.config.max_tokens
+            or (model_info.output_tokens if model_info else None)
+            or 16384,
+            context_size,
+        )
+
+        # Keep each agent's config and session separate, including within one sample.
+        session = store().get(session_key)
+        if session is None or not has_assistant_response:
+            result = await sbox.exec(
+                cmd=["mktemp", "-d", "/tmp/inspect-pi-XXXXXXXX"], user=user
+            )
+            if not result.success:
+                raise RuntimeError(
+                    f"Unable to create Pi config directory: {result.stderr}"
+                )
+            system_messages = [
+                m.text for m in state.messages if isinstance(m, ChatMessageSystem)
+            ]
+            if system_prompt is not None:
+                system_messages.append(system_prompt)
+            session = {
+                "directory": result.stdout.strip(),
+                "system_prompt": "\n\n".join(system_messages),
+            }
+            store().set(key=session_key, value=session)
+        pi_dir = session["directory"]
+
+        port = store().get("pi_model_port", 3200) + 1
+        store().set(key="pi_model_port", value=port)
+        async with sandbox_agent_bridge(
+            state=state,
+            model=bridge_model,
+            model_aliases=model_aliases,
+            filter=filter,
+            sandbox=sandbox,
+            retry_refusals=retry_refusals,
+            forward_generation_config=True,
+            port=port,
+        ) as bridge:
+            pi_binary = await ensure_agent_binary_installed(
+                source=pi_binary_source(), sandbox=sbox, version=version, user=user
+            )
+            await sbox.write_file(
+                file=f"{pi_dir}/models.json",
+                contents=pi_models_json(
+                    port=bridge.port,
+                    model=requested_model,
+                    context_size=context_size,
+                    max_tokens=max_tokens,
+                    reasoning=thinking != "off",
+                ),
+            )
+            await sbox.write_file(
+                file=f"{pi_dir}/settings.json",
+                contents=json.dumps(
+                    {
+                        "retry": {"enabled": False},
+                        "compaction": {"reserveTokens": min(16384, context_size // 4)},
+                    }
+                ),
+            )
+            cmd = [
+                pi_binary,
+                "--provider",
+                "inspect",
+                "--model",
+                requested_model,
+                "--thinking",
+                thinking,
+                "--session",
+                f"{pi_dir}/session.jsonl",
+                "--no-extensions",
+                "--no-skills",
+                "--no-prompt-templates",
+                "--no-themes",
+                "--no-approve",
+            ]
+            # Pi rebuilds its system prompt on each launch. Reapply only the original
+            # instructions, never the full Pi prompt captured by the bridge.
+            if session["system_prompt"]:
+                system_file = f"{pi_dir}/system.txt"
+                await sbox.write_file(
+                    file=system_file, contents=session["system_prompt"]
+                )
+                cmd.extend(["--append-system-prompt", system_file])
+            if resolved_skills is not None:
+                skills_dir = f"{pi_dir}/skills"
+                await install_skills(
+                    skills=resolved_skills, sandbox=sbox, user=user, dir=skills_dir
+                )
+                cmd.extend(["--skill", skills_dir])
+            agent_env = (env or {}) | {
+                "PI_CODING_AGENT_DIR": pi_dir,
+                "PI_OFFLINE": "1",
+                "PI_TELEMETRY": "0",
+            }
+            if centaur:
+                exports = [
+                    f"export {key}={shlex.quote(s)}" for key, s in agent_env.items()
+                ]
+                alias = f"alias pi={shlex.quote(shlex.join(cmd))}"
+                await run_centaur(
+                    options=centaur,
+                    instructions="Use 'pi' to run the Pi coding agent. Repeated calls resume the same session. Pi tools run without approval prompts.",
+                    bashrc="\n".join([*exports, alias]),
+                    state=state,
+                )
+            else:
+                for attempt in range(attempts.attempts):
+                    # Stdin avoids argv limits and Pi's @file argument expansion.
+                    prompt_file = f"{pi_dir}/prompt.txt"
+                    await sbox.write_file(file=prompt_file, contents=prompt)
+                    result = await sbox.exec_remote(
+                        cmd=[
+                            "bash",
+                            "-c",
+                            'prompt=$1; shift; exec "$@" < "$prompt"',
+                            "bash",
+                            prompt_file,
+                            *cmd,
+                            "--print",
+                            "--mode",
+                            "json",
+                        ],
+                        options=ExecRemoteAwaitableOptions(
+                            cwd=agent_cwd, env=agent_env, user=user, concurrency=False
+                        ),
+                        stream=False,
+                    )
+                    if debug:
+                        trace(
+                            message=f"Pi Debug Output:\n{result.stdout}\n{result.stderr}"
+                        )
+                    error = pi_result_error(stdout=result.stdout)
+                    if not result.success or error:
+                        detail = result.stderr or error or result.stdout or "No output"
+                        raise RuntimeError(
+                            f"Error executing Pi agent {result.returncode}: {detail[:2000]}"
+                        )
+                    if attempt + 1 >= attempts.attempts:
+                        break
+                    answer_scores = await score(conversation=bridge.state)
+                    if attempts.score_value(answer_scores[0].value) == 1.0:
+                        break
+                    if callable(attempts.incorrect_message):
+                        if not is_callable_coroutine(
+                            func_or_cls=attempts.incorrect_message
+                        ):
+                            raise ValueError(
+                                "The incorrect_message function must be async."
+                            )
+                        prompt = await attempts.incorrect_message(
+                            bridge.state, answer_scores
+                        )
+                    else:
+                        prompt = attempts.incorrect_message
+        return bridge.state
+
+    return agent_with(agent=execute, name=name, description=description)

--- a/src/inspect_swe/_registry.py
+++ b/src/inspect_swe/_registry.py
@@ -7,6 +7,7 @@ from ._gemini_cli.gemini_cli import gemini_cli
 from ._kimi_code.kimi_code import kimi_code
 from ._mini_swe_agent.mini_swe_agent import mini_swe_agent
 from ._opencode.opencode import opencode
+from ._pi.pi import pi
 
 __all__ = [
     "antigravity",
@@ -16,4 +17,5 @@ __all__ = [
     "kimi_code",
     "mini_swe_agent",
     "opencode",
+    "pi",
 ]

--- a/src/inspect_swe/_tools/download.py
+++ b/src/inspect_swe/_tools/download.py
@@ -6,6 +6,7 @@ from .._claude_code.agentbinary import claude_code_binary_source
 from .._codex_cli.agentbinary import codex_cli_binary_source
 from .._kimi_code.agentbinary import kimi_code_binary_source
 from .._opencode.agentbinary import opencode_binary_source
+from .._pi.agentbinary import pi_binary_source
 from .._util._async import run_coroutine
 from .._util.agentbinary import (
     AgentBinarySource,
@@ -18,7 +19,7 @@ from .._util.sandbox import SandboxPlatform
 class AgentBinary(NamedTuple):
     """Agent binary."""
 
-    agent: Literal["claude_code", "codex_cli", "kimi_code", "opencode"]
+    agent: Literal["claude_code", "codex_cli", "kimi_code", "opencode", "pi"]
     """Agent type."""
 
     version: str
@@ -54,7 +55,7 @@ class AgentBinaries(list[AgentBinary]):
 
 
 def download_agent_binary(
-    binary: Literal["claude_code", "codex_cli", "kimi_code", "opencode"],
+    binary: Literal["claude_code", "codex_cli", "kimi_code", "opencode", "pi"],
     version: Literal["stable", "latest"] | str,
     platform: SandboxPlatform,
 ) -> None:
@@ -75,7 +76,8 @@ def download_agent_binary(
 
 
 def cached_agent_binaries(
-    binary: Literal["claude_code", "codex_cli", "kimi_code", "opencode"] | None = None,
+    binary: Literal["claude_code", "codex_cli", "kimi_code", "opencode", "pi"]
+    | None = None,
     quiet: bool = False,
 ) -> AgentBinaries:
     """List the agent binaries which have been cached on this system.
@@ -94,6 +96,7 @@ def cached_agent_binaries(
             + cached_agent_binaries("codex_cli")
             + cached_agent_binaries("kimi_code")
             + cached_agent_binaries("opencode")
+            + cached_agent_binaries("pi")
         )
 
     source = _agent_binary_source(binary)
@@ -141,7 +144,7 @@ def cached_agent_binaries(
 
 
 def resolve_agent_version(
-    agent: Literal["claude_code", "codex_cli", "kimi_code", "opencode"],
+    agent: Literal["claude_code", "codex_cli", "kimi_code", "opencode", "pi"],
     version: Literal["stable", "latest"] | str,
     platform: SandboxPlatform = "linux-x64",
 ) -> str:
@@ -171,7 +174,7 @@ def resolve_agent_version(
 
 
 def _agent_binary_source(
-    binary: Literal["claude_code", "codex_cli", "kimi_code", "opencode"],
+    binary: Literal["claude_code", "codex_cli", "kimi_code", "opencode", "pi"],
 ) -> AgentBinarySource:
     match binary:
         case "claude_code":
@@ -182,8 +185,10 @@ def _agent_binary_source(
             return kimi_code_binary_source()
         case "opencode":
             return opencode_binary_source()
+        case "pi":
+            return pi_binary_source()
         case _:
             raise ValueError(
                 f"Unsupported agent binary type: {binary} "
-                "(expected one of claude_code, codex_cli, kimi_code, opencode)"
+                "(expected one of claude_code, codex_cli, kimi_code, opencode, pi)"
             )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -170,6 +170,7 @@ def run_example(
         "kimi_code",
         "mini_swe_agent",
         "opencode",
+        "pi",
     ],
     model: str,
     sandbox: str | None = None,

--- a/tests/test_pi.py
+++ b/tests/test_pi.py
@@ -1,0 +1,169 @@
+import json
+from typing import Any
+
+import pytest
+from inspect_ai._util.registry import registry_info
+from inspect_ai.model import ChatMessageAssistant, ChatMessageUser
+from inspect_swe import pi
+from inspect_swe._pi.config import pi_models_json, pi_result_error
+
+from tests.conftest import get_available_sandboxes, run_example, skip_if_no_openai
+
+
+def test_pi_registration() -> None:
+    assert registry_info(pi()).name == "inspect_swe/pi"
+
+
+@pytest.mark.parametrize("thinking", ["invalid", "", "HIGH"])
+def test_pi_rejects_invalid_thinking(thinking: Any) -> None:
+    with pytest.raises(ValueError, match="thinking"):
+        pi(thinking=thinking)
+
+
+@pytest.mark.parametrize("context_size", [0, -1])
+def test_pi_rejects_invalid_context_size(context_size: int) -> None:
+    with pytest.raises(ValueError, match="max_context_size"):
+        pi(max_context_size=context_size)
+
+
+@pytest.mark.parametrize("attempts", [0, -1])
+def test_pi_rejects_invalid_attempts(attempts: int) -> None:
+    with pytest.raises(ValueError, match="attempts"):
+        pi(attempts=attempts)
+
+
+@pytest.mark.parametrize("reasoning", [False, True])
+def test_pi_model_config(reasoning: bool) -> None:
+    config = json.loads(
+        pi_models_json(
+            port=3201,
+            model="openai/gpt-5-mini",
+            context_size=400000,
+            max_tokens=128000,
+            reasoning=reasoning,
+        )
+    )
+    assert list(config["providers"]) == ["inspect"]
+    provider = config["providers"]["inspect"]
+    assert provider["baseUrl"] == "http://localhost:3201/v1"
+    assert provider["api"] == "openai-completions"
+    assert provider["apiKey"] == "inspect-bridge"
+    assert provider["compat"]["supportsDeveloperRole"] is False
+    model = provider["models"][0]
+    assert model["id"] == "openai/gpt-5-mini"
+    assert model["contextWindow"] == 400000
+    assert model["maxTokens"] == 128000
+    assert model["reasoning"] is reasoning
+
+
+@pytest.mark.parametrize(
+    "output", ["", "startup failure", "null\n[]\n42", '{"type":"agent_end"}']
+)
+def test_pi_incomplete_output_is_error(output: str) -> None:
+    assert (
+        pi_result_error(stdout=output) == "Pi exited without a completed assistant turn"
+    )
+
+
+@pytest.mark.parametrize("stop_reason", ["error", "aborted"])
+def test_pi_assistant_failure_is_error(stop_reason: str) -> None:
+    output = (
+        json.dumps(
+            {
+                "type": "message_end",
+                "message": {
+                    "role": "assistant",
+                    "stopReason": stop_reason,
+                    "errorMessage": "Request failed",
+                },
+            }
+        )
+        + '\n{"type":"agent_end"}'
+    )
+    assert pi_result_error(stdout=output) == "Request failed"
+
+
+@pytest.mark.parametrize("stop_reason", ["toolUse", "pending", None])
+def test_pi_unfinished_assistant_is_error(stop_reason: str | None) -> None:
+    output = (
+        json.dumps(
+            {
+                "type": "message_end",
+                "message": {"role": "assistant", "stopReason": stop_reason},
+            }
+        )
+        + '\n{"type":"agent_end"}'
+    )
+    assert (
+        pi_result_error(stdout=output) == "Pi exited without a completed assistant turn"
+    )
+
+
+def test_pi_complete_json_turn() -> None:
+    output = (
+        json.dumps(
+            {
+                "type": "message_end",
+                "message": {
+                    "role": "assistant",
+                    "stopReason": "stop",
+                    "content": [{"type": "text", "text": "First\u2028second"}],
+                },
+            }
+        )
+        + '\n{"type":"agent_end"}'
+    )
+    assert pi_result_error(stdout=output) is None
+    assert (
+        pi_result_error(stdout=output + '\n{"type":"agent_start"}')
+        == "Pi exited without a completed assistant turn"
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.api
+@skip_if_no_openai
+@pytest.mark.parametrize("sandbox", get_available_sandboxes())
+def test_pi_multi_call(sandbox: str) -> None:
+    log = run_example(
+        example="multi_call", agent="pi", model="openai/gpt-5-mini", sandbox=sandbox
+    )[0]
+    assert log.status == "success", log.error
+    assert log.samples
+    messages = log.samples[0].messages
+    assert len([m for m in messages if isinstance(m, ChatMessageUser)]) == 4
+    assert len([m for m in messages if isinstance(m, ChatMessageAssistant)]) >= 4
+    assert "paris" in messages[-1].text.lower()
+    system = messages[0].text
+    assert system.count("Answer simple questions concisely") == 1
+
+
+@pytest.mark.slow
+@pytest.mark.api
+@skip_if_no_openai
+@pytest.mark.parametrize("example", ["skills", "multiple_attempts", "system_explorer"])
+@pytest.mark.parametrize("sandbox", get_available_sandboxes())
+def test_pi_examples(example: str, sandbox: str) -> None:
+    log = run_example(
+        example=example, agent="pi", model="openai/gpt-5-mini", sandbox=sandbox
+    )[0]
+    assert log.status == "success", log.error
+    assert log.samples
+    assert log.samples[0].error is None
+    if example == "skills":
+        content = "\n".join(message.text for message in log.samples[0].messages)
+        assert "ALPHA-BRAVO-CHARLIE" in content
+        assert "DELTA-ECHO-FOXTROT" in content
+    elif example == "multiple_attempts":
+        from inspect_ai.event import ScoreEvent
+
+        assert (
+            len(
+                [
+                    event
+                    for event in log.samples[0].events
+                    if isinstance(event, ScoreEvent)
+                ]
+            )
+            == 2
+        )

--- a/tests/test_pi_agentbinary.py
+++ b/tests/test_pi_agentbinary.py
@@ -1,0 +1,53 @@
+from functools import partial
+
+import anyio
+import pytest
+from inspect_swe import resolve_agent_version
+from inspect_swe._pi.agentbinary import _asset_name, pi_binary_source
+from inspect_swe._util.sandbox import SandboxPlatform
+
+
+@pytest.mark.parametrize(
+    ("platform", "asset"),
+    [
+        ("linux-x64", "pi-linux-x64.tar.gz"),
+        ("linux-arm64", "pi-linux-arm64.tar.gz"),
+    ],
+)
+def test_pi_release_asset_mapping(platform: SandboxPlatform, asset: str) -> None:
+    assert _asset_name(platform=platform) == asset
+
+
+@pytest.mark.parametrize("platform", ["linux-x64-musl", "linux-arm64-musl"])
+def test_pi_rejects_musl(platform: SandboxPlatform) -> None:
+    with pytest.raises(RuntimeError, match="glibc"):
+        _asset_name(platform=platform)
+
+
+@pytest.mark.slow
+def test_pi_latest_release_has_verified_linux_assets() -> None:
+    source = pi_binary_source()
+    for platform in ("linux-x64", "linux-arm64"):
+        resolved = anyio.run(partial(source.resolve_version, "latest", platform))
+        assert resolved.download_url.startswith(
+            "https://github.com/earendil-works/pi/releases/"
+        )
+        assert len(resolved.expected_checksum) == 64
+        assert int(resolved.expected_checksum, 16) > 0
+        assert resolved.package
+
+
+def test_pi_source_uses_standalone_package() -> None:
+    source = pi_binary_source()
+    assert source.binary == "pi"
+    assert source.package_entrypoint == "pi/pi"
+    assert source.cached_package_path is not None
+    assert (
+        source.cached_package_path("0.85.1", "linux-x64").name
+        == "pi-package-0.85.1-linux-x64.tar.gz"
+    )
+
+
+@pytest.mark.parametrize("version", ["auto", "sandbox", "0.85.1"])
+def test_pi_explicit_version_resolution(version: str) -> None:
+    assert resolve_agent_version(agent="pi", version=version) == version

--- a/tests/test_pi_bridge.py
+++ b/tests/test_pi_bridge.py
@@ -1,0 +1,105 @@
+from pathlib import Path
+from typing import Literal
+
+import pytest
+from inspect_ai import Task, eval
+from inspect_ai.dataset import Sample
+from inspect_ai.model import (
+    ChatMessage,
+    GenerateConfig,
+    GenerateInput,
+    Model,
+    get_model,
+)
+from inspect_ai.tool import ToolChoice, ToolInfo
+from inspect_swe import pi
+
+from tests.conftest import skip_if_no_docker
+
+
+@pytest.mark.slow
+@skip_if_no_docker
+@pytest.mark.parametrize(
+    ("thinking", "expected_effort"), [("off", None), ("high", "high")]
+)
+def test_pi_bridge_failure_with_real_cli(
+    tmp_path: Path, thinking: Literal["off", "high"], expected_effort: str | None
+) -> None:
+    """Exercise the actual bridge and CLI with a deliberately unavailable provider."""
+    compose = tmp_path / "compose.yaml"
+    compose.write_text(
+        data="""services:
+  default:
+    image: python:3.12-slim
+    command: sleep infinity
+    network_mode: none
+    working_dir: /tmp
+"""
+    )
+    requests: list[GenerateInput] = []
+
+    async def record_request(
+        model: Model,
+        messages: list[ChatMessage],
+        tools: list[ToolInfo],
+        tool_choice: ToolChoice | None,
+        config: GenerateConfig,
+    ) -> None:
+        requests.append(
+            GenerateInput(
+                input=messages, tools=tools, tool_choice=tool_choice, config=config
+            )
+        )
+
+    # This is the real OpenAI provider, not a replacement ModelAPI or canned
+    # response. It fails at localhost, so no credentials or paid calls are needed.
+    model = get_model(
+        model="openai/gpt-5-mini",
+        api_key="host-only-test-key",
+        base_url="http://127.0.0.1:1/v1",
+        config=GenerateConfig(max_retries=0, timeout=5),
+        memoize=False,
+    )
+    logs = eval(
+        tasks=Task(
+            dataset=[Sample(input="@not-a-file\nSay hello")],
+            solver=pi(
+                user="nobody",
+                system_prompt="pi-bridge-system-marker",
+                skills=[
+                    Path(__file__).resolve().parents[1]
+                    / "examples/skills/welcome-banner"
+                ],
+                thinking=thinking,
+                filter=record_request,
+                model="alias/with-slash",
+                model_aliases={"alias/with-slash": model},
+                max_context_size=32000,
+            ),
+            sandbox=("docker", str(compose)),
+        ),
+        model=model,
+        log_dir=str(tmp_path / "logs"),
+        time_limit=60,
+        token_limit=1000,
+        max_samples=1,
+        display="none",
+    )
+    assert requests, logs[0].error
+    first_request = requests[0]
+    assert first_request.input[0].text.count("pi-bridge-system-marker") == 1
+    assert "welcome-banner" in first_request.input[0].text
+    assert all(
+        "host-only-test-key" not in message.model_dump_json()
+        for message in first_request.input
+    )
+    assert first_request.config.reasoning_effort == expected_effort
+    assert first_request.input[-1].text == "@not-a-file\nSay hello"
+    assert {tool.name for tool in first_request.tools} >= {
+        "read",
+        "write",
+        "edit",
+        "bash",
+    }
+    assert logs[0].samples
+    assert logs[0].samples[0].error is not None

--- a/tests/test_pi_install.py
+++ b/tests/test_pi_install.py
@@ -1,0 +1,149 @@
+import json
+from pathlib import Path
+
+import anyio
+import pytest
+from inspect_ai._eval.task.sandbox import sandboxenv_context
+from inspect_ai._util.logger import init_logger
+from inspect_ai.dataset import Sample
+from inspect_ai.util import SandboxEnvironmentSpec, sandbox
+from inspect_swe._pi.agentbinary import pi_binary_source
+from inspect_swe._pi.config import pi_models_json, pi_result_error
+from inspect_swe._util.agentbinary import ensure_agent_binary_installed
+
+from tests.conftest import skip_if_no_docker
+
+
+@pytest.mark.slow
+@skip_if_no_docker
+def test_pi_offline_sandbox_install_and_cli(tmp_path: Path) -> None:
+    """Run the real standalone release in a network-isolated, non-root sandbox."""
+    init_logger(log_level="warning")
+    compose = tmp_path / "compose.yaml"
+    compose.write_text(
+        data="""services:
+  default:
+    image: python:3.12-slim
+    command: sleep infinity
+    network_mode: none
+    working_dir: /tmp
+"""
+    )
+
+    async def check() -> None:
+        async with sandboxenv_context(
+            task_name="pi-install-test",
+            sandbox=SandboxEnvironmentSpec(type="docker", config=str(compose)),
+            max_sandboxes=None,
+            cleanup=True,
+            sample=Sample(input="Install Pi"),
+        ):
+            sbox = sandbox()
+            binary = await ensure_agent_binary_installed(
+                source=pi_binary_source(), version="latest", sandbox=sbox
+            )
+            result = await sbox.exec(cmd=[binary, "--version"])
+            assert result.success, result.stderr
+            version = result.stdout.strip()
+            assert version
+            cached = await ensure_agent_binary_installed(
+                source=pi_binary_source(), version=version, sandbox=sbox
+            )
+            assert cached == binary
+            for mode in ("auto", "sandbox"):
+                linked = await sbox.exec(cmd=["ln", "-sf", binary, "/usr/local/bin/pi"])
+                assert linked.success, linked.stderr
+                assert (
+                    await ensure_agent_binary_installed(
+                        source=pi_binary_source(),
+                        version=mode,
+                        user="nobody",
+                        sandbox=sbox,
+                    )
+                    == "/usr/local/bin/pi"
+                )
+            setup = await sbox.exec(
+                cmd=["mktemp", "-d", "/tmp/inspect-pi-XXXXXXXX"], user="nobody"
+            )
+            assert setup.success, setup.stderr
+            pi_dir = setup.stdout.strip()
+            await sbox.write_file(
+                file=f"{pi_dir}/models.json",
+                contents=pi_models_json(
+                    port=1,
+                    model="openai/gpt-5-mini",
+                    context_size=400000,
+                    max_tokens=4096,
+                    reasoning=False,
+                ),
+            )
+            await sbox.write_file(
+                file=f"{pi_dir}/settings.json",
+                contents=json.dumps({"retry": {"enabled": False}}),
+            )
+            env = {
+                "PI_CODING_AGENT_DIR": pi_dir,
+                "PI_OFFLINE": "1",
+                "PI_TELEMETRY": "0",
+            }
+            result = await sbox.exec(
+                cmd=[binary, "--list-models", "inspect"],
+                env=env,
+                user="nobody",
+                cwd=pi_dir,
+                timeout=30,
+            )
+            assert result.success, result.stderr
+            assert "openai/gpt-5-mini" in result.stdout
+            prompt = "@nonexistent-pi-file\nSay hello"
+            await sbox.write_file(file=f"{pi_dir}/prompt.txt", contents=prompt)
+            result = await sbox.exec(
+                cmd=[
+                    "bash",
+                    "-c",
+                    'prompt=$1; shift; exec "$@" < "$prompt"',
+                    "bash",
+                    f"{pi_dir}/prompt.txt",
+                    binary,
+                    "--append-system-prompt",
+                    "pi-test-system-marker",
+                    "--provider",
+                    "inspect",
+                    "--model",
+                    "openai/gpt-5-mini",
+                    "--thinking",
+                    "off",
+                    "--session",
+                    f"{pi_dir}/session.jsonl",
+                    "--no-extensions",
+                    "--no-skills",
+                    "--no-prompt-templates",
+                    "--no-themes",
+                    "--no-approve",
+                    "--print",
+                    "--mode",
+                    "json",
+                ],
+                env=env,
+                user="nobody",
+                cwd=pi_dir,
+                timeout=60,
+            )
+            # No server is listening on port 1. This checks actual Pi failure events,
+            # not a fabricated CLI transcript or a replacement model implementation.
+            assert pi_result_error(stdout=result.stdout) is not None
+            assert '"stopReason":"error"' in result.stdout, (
+                result.stdout + result.stderr
+            )
+            session_text = await sbox.read_file(file=f"{pi_dir}/session.jsonl")
+            entries = [json.loads(line) for line in session_text.split("\n") if line]
+            messages = [
+                entry["message"] for entry in entries if entry["type"] == "message"
+            ]
+            assert messages[0]["role"] == "user"
+            assert messages[0]["content"][0]["text"] == prompt
+            # Pi stores conversation messages, not the system prompt. The wrapper
+            # must supply its original append-system-prompt again when resuming.
+            assert "pi-test-system-marker" not in session_text
+
+    anyio.run(check)


### PR DESCRIPTION
- goal here was to add [pi](https://pi.dev/) as a harness to inspect_swe
- I think I followed all the practices in the repo - similar to other harnesses
- Pi is a bit specific (--yolo by default, etc) - but I think should fit nicely! 
- let me know what you think! 