### PR TITLE
feat: Antigravity CLI agent

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -18,4 +18,5 @@ inspect-docs:
         - href: kimi_code.qmd
         - href: opencode.qmd
         - href: mini_swe_agent.qmd
+        - href: antigravity_cli.qmd
         - href: antigravity.qmd

--- a/docs/_snippets/agent_google_codec.md
+++ b/docs/_snippets/agent_google_codec.md
@@ -1,0 +1,5 @@
+## Host Codec {#host-codec}
+
+{{< meta agent_name >}} uses Gemini's `generateContent` wire to communicate with the Inspect bridge. The required `google-genai` codec installs automatically with `inspect-swe`.
+
+The bridge selects its Google request handler from the wire format, not the model that actually serves the request. Therefore this applies even when Inspect routes an agent's requests to Anthropic, OpenAI, or a mock model. The codec does not require a Google account, API key, or sign-in.

--- a/docs/_snippets/agent_installation.md
+++ b/docs/_snippets/agent_installation.md
@@ -7,14 +7,14 @@ If you don't ever want to rely on automatic downloads of {{< meta agent_name >}}
     {{< meta agent >}}(version="sandbox")
     ```
 
-2.  Download the version of {{< meta agent_name >}} you want to use into the cache, then specify that version explicitly:
+2.  For the agents that `download_agent_binary()` supports — `antigravity_cli`, `claude_code`, `codex_cli`, `kimi_code`, and `opencode` — download the version you want into the cache, then specify that version explicitly:
 
     ``` python
     # download the agent binary during installation/configuration
-    download_agent_binary("{{< meta agent >}}", "0.29.0", "linux-x64")
+    download_agent_binary("claude_code", "2.1.258", "linux-x64")
 
     # reference that version in your task (no download will occur)
-    {{< meta agent >}}(version="0.29.0")
+    claude_code(version="2.1.258")
     ```
 
-    Note that the 5 most recently downloaded versions are retained in the cache. Use the `cached_agent_binaries()` function to list the contents of the cache.
+    Note that for those agents the 3 most recently downloaded versions are retained in the cache. Use the `cached_agent_binaries()` function to list the contents of the cache.

--- a/docs/antigravity.qmd
+++ b/docs/antigravity.qmd
@@ -8,6 +8,8 @@ agent_url: "https://pypi.org/project/google-antigravity/"
 
 Runs Google's Antigravity SDK (`google-antigravity`, which bundles the `localharness` engine) headless inside an Inspect sandbox. Model calls are routed through the sandbox agent bridge: the SDK's native connection speaks the Gemini `generateContent` wire directly to the bridge via a `GeminiAPIEndpoint` `base_url` override (no OpenAI translation), so only a placeholder API key ever enters the sandbox.
 
+For Google's shipped Antigravity CLI (`agy`) rather than the SDK, see [`antigravity_cli()`](antigravity_cli.qmd).
+
 ## Options
 
 The following options are supported for customizing the behavior of the agent:
@@ -37,6 +39,8 @@ The agent confines the model's tool surface to the configured MCP servers and on
 `view_file` is the one builtin left enabled, because localharness offloads any large MCP tool result to a file and returns the model only a `file://` pointer. Without a read-back path every tool observation above its internal cap (~4KB) is silently lost. A policy predicate confines `view_file` to the agent's own `app_data_dir`, where those offloaded results are written: both the requested path and that directory are canonicalized with symlinks resolved, an unresolvable path is denied, and containment is compared on resolved path segments. Note this confines `view_file` to the directory rather than absolutely bounding what the harness can open, since the predicate runs in the SDK process while the file is opened by localharness.
 
 Everything the agent itself writes — the runner, `request.json` (which serializes the MCP server configs, including any `headers` an authenticated server needs), and the SDK's session store — lives in a sibling state directory outside that tree, so a server credential or the agent's own configuration is never inside `view_file`'s reach.
+
+{{< include _snippets/agent_google_codec.md >}}
 
 ## Installation
 

--- a/docs/antigravity_cli.qmd
+++ b/docs/antigravity_cli.qmd
@@ -50,6 +50,8 @@ For a CLI model that rejects the `--effort` flag, pass `effort=None`.
 
 `mcp_servers` accepts Inspect `MCPServerConfig` objects. The agent writes the native CLI MCP registry at `$HOME/.gemini/config/mcp_config.json`; stdio servers retain their command and arguments, while HTTP server URLs are written using the CLI's `serverUrl` field.
 
+For a fresh sandbox home, the agent records the native onboarding state and trusts exactly its resolved working directory. This bypasses the CLI's first-use consent and workspace-trust screens without trusting other paths. In Centaur Mode this setup does not set either tool or artifact approval policy; the person at the terminal remains the approver.
+
 Bridged tools are added to the same registry as bridge-provided MCP servers, and each of their tools is additionally marked eager (`tools.<tool>.eager`), so the CLI declares it as a native tool the model can call by name rather than routing it through its lazy MCP dispatcher. The registry key is the tool name the server serves, the same namespace as the CLI's `disabledTools` and `mcp(server/tool)` permission entries; the name the CLI then declares to the model is `mcp_<server>_<tool>`, with the server name spliced in verbatim: a tool named `echo` on a server named `inspect-tools` is declared as `mcp_inspect-tools_echo`, hyphens and all. When every server in the registry is bridge-provided, the CLI has nothing left to load lazily and declares no `call_mcp_tool` dispatcher at all. Servers you configure yourself through `mcp_servers` are left alone: their tools keep the CLI's default lazy loading, and the dispatcher is declared for them.
 
 Unattended runs pass `--disable-slash-commands`, so a prompt whose first token looks like `/something` reaches the model as text. Slash-command and skill expansion is therefore unavailable in unattended mode; it stays available to the person at the terminal in Centaur Mode.
@@ -78,7 +80,7 @@ By default, `version="auto"` uses an `agy` binary already present in the sandbox
 
 : {tbl-colwidths=\[25,75\]}
 
-`"stable"` and `"latest"` currently resolve the latest published release tag. Downloaded release assets are checksum-verified, and the agent disables the CLI's self-updater so an explicit version remains the version used in the sandbox.
+`"stable"` and `"latest"` currently resolve the latest published release tag. `antigravity_cli()` sets `AGY_CLI_DISABLE_AUTO_UPDATE=true` for every launch, so the native updater does not replace the selected binary while the sandbox is running. Downloaded release assets are checksum-verified.
 
 {{< include _snippets/agent_installation.md >}}
 

--- a/docs/antigravity_cli.qmd
+++ b/docs/antigravity_cli.qmd
@@ -1,0 +1,99 @@
+---
+title: Antigravity CLI
+agent: antigravity_cli
+agent_provider: "Google"
+agent_name: "Antigravity CLI"
+agent_url: "https://antigravity.google/docs/cli/overview"
+---
+
+`antigravity_cli()` runs the Antigravity CLI (`agy`) inside the Inspect sandbox. It is distinct from [`antigravity()`](antigravity.qmd), which runs the `google-antigravity` SDK and its localharness engine.
+
+The CLI uses its native Gemini API client, configured to call the local Inspect sandbox-agent bridge, so the model request is handled on the host. The agent sets a placeholder `GEMINI_API_KEY` only to satisfy the CLI's client-side check; it does not copy Google credentials into the sandbox.
+
+{{< include _snippets/agent_intro.md >}}
+
+## Options
+
+| Option | Description |
+|------------------------------------|------------------------------------|
+| `system_prompt` | Additional system prompt to append to the task's system prompt. |
+| `skills` | Additional [skills](https://inspect.aisi.org.uk/tools-standard.html#sec-skill) to install for the CLI. |
+| `mcp_servers` | MCP servers to configure for the CLI (see [MCP Servers](#mcp-servers) below for details). |
+| `bridged_tools` | Host-side Inspect tools to expose to the CLI through MCP (see [Bridged Tools](#bridged-tools) below for details). |
+| `mcp_ready_timeout` | Seconds to wait for bridged MCP endpoints to serve tools before agent launch errors. |
+| `centaur` | Run in [Centaur Mode](#centaur-mode), making the CLI available to an Inspect `human_cli()` agent rather than running it unattended. |
+| `attempts` | Allow multiple scored attempts at the task. |
+| `model` | Model name for the Inspect bridge. Defaults to the task's main model. |
+| `model_aliases` | Mapping of bridge model names to model names or `Model` instances. |
+| `agy_model` | Model identifier passed to `agy`. It selects the CLI's client-side model configuration; generation still goes through the Inspect bridge. Defaults to `"gemini-3.6-flash"`. |
+| `effort` | CLI reasoning effort: `"low"`, `"medium"`, `"high"`, or `None` to omit `--effort`. Defaults to `"low"`. |
+| `filter` | Filter for intercepting bridged model requests. |
+| `retry_refusals` | Number of refusal retries. |
+| `cwd` | Working directory for the CLI session. |
+| `env` | Environment variables for the CLI process. |
+| `user` | Sandbox user that runs the CLI. |
+| `sandbox` | Optional sandbox environment name. |
+| `version` | CLI version to use. See [Installation](#installation). |
+| `debug` | Trace the CLI's runner output. |
+
+: {tbl-colwidths=\[25,75\]}
+
+### Model selection
+
+`model` and `agy_model` configure different layers. `model` selects the model used by the Inspect bridge. `agy_model` is passed to the native CLI so it can select its own client-side behavior, including context-window, tool-schema, and effort handling. It does not route model requests directly to a Google endpoint.
+
+For a CLI model that rejects the `--effort` flag, pass `effort=None`.
+
+## Native CLI configuration
+
+`skills` accepts Inspect skill paths or `Skill` objects. They are installed in `<cwd>/.agents/skills` for `agy` to discover.
+
+`mcp_servers` accepts Inspect `MCPServerConfig` objects. The agent writes the native CLI MCP registry at `$HOME/.gemini/config/mcp_config.json`; stdio servers retain their command and arguments, while HTTP server URLs are written using the CLI's `serverUrl` field.
+
+Bridged tools are added to the same registry as bridge-provided MCP servers, and each of their tools is additionally marked eager (`tools.<tool>.eager`), so the CLI declares it as a native tool the model can call by name rather than routing it through its lazy MCP dispatcher. The registry key is the tool name the server serves, the same namespace as the CLI's `disabledTools` and `mcp(server/tool)` permission entries; the name the CLI then declares to the model is `mcp_<server>_<tool>`, with the server name spliced in verbatim: a tool named `echo` on a server named `inspect-tools` is declared as `mcp_inspect-tools_echo`, hyphens and all. When every server in the registry is bridge-provided, the CLI has nothing left to load lazily and declares no `call_mcp_tool` dispatcher at all. Servers you configure yourself through `mcp_servers` are left alone: their tools keep the CLI's default lazy loading, and the dispatcher is declared for them.
+
+Unattended runs pass `--disable-slash-commands`, so a prompt whose first token looks like `/something` reaches the model as text. Slash-command and skill expansion is therefore unavailable in unattended mode; it stays available to the person at the terminal in Centaur Mode.
+
+The CLI's own `search_web` tool is client-side: it reaches the network from inside the sandbox and so depends on sandbox egress. It is not Inspect's bridged web search, and `antigravity_cli()` has no web-search option.
+
+{{< include _snippets/agent_mcp_servers.md >}}
+
+{{< include _snippets/agent_bridged_tools.md >}}
+
+{{< include _snippets/agent_google_codec.md >}}
+
+## Installation
+
+The CLI binary is named `agy`. Downloaded binaries support glibc Linux sandbox targets `linux-x64` and `linux-arm64`. musl-based images, including Alpine, are not supported by the published CLI assets.
+
+By default, `version="auto"` uses an `agy` binary already present in the sandbox. If none is available, it downloads the current stable release. The `version` option selects a different behavior:
+
+| Option | Description |
+|------------------------------------|------------------------------------|
+| `"auto"` | Use `agy` available in the sandbox; otherwise download the stable release. |
+| `"sandbox"` | Use `agy` from the sandbox, raising `RuntimeError` if it is unavailable. |
+| `"stable"` | Download the current stable release. |
+| `"latest"` | Download the current latest release. |
+| `"x.x.x"` | Download that exact CLI release version. |
+
+: {tbl-colwidths=\[25,75\]}
+
+`"stable"` and `"latest"` currently resolve the latest published release tag. Downloaded release assets are checksum-verified, and the agent disables the CLI's self-updater so an explicit version remains the version used in the sandbox.
+
+{{< include _snippets/agent_installation.md >}}
+
+For the Antigravity CLI, that second approach reads:
+
+``` python
+# download the agy binary during installation/configuration
+download_agent_binary("antigravity_cli", "1.1.27", "linux-x64")
+
+# reference that version in your task (no download will occur)
+antigravity_cli(version="1.1.27")
+```
+
+{{< include _snippets/agent_centaur.md >}}
+
+In centaur mode the CLI is made available to the human as an `agy` shell alias carrying the agent's bridge configuration. The unattended-only `--dangerously-skip-permissions` flag is not passed, and the auto-approval settings the headless path writes (`toolPermission`, `artifactReviewPolicy`) are withheld as well, so the person at the terminal stays the approver for tool calls and artifact review.
+
+{{< include _snippets/agent_troubleshooting.md >}}

--- a/docs/gemini_cli.qmd
+++ b/docs/gemini_cli.qmd
@@ -45,6 +45,8 @@ For example, here we specify a custom system prompt:
 
 {{< include _snippets/agent_bridged_tools.md >}}
 
+{{< include _snippets/agent_google_codec.md >}}
+
 ## Installation
 
 By default, the agent will download the current stable version of {{< meta agent_name >}} and copy it to the sandbox. You can override this behaviour using the `version` option:

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -46,6 +46,7 @@ Then, try out one or more of the available agents:
 | [`kimi_code()`](kimi_code.qmd) | Moonshot AI's terminal-based coding agent [Kimi Code](https://github.com/MoonshotAI/kimi-code) |
 | [`opencode()`](opencode.qmd) | Provider-independent terminal-based coding agent. |
 | [`mini_swe_agent()`](mini_swe_agent.qmd) | SWE-agent's minimal 100-line agent. |
+| [`antigravity_cli()`](antigravity_cli.qmd) | Google's [Antigravity CLI](https://antigravity.google/docs/cli/overview) (`agy`). |
 | [`antigravity()`](antigravity.qmd) | Google's Antigravity SDK agent (`google-antigravity` / localharness). |
 
 

--- a/docs/reference/index.qmd
+++ b/docs/reference/index.qmd
@@ -9,8 +9,10 @@ reference: inspect_swe
 ### claude_code
 ### codex_cli
 ### gemini_cli
+### kimi_code
 ### opencode
 ### mini_swe_agent
+### antigravity_cli
 ### antigravity
 
 ## Binaries

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "anyio",
     "typing_extensions>=4.9.0",
     "agent-client-protocol>=0.11.0",
+    "google-genai>=1.69.0",
 ]
 
 [project.urls]

--- a/src/inspect_swe/__init__.py
+++ b/src/inspect_swe/__init__.py
@@ -1,4 +1,5 @@
 from ._antigravity.antigravity import antigravity
+from ._antigravity_cli.antigravity_cli import antigravity_cli
 from ._claude_code.claude_code import claude_code
 from ._codex_cli.codex_cli import codex_cli
 from ._codex_cli.config import CodexAutoReview
@@ -32,6 +33,7 @@ __all__ = [
     "acp_connection",
     "bridge_mcp_to_acp",
     "antigravity",
+    "antigravity_cli",
     "claude_code",
     "codex_cli",
     "gemini_cli",

--- a/src/inspect_swe/_antigravity_cli/__init__.py
+++ b/src/inspect_swe/_antigravity_cli/__init__.py
@@ -1,0 +1,3 @@
+from .antigravity_cli import antigravity_cli
+
+__all__ = ["antigravity_cli"]

--- a/src/inspect_swe/_antigravity_cli/agentbinary.py
+++ b/src/inspect_swe/_antigravity_cli/agentbinary.py
@@ -1,0 +1,110 @@
+import json
+from pathlib import Path
+from typing import Any
+
+from typing_extensions import Literal
+
+from .._util.agentbinary import AgentBinarySource, AgentBinaryVersion
+from .._util.appdirs import package_cache_dir
+from .._util.download import download_text_file
+from .._util.sandbox import SandboxPlatform
+from .._util.tarball import extract_tarball
+
+# The Antigravity CLI publishes signed, digest-bearing release assets on a public
+# GitHub repo, so version resolution is the same shape as codex's: read the
+# release, pick the platform asset, take its sha256 digest.
+_RELEASES_REPO = "google-antigravity/antigravity-cli"
+
+# Only glibc Linux builds are published: there is no musl asset. Fail loud on a
+# musl platform rather than installing the glibc binary, which would die at exec
+# time with an unhelpful "not found" from the loader.
+_PLATFORM_ASSETS: dict[SandboxPlatform, str] = {
+    "linux-x64": "agy_cli_linux_x64.tar.gz",
+    "linux-arm64": "agy_cli_linux_arm64.tar.gz",
+}
+
+
+def antigravity_cli_binary_source() -> AgentBinarySource:
+    cached_binary_dir = package_cache_dir("antigravity-cli-downloads")
+
+    async def resolve_version(
+        version: Literal["stable", "latest"] | str, platform: SandboxPlatform
+    ) -> AgentBinaryVersion:
+        # Resolve the platform first: an unsupported platform is knowable
+        # without the network, and reporting it as a failed release lookup
+        # (which is what an offline or rate-limited `stable` resolution raises)
+        # hides the actual cause.
+        asset_name = _PLATFORM_ASSETS.get(platform)
+        if asset_name is None:
+            raise ValueError(
+                f"Unsupported platform for the Antigravity CLI: {platform}. "
+                f"Supported: {sorted(_PLATFORM_ASSETS)}."
+            )
+
+        if version in ("stable", "latest"):
+            version = await _fetch_latest_version()
+
+        release = await _fetch_release(version)
+        assets = {
+            asset["name"]: asset
+            for asset in release.get("assets", [])
+            if isinstance(asset, dict)
+        }
+        asset = assets.get(asset_name)
+        if asset is None:
+            raise RuntimeError(
+                f"No asset {asset_name} in Antigravity CLI release {version}"
+            )
+
+        digest = asset.get("digest", "")
+        if not isinstance(digest, str) or not digest.startswith("sha256:"):
+            raise RuntimeError(f"Invalid digest format: {digest!r}")
+
+        download_url = asset.get("browser_download_url")
+        if not isinstance(download_url, str):
+            raise RuntimeError(
+                f"No download URL for asset {asset_name} in Antigravity CLI "
+                f"release {version}: {download_url!r}"
+            )
+
+        return AgentBinaryVersion(version, digest.removeprefix("sha256:"), download_url)
+
+    def cached_binary_path(version: str, platform: SandboxPlatform) -> Path:
+        return cached_binary_dir / f"agy-{version}-{platform}"
+
+    def list_cached_binaries() -> list[Path]:
+        return list(cached_binary_dir.glob("agy-*"))
+
+    return AgentBinarySource(
+        # The release asset is a tar.gz holding exactly one file (named
+        # `antigravity`), which is what extract_tarball requires -- and the file
+        # is installed under the `agy` name the CLI is invoked as.
+        agent="antigravity cli",
+        binary="agy",
+        resolve_version=resolve_version,
+        cached_binary_path=cached_binary_path,
+        list_cached_binaries=list_cached_binaries,
+        post_download=extract_tarball,
+        post_install=None,
+    )
+
+
+async def _fetch_latest_version() -> str:
+    latest = json.loads(
+        await download_text_file(
+            f"https://api.github.com/repos/{_RELEASES_REPO}/releases/latest"
+        )
+    )
+    tag_name = latest["tag_name"]
+    if not isinstance(tag_name, str):
+        raise RuntimeError(f"Unexpected tag format: {tag_name!r}")
+    # Antigravity CLI tags are bare versions ("1.1.20"), with no prefix to strip.
+    return tag_name
+
+
+async def _fetch_release(version: str) -> dict[str, Any]:
+    release_json = await download_text_file(
+        f"https://api.github.com/repos/{_RELEASES_REPO}/releases/tags/{version}"
+    )
+    result: dict[str, Any] = json.loads(release_json)
+    return result

--- a/src/inspect_swe/_antigravity_cli/antigravity_cli.py
+++ b/src/inspect_swe/_antigravity_cli/antigravity_cli.py
@@ -1,0 +1,781 @@
+import json
+import re
+import shlex
+import uuid
+from pathlib import Path
+from textwrap import dedent
+from typing import Any, Iterable, Literal, Mapping, Sequence
+
+from inspect_ai.agent import (
+    Agent,
+    AgentAttempts,
+    AgentState,
+    BridgedToolsSpec,
+    agent,
+    agent_with,
+    sandbox_agent_bridge,
+)
+from inspect_ai.model import (
+    ChatMessage,
+    ChatMessageSystem,
+    GenerateFilter,
+    Model,
+)
+from inspect_ai.scorer import score
+from inspect_ai.tool import MCPServerConfig, Skill, install_skills, read_skills
+from inspect_ai.tool._mcp._config import MCPServerConfigHTTP
+from inspect_ai.util import sandbox as sandbox_env
+from inspect_ai.util import store
+from inspect_ai.util._sandbox import ExecRemoteAwaitableOptions
+
+from .._util._async import is_callable_coroutine
+from .._util.agentbinary import ensure_agent_binary_installed
+from .._util.centaur import CentaurOptions, run_centaur
+from .._util.mcp_ready import DEFAULT_MCP_READY_TIMEOUT, wait_for_mcp_endpoints
+from .._util.messages import build_user_prompt
+from .._util.path import join_path
+from .._util.sandbox import resolve_agent_cwd
+from .._util.trace import trace
+from .agentbinary import antigravity_cli_binary_source
+
+# Reasoning efforts the CLI accepts. Narrower than most agents' scales: `agy
+# --effort` takes exactly these three, and REQUIRES one for the Gemini 3.6/3.7
+# Flash families (it exits 1 with "requires --effort" otherwise), because it
+# resolves `<model>` + `<effort>` into one catalog id (`gemini-3.6-flash-low`).
+AntigravityEffort = Literal["low", "medium", "high"]
+
+# Where the CLI keeps its persistent settings and its global MCP registry. These
+# are two different files under two different directories -- settings live with
+# the CLI's own state, MCP servers in the shared `~/.gemini/config` tree.
+_SETTINGS_DIR = ".gemini/antigravity-cli"
+_MCP_CONFIG_DIR = ".gemini/config"
+
+# The CLI states the identity of its own conversation in every primary
+# request: official 1.1.27/1.1.28 requests carry exactly one system
+# `<user_information>` block containing `Conversation ID: <UUID>`, while the
+# title-generation conversation the CLI opens alongside carries no such block.
+# That declaration is what separates the task's conversation from the CLI's own
+# auxiliary traffic -- not title text, and not whether tools were offered.
+_USER_INFORMATION_BLOCK = re.compile(
+    r"<user_information>(.*?)</user_information>", re.DOTALL
+)
+_CONVERSATION_ID_LINE = re.compile(r"^[ \t]*Conversation ID:[ \t]*(\S+)[ \t]*$", re.M)
+_USER_INFORMATION_DELIMITER = re.compile(r"</?user_information>")
+
+
+def _framed_blocks(text: str) -> list[str]:
+    """The bodies of the complete `<user_information>` blocks in one message.
+
+    The delimiters are counted and ordered before any content is read. Pairing
+    an opener with a closer cannot by itself tell an unterminated declaration
+    from an absent one, and absence is the positive signal for the CLI's
+    auxiliary title request -- so an unbalanced or out-of-order delimiter has
+    to raise rather than resolve to a block, or to nothing.
+    """
+    delimiters = _USER_INFORMATION_DELIMITER.findall(text)
+    alternating = [
+        "<user_information>" if index % 2 == 0 else "</user_information>"
+        for index in range(len(delimiters))
+    ]
+    if len(delimiters) % 2 or delimiters != alternating:
+        raise ValueError(
+            f"antigravity cli framed its <user_information> with {len(delimiters)} "
+            "delimiters that do not open and close complete blocks"
+        )
+    return _USER_INFORMATION_BLOCK.findall(text)
+
+
+def _validated_conversation_id(value: str) -> str:
+    # Returned verbatim rather than normalised: this string is compared against
+    # the id the CLI prints in its own result, and against the id a later
+    # attempt resumes by.
+    try:
+        uuid.UUID(value)
+    except ValueError as ex:
+        raise ValueError(
+            f"antigravity cli declared a malformed conversation id {value!r}"
+        ) from ex
+    return value
+
+
+def _native_conversation_id(messages: Sequence[ChatMessage]) -> str | None:
+    """Read the conversation id the CLI declared for a request.
+
+    Args:
+        messages: One request, as the model received it.
+
+    Returns:
+        The UUID from the request's single system `<user_information>` block,
+        or `None` when no system message carries such a block -- which is how
+        the CLI's auxiliary title request presents.
+
+    Raises:
+        ValueError: The declaration cannot be read unambiguously -- delimiters
+            that do not frame complete blocks, more than one block, a block
+            carrying no id, or an id that is not a UUID. Guessing would bind
+            the run to an identity the CLI's own result can never match,
+            turning a parse fault into an unattributable score.
+    """
+    blocks = [
+        block
+        for message in messages
+        if isinstance(message, ChatMessageSystem)
+        for block in _framed_blocks(message.text)
+    ]
+    if not blocks:
+        return None
+    if len(blocks) > 1:
+        raise ValueError(
+            f"antigravity cli declared {len(blocks)} <user_information> blocks "
+            "in one request; expected exactly one carrying its conversation id"
+        )
+
+    declared = _CONVERSATION_ID_LINE.findall(blocks[0])
+    if len(declared) != 1:
+        raise ValueError(
+            "antigravity cli declared a <user_information> block carrying "
+            f"{len(declared)} conversation ids; expected exactly one"
+        )
+    return _validated_conversation_id(declared[0])
+
+
+class _NativeConversation:
+    """Whose traffic is the canonical `AgentState`, and which id to resume.
+
+    `accept` is handed to the bridge as its `state_filter`, so its signature is
+    the bridge's: one request's messages in, a verdict out. Excluding a request
+    changes nothing else about it -- it still generates, still emits its own
+    producer ids and events, and still counts its usage. All exclusion does is
+    keep the CLI's auxiliary title conversation from displacing the task's.
+
+    Args:
+        unattended: Keep canonical state on ONE conversation. In centaur mode
+            the human may start or resume several, and all of them are theirs.
+        bound_id: A conversation this invocation is resuming, bound before any
+            request is filtered. Without it the first native conversation to
+            arrive takes the binding, which on a resume could be a fresh one
+            the CLI substituted rather than the one being continued.
+    """
+
+    def __init__(self, *, unattended: bool, bound_id: str | None = None) -> None:
+        self._unattended = unattended
+        self.bound_id: str | None = bound_id
+
+    def accept(self, messages: Sequence[ChatMessage]) -> bool:
+        conversation_id = _native_conversation_id(messages)
+        if conversation_id is None:
+            # The CLI's own auxiliary request. It must not become canonical,
+            # and it must not consume the binding the primary request needs.
+            return False
+
+        if self.bound_id is None:
+            self.bound_id = conversation_id
+        if not self._unattended:
+            # A human may start or resume several conversations in one session,
+            # and every one of them is theirs. The existing accumulation
+            # contract is what preserves them.
+            return True
+        # One unattended invocation, one canonical conversation.
+        return self.bound_id == conversation_id
+
+
+@agent
+def antigravity_cli(
+    name: str = "Antigravity CLI",
+    description: str = dedent("""
+       Autonomous coding agent capable of writing, testing, debugging,
+       and iterating on code across multiple languages.
+    """),
+    system_prompt: str | None = None,
+    skills: Sequence[str | Path | Skill] | None = None,
+    mcp_servers: Sequence[MCPServerConfig] | None = None,
+    bridged_tools: Sequence[BridgedToolsSpec] | None = None,
+    mcp_ready_timeout: float = DEFAULT_MCP_READY_TIMEOUT,
+    centaur: bool | CentaurOptions = False,
+    attempts: int | AgentAttempts = 1,
+    model: str | None = None,
+    model_aliases: dict[str, str | Model] | None = None,
+    agy_model: str = "gemini-3.6-flash",
+    effort: AntigravityEffort | None = "low",
+    filter: GenerateFilter | None = None,
+    retry_refusals: int | None = None,
+    cwd: str | None = None,
+    env: dict[str, str] | None = None,
+    user: str | None = None,
+    sandbox: str | None = None,
+    version: Literal["auto", "sandbox", "stable", "latest"] | str = "auto",
+    debug: bool | None = None,
+) -> Agent:
+    """Antigravity CLI agent.
+
+    Agent that uses Google's [Antigravity CLI](https://antigravity.google/docs/cli/overview)
+    (`agy`) running in a sandbox with Inspect model bridging.
+
+    Model calls are bridged the same way `gemini_cli`'s are: the CLI's direct
+    Gemini API route (`modelProvider: "gemini"`, added in `agy` 1.1.13) is
+    selected and `GOOGLE_GEMINI_BASE_URL` is pointed at the loopback
+    `sandbox_agent_bridge`, so generation never leaves the sandbox and no Google
+    sign-in happens. `GEMINI_API_KEY` is set to a placeholder purely to satisfy
+    the CLI's credential check -- the bridge does not read it.
+
+    This is a different agent from `antigravity`, which runs the
+    `google-antigravity` **SDK** rather than the shipped CLI.
+
+    Use the `attempts` option to enable additional submissions if the initial
+    submission(s) are incorrect (by default, no additional attempts are permitted).
+
+    Args:
+        name: Agent name (used in multi-agent systems with `as_tool()` and `handoff()`)
+        description: Agent description
+        system_prompt: Additional system prompt to append
+        skills: Additional [skills](https://inspect.aisi.org.uk/tools-standard.html#sec-skill) to make available to the agent.
+        mcp_servers: MCP servers to make available to the agent
+        bridged_tools: Host-side Inspect tools to expose to the agent via MCP
+        mcp_ready_timeout: Seconds to wait for bridged MCP endpoints to serve
+            tools before the agent launch errors.
+        centaur: Run in 'centaur' mode, which makes the Antigravity CLI available to an Inspect `human_cli()` agent rather than running it unattended.
+        attempts: Configure agent to make multiple attempts
+        model: Model name to use for inspect bridge (defaults to main model for task)
+        model_aliases: Optional mapping of model names to Model instances or model name strings.
+            Allows using custom Model implementations (e.g. wrapped Agents) instead of standard models.
+        agy_model: Model name to pass to the CLI. The actual model calls still go
+            through the Inspect bridge; this selects the CLI's own client-side
+            model configuration (context window, effort handling, tool schema).
+        effort: Reasoning effort to pass to the CLI. Passed explicitly by default:
+            the Gemini 3.6/3.7 Flash families that `agy` defaults to require it,
+            and leaving it implicit would let the CLI's own default decide what
+            an eval measured. Pass `None` for a model that rejects the flag.
+        filter: Filter for intercepting bridged model requests
+        retry_refusals: Should refusals be retried? (pass number of times to retry)
+        cwd: Working directory to run the CLI within
+        env: Environment variables to set for the CLI
+        user: User to execute the CLI with
+        sandbox: Optional sandbox environment name
+        version: Version of the Antigravity CLI to use. One of:
+            - "auto": Use any available version in sandbox, otherwise download latest
+            - "sandbox": Use sandbox version (raises RuntimeError if not available)
+            - "stable"/"latest": Download and use the latest version
+            - "x.x.x": Download and use a specific version
+        debug: Trace all debug output.
+    """
+    # resolve centaur
+    if centaur is True:
+        centaur = CentaurOptions()
+
+    # resolve model
+    model = f"inspect/{model}" if model is not None else "inspect"
+
+    # resolve skills
+    resolved_skills = read_skills(skills) if skills is not None else None
+
+    # resolve attempts
+    attempts = AgentAttempts(attempts) if isinstance(attempts, int) else attempts
+
+    async def execute(state: AgentState) -> AgentState:
+        # determine port (use new port for each execution of agent on sample)
+        MODEL_PORT = "antigravity_cli_model_port"
+        port = store().get(MODEL_PORT, 3000) + 1
+        store().set(MODEL_PORT, port)
+
+        # On re-entry an unattended run continues the conversation the previous
+        # invocation ran, and its id is in the canonical system block that
+        # invocation tracked -- no separate record of it is kept anywhere.
+        # Seeded here, BEFORE the bridge starts filtering, so the CLI's own
+        # first request cannot rebind canonical state to a fresh conversation.
+        # A fresh run has no such block and binds whatever the CLI declares.
+        #
+        # Only unattended runs resume by id, so only they read the incoming
+        # state as a declaration. A centaur session accumulates a conversation
+        # per thing the human started or resumed, and reading that as one
+        # declaration would make its own accumulation contract ambiguous --
+        # centaur filters per request instead, which needs no prior id.
+        prior_conversation_id = (
+            _native_conversation_id(state.messages) if centaur is False else None
+        )
+        conversation = _NativeConversation(
+            unattended=centaur is False, bound_id=prior_conversation_id
+        )
+
+        async with sandbox_agent_bridge(
+            state,
+            model=model,
+            model_aliases=model_aliases,
+            filter=filter,
+            sandbox=sandbox,
+            retry_refusals=retry_refusals,
+            port=port,
+            bridged_tools=bridged_tools,
+            state_filter=conversation.accept,
+        ) as bridge:
+            # resolve sandbox
+            sbox = sandbox_env(sandbox)
+
+            # resolve working directory (home dir if sandbox default is '/')
+            agent_cwd = await resolve_agent_cwd(sbox, user, cwd)
+
+            # install the CLI in the sandbox
+            agy_binary = await ensure_agent_binary_installed(
+                antigravity_cli_binary_source(), version, user, sbox
+            )
+
+            # detect sandbox home directory (the CLI resolves both its settings
+            # and its global MCP registry relative to $HOME)
+            home_result = await sbox.exec(["sh", "-c", "echo $HOME"], user=user)
+            sandbox_home = home_result.stdout.strip() or "/root"
+
+            # install skills
+            if resolved_skills is not None:
+                skills_dir = join_path(agent_cwd, ".agents/skills")
+                await install_skills(resolved_skills, sbox, user, skills_dir)
+
+            # mcp servers
+            all_mcp_servers = list(mcp_servers or []) + list(bridge.mcp_server_configs)
+
+            settings_dir = join_path(sandbox_home, _SETTINGS_DIR)
+            mcp_config_dir = join_path(sandbox_home, _MCP_CONFIG_DIR)
+            await sbox.exec(["mkdir", "-p", settings_dir, mcp_config_dir], user=user)
+            await sbox.write_file(
+                join_path(settings_dir, "settings.json"),
+                build_antigravity_settings(unattended=centaur is False),
+            )
+            await sbox.write_file(
+                join_path(mcp_config_dir, "mcp_config.json"),
+                build_antigravity_mcp_config(
+                    all_mcp_servers, eager_tools=bridge.bridged_tools
+                ),
+            )
+
+            # build system prompt
+            system_messages = [
+                m.text for m in state.messages if isinstance(m, ChatMessageSystem)
+            ]
+            if system_prompt is not None:
+                system_messages.append(system_prompt)
+
+            prompt, has_assistant_response = build_user_prompt(state.messages)
+
+            # A caller can hand this agent assistant turns the CLI never
+            # produced -- a synthesised or replayed transcript -- and then
+            # there is nothing to resume. Both silent options are wrong:
+            # `--continue` resumes whatever conversation the CLI has cached,
+            # which may be unrelated to this run, and starting fresh drops the
+            # context those turns carry, because the prompt built above is only
+            # the user turns AFTER the last assistant message.
+            if centaur is False and has_assistant_response:
+                if prior_conversation_id is None:
+                    raise RuntimeError(
+                        "antigravity cli cannot resume: the conversation handed "
+                        "to this agent carries assistant turns but no native "
+                        "conversation id, so there is no conversation to "
+                        "continue"
+                    )
+
+            # Prepend the system prompt to the user prompt: the CLI has no
+            # separate --system-prompt flag (same as gemini_cli).
+            if system_messages:
+                combined_system = "\n\n".join(system_messages)
+                prompt = f"{combined_system}\n\n{prompt}"
+
+            cmd = [
+                agy_binary,
+                "--model",
+                agy_model,
+                # Omitted only when explicitly disabled: models outside the
+                # 3.6/3.7 Flash families reject --effort as not adjustable.
+                *(["--effort", effort] if effort is not None else []),
+            ]
+
+            # Headless prompts stay literal, tool calls proceed without
+            # prompting, and the run's own result comes back as JSON to be
+            # verified before it is scored. All three are print-mode concerns:
+            # the human at the terminal reads the CLI's ordinary output, and
+            # there is no result envelope for us to parse on their behalf.
+            if centaur is False:
+                cmd.extend(
+                    [
+                        "--disable-slash-commands",
+                        "--dangerously-skip-permissions",
+                        "--output-format",
+                        "json",
+                    ]
+                )
+
+            agent_env = {
+                # The CLI's direct-Gemini-API route, pointed at the bridge. Both
+                # halves are required: the base URL alone leaves the CLI on its
+                # sign-in path, and the key alone leaves generation on Google's
+                # endpoint.
+                "GOOGLE_GEMINI_BASE_URL": f"http://localhost:{bridge.port}",
+                "GEMINI_API_KEY": "api-key",
+                # The CLI self-updates from its auto-updater service on startup.
+                # Left on, a run silently executes whatever version was stable
+                # that day rather than the pinned one -- the same
+                # eval-reproducibility hazard as an unpinned download.
+                "AGY_CLI_DISABLE_AUTO_UPDATE": "1",
+                # Keep logo art out of captured transcripts.
+                "AGY_CLI_HIDE_LOGO": "1",
+                "HOME": sandbox_home,
+                # No PATH: the CLI is a self-contained binary launched by
+                # absolute path, and overriding PATH would hide the image's
+                # toolchain from every command the agent runs.
+            } | (env or {})
+
+            # Gate the launch on the bridged MCP endpoints actually serving
+            # tools: the CLI blocks its first turn on MCP connect for headless
+            # runs, but only after the endpoint answers `tools/list`.
+            _http_mcp_configs = [
+                c
+                for c in bridge.mcp_server_configs
+                if isinstance(c, MCPServerConfigHTTP)
+            ]
+            if _http_mcp_configs:
+                await wait_for_mcp_endpoints(
+                    _http_mcp_configs,
+                    bridge,
+                    sandbox=sandbox,
+                    timeout=mcp_ready_timeout,
+                    required=True,
+                )
+
+            if centaur:
+                await _run_antigravity_cli_centaur(
+                    options=centaur,
+                    agy_cmd=cmd,
+                    agent_env=agent_env,
+                    state=bridge.state,
+                    user=user,
+                    sandbox=sandbox,
+                    cwd=agent_cwd,
+                )
+            else:
+                debug_output: list[str] = []
+                agent_prompt = prompt
+                attempt_count = 0
+
+                while True:
+                    agent_cmd = cmd.copy()
+
+                    # Resume by id, never with `--continue`: the id names the
+                    # conversation this run is continuing or has already
+                    # verified, rather than whatever the CLI would select on
+                    # our behalf. A first attempt with nothing to resume names
+                    # nothing -- preassigning an id the CLI does not know makes
+                    # it warn and create a different conversation.
+                    if has_assistant_response or attempt_count > 0:
+                        if conversation.bound_id is None:
+                            raise RuntimeError(
+                                "antigravity cli never declared a conversation "
+                                "id, so there is nothing to resume"
+                            )
+                        agent_cmd.extend(["--conversation", conversation.bound_id])
+
+                    agent_cmd.extend(["--print", agent_prompt])
+
+                    if _http_mcp_configs and attempt_count > 0:
+                        await wait_for_mcp_endpoints(
+                            _http_mcp_configs,
+                            bridge,
+                            sandbox=sandbox,
+                            timeout=mcp_ready_timeout,
+                            required=True,
+                        )
+                    result = await sbox.exec_remote(
+                        cmd=["bash", "-c", 'exec 0</dev/null; "$@"', "bash"]
+                        + agent_cmd,
+                        options=ExecRemoteAwaitableOptions(
+                            cwd=agent_cwd,
+                            env=agent_env,
+                            user=user,
+                            concurrency=False,
+                        ),
+                        stream=False,
+                    )
+
+                    if debug:
+                        debug_output.append(result.stdout)
+                        debug_output.append(result.stderr)
+
+                    if not result.success:
+                        raise RuntimeError(
+                            f"Error executing antigravity cli agent {result.returncode}: "
+                            f"{_clean_antigravity_error(result.stdout, result.stderr)}"
+                        )
+
+                    # Exit zero says nothing about whether the conversation
+                    # succeeded, or about which conversation ran: the CLI
+                    # reports a failed conversation while exiting zero. Both
+                    # are checked here, before this attempt can be scored or
+                    # its state returned.
+                    _verify_native_result(result.stdout, conversation.bound_id)
+
+                    attempt_count += 1
+                    if attempt_count >= attempts.attempts:
+                        break
+
+                    answer_scores = await score(bridge.state)
+                    if attempts.score_value(answer_scores[0].value) == 1.0:
+                        break
+
+                    if callable(attempts.incorrect_message):
+                        if not is_callable_coroutine(attempts.incorrect_message):
+                            raise ValueError(
+                                "The incorrect_message function must be async."
+                            )
+                        agent_prompt = await attempts.incorrect_message(
+                            bridge.state, answer_scores
+                        )
+                    else:
+                        agent_prompt = attempts.incorrect_message
+
+                if debug:
+                    debug_output.insert(0, "Antigravity CLI Debug Output:")
+                    trace("\n".join(debug_output))
+
+        return bridge.state
+
+    return agent_with(execute, name=name, description=description)
+
+
+def build_antigravity_settings(*, unattended: bool = True) -> str:
+    """Build Antigravity CLI settings.json content.
+
+    `modelProvider` is the load-bearing key: it selects the direct Gemini API
+    route (`GEMINI_API_KEY` + `GOOGLE_GEMINI_BASE_URL`) instead of the OAuth
+    sign-in the CLI otherwise blocks on. Everything else here removes a way for
+    a headless run to stall or to reach outside the sandbox.
+
+    Args:
+        unattended: Write the policies that keep a headless run from stalling
+            on an approval it cannot answer. Withheld in centaur mode, where
+            the human at the terminal is the approver.
+    """
+    settings: dict[str, Any] = {
+        "modelProvider": "gemini",
+        # The CLI's own terminal sandbox. Isolation is the Inspect sandbox's job;
+        # the CLI's needs unprivileged user namespaces, which container policy
+        # typically denies.
+        #
+        # The four booleans below MUST be JSON booleans, not the "on"/"off"
+        # strings the settings documentation uses for them. A string is dropped
+        # on load with no error and no rewrite of the file, so `settings.json`
+        # keeps saying "off" while `/config` reports the default -- which is how
+        # the first cut of this shipped with telemetry still enabled.
+        "enableTerminalSandbox": False,
+        # No usage statistics or crash reports off-box from an eval run.
+        "enableTelemetry": False,
+        "showTips": False,
+        "showFeedbackSurvey": False,
+        # Sequential stdout rather than the alternate screen buffer: the run is
+        # captured as text, and alt-screen escape sequences corrupt it.
+        "altScreenMode": "never",
+    }
+    if unattended:
+        # Nothing is watching this run, so neither policy can be left to
+        # prompt. `--dangerously-skip-permissions` already covers tool
+        # permissions for a print-mode run -- the CLI says as much when it
+        # auto-denies one ("Settings allow-rules do not apply; re-run with
+        # --dangerously-skip-permissions to auto-approve all tools") -- but
+        # the persisted artifact-review policy is still honored, and its
+        # default ("asks-for-review") is a prompt nobody is there to answer.
+        #
+        # Centaur mode gets neither. That flag is withheld there so the human
+        # approves, exactly as gemini_cli withholds --yolo, and a settings
+        # file that auto-approves everything would quietly take that back.
+        settings["toolPermission"] = "always-proceed"
+        settings["artifactReviewPolicy"] = "always-proceed"
+    return json.dumps(settings, indent=2)
+
+
+def build_antigravity_mcp_config(
+    mcp_servers: Sequence[MCPServerConfig],
+    eager_tools: Mapping[str, Iterable[str]],
+) -> str:
+    """Build Antigravity CLI mcp_config.json content.
+
+    The CLI's remote-server schema names the endpoint `serverUrl`; the `url` and
+    `httpUrl` spellings other agents accept are silently ignored, which presents
+    as a server that is configured but never connects.
+
+    MCP tools are otherwise loaded LAZILY: the CLI declares one native
+    dispatcher (`call_mcp_tool`) and routes every MCP tool through it, so a
+    bridged Inspect tool is never a tool the model can call by name. Listing a
+    tool under the server's `tools` map with `eager: true` registers it as a
+    native tool instead. The key is the name the server itself serves -- the
+    same namespace as the CLI's `disabledTools` and its `mcp(server/tool)`
+    permission syntax; the model-facing `mcp_<server>_<tool>` spelling is
+    derived by the CLI, so writing that here would mark nothing.
+
+    Args:
+        mcp_servers: Servers to write into the registry.
+        eager_tools: Bridged tool names by server name (the bridge's
+            `bridged_tools` registry). Only these servers are marked; anything
+            the caller configured itself keeps the CLI's native lazy loading.
+    """
+    servers: dict[str, Any] = {}
+    for server in mcp_servers:
+        config = server.model_dump(exclude={"name", "tools", "type"}, exclude_none=True)
+        if isinstance(server, MCPServerConfigHTTP) and "url" in config:
+            config["serverUrl"] = config.pop("url")
+        if "cwd" in config and not isinstance(config["cwd"], str):
+            config["cwd"] = str(config["cwd"])
+        eager = sorted(eager_tools.get(server.name, ()))
+        if eager:
+            config["tools"] = {name: {"eager": True} for name in eager}
+        servers[server.name] = config
+    return json.dumps({"mcpServers": servers}, indent=2)
+
+
+# Opaque base64 payloads the CLI prints on stdout -- Gemini thought signatures,
+# emitted one per reasoning turn. They carry no diagnostic text, and a long run
+# emits enough of them to fill any error budget, so they are replaced by a short
+# placeholder before truncation rather than being allowed to evict the real
+# message. 200 chars is well above any base64 token that might carry meaning and
+# well below the ~2KB signatures.
+_OPAQUE_BLOB = re.compile(r"[A-Za-z0-9+/]{200,}={0,2}")
+_MAX_ERROR_LEN = 20000
+
+
+def _clean_antigravity_error(stdout: str, stderr: str) -> str:
+    """Trim the CLI's failure output down to something readable in a traceback.
+
+    stderr is placed FIRST and stdout second: the CLI reports its actual failure
+    reason on stderr (e.g. "Error: timeout waiting for response") while stdout
+    carries the reasoning stream. Concatenating stdout first pushed every real
+    error past the truncation limit, so a failed run surfaced as a wall of
+    base64 with no cause in it.
+    """
+
+    def scrub(text: str) -> str:
+        kept = [
+            line for line in text.split("\n") if not line.strip().startswith("<think")
+        ]
+        return _OPAQUE_BLOB.sub(
+            lambda match: f"<{len(match.group(0))}-char opaque payload>",
+            "\n".join(kept),
+        ).strip()
+
+    sections = [
+        f"{label}:\n{body}"
+        for label, body in (("STDERR", scrub(stderr)), ("STDOUT", scrub(stdout)))
+        if body
+    ]
+    cleaned = "\n\n".join(sections).strip()
+    if len(cleaned) > _MAX_ERROR_LEN:
+        cleaned = cleaned[:_MAX_ERROR_LEN] + "... (truncated)"
+    return cleaned if cleaned else "Unknown error (no output)"
+
+
+def _native_result_json(stdout: str) -> Mapping[str, Any]:
+    """Return the CLI's JSON result, which is the whole of headless stdout.
+
+    The `--output-format json` artifact is exactly one JSON object, carrying
+    `conversation_id`, `status`, `response` and the run's usage totals.
+    Anything else is a failure rather than something to search past: no
+    object, a truncated one, or a second one after it all mean this attempt
+    did not report its own result, and an earlier object cannot vouch for an
+    attempt whose result never arrived. The CLI's stream-json dialect is a
+    different envelope and is not read here.
+    """
+    try:
+        parsed: Any = json.loads(stdout.strip())
+    except json.JSONDecodeError as ex:
+        raise RuntimeError(
+            "antigravity cli did not print exactly one JSON result on stdout "
+            f"({ex.msg}): {_clean_antigravity_error(stdout, '')}"
+        ) from ex
+
+    if not isinstance(parsed, dict):
+        raise RuntimeError(
+            f"antigravity cli printed a JSON {type(parsed).__name__} rather "
+            f"than a result object: {_clean_antigravity_error(stdout, '')}"
+        )
+    return parsed
+
+
+def _verify_native_result(stdout: str, conversation_id: str | None) -> None:
+    """Check the CLI's own result before this attempt is scored or returned.
+
+    Only identity and status are read here. The envelope's aggregate
+    `response` is deliberately never adopted: canonical output stays the
+    bridge's real `ModelOutput`, messages, producer ids and usage.
+
+    Args:
+        stdout: Headless stdout, whose final JSON object is the CLI's result.
+        conversation_id: The conversation this invocation bound, or `None` when
+            it never saw the CLI open one -- itself a failure, not a wildcard.
+
+    Raises:
+        RuntimeError: There is no readable result, its status is not SUCCESS,
+            this run bound no conversation, or the result names another one or
+            none at all. None of these is covered by the process exit status --
+            the CLI reports a failed conversation while exiting zero -- and
+            each would otherwise be scored as an ordinary run, on a transcript
+            nobody can attribute.
+    """
+    result = _native_result_json(stdout)
+
+    status = result.get("status")
+    if status != "SUCCESS":
+        raise RuntimeError(
+            f"antigravity cli reported status {status!r} for conversation "
+            f"{result.get('conversation_id')!r}; expected SUCCESS"
+        )
+
+    # Comparing the two directly would let a run with no identity on either
+    # side match itself: nothing bound, nothing named, and a success reported
+    # for an attempt with no transcript behind it. Each side is required in its
+    # own right, and only then compared.
+    if conversation_id is None:
+        raise RuntimeError(
+            "antigravity cli reported success for conversation "
+            f"{result.get('conversation_id')!r}, but this run bound no "
+            "conversation at all: it never saw the CLI declare one, so there "
+            "is nothing here to attribute this result to"
+        )
+
+    returned = result.get("conversation_id")
+    if not isinstance(returned, str):
+        raise RuntimeError(
+            f"antigravity cli reported success with conversation id {returned!r} "
+            f"({type(returned).__name__}) rather than a string, while this run "
+            f"bound {conversation_id!r}; refusing to score a result whose own "
+            "identity cannot be read"
+        )
+
+    if returned != conversation_id:
+        raise RuntimeError(
+            f"antigravity cli returned conversation {returned!r} but this run "
+            f"bound {conversation_id!r}; refusing to score a conversation it "
+            "did not run"
+        )
+
+
+async def _run_antigravity_cli_centaur(
+    options: CentaurOptions,
+    agy_cmd: list[str],
+    agent_env: dict[str, str],
+    state: AgentState,
+    *,
+    user: str | None,
+    sandbox: str | None,
+    cwd: str,
+) -> None:
+    instructions = (
+        "Antigravity CLI:\n\n"
+        " - You may also use the Antigravity CLI via the 'agy' command.\n"
+        " - Use 'agy --continue' if you need to resume a previous session."
+    )
+
+    # Only the vars the alias needs: exporting HOME would break human_cli.
+    centaur_env = {k: v for k, v in agent_env.items() if k != "HOME"}
+    agent_env_vars = [f'export {k}="{v}"' for k, v in centaur_env.items()]
+    alias_cmd = shlex.join(agy_cmd)
+    alias_cmd = "alias agy='" + alias_cmd.replace("'", "'\\''") + "'"
+    # The shell starts where this agent's own commands would have run. `agy`
+    # resolves relative paths and writes its artifacts against the working
+    # directory, and a login shell would otherwise start at the image's
+    # default -- `/` for most images, which is not what the task set up.
+    cd_cmd = f"cd {shlex.quote(cwd)}"
+    bashrc = "\n".join(agent_env_vars + ["", cd_cmd, alias_cmd])
+
+    await run_centaur(options, instructions, bashrc, state, user=user, sandbox=sandbox)

--- a/src/inspect_swe/_antigravity_cli/antigravity_cli.py
+++ b/src/inspect_swe/_antigravity_cli/antigravity_cli.py
@@ -23,7 +23,7 @@ from inspect_ai.model import (
 )
 from inspect_ai.scorer import score
 from inspect_ai.tool import MCPServerConfig, Skill, install_skills, read_skills
-from inspect_ai.tool._mcp._config import MCPServerConfigHTTP
+from inspect_ai.tool._mcp._config import MCPServerConfigHTTP, MCPServerConfigStdio
 from inspect_ai.util import sandbox as sandbox_env
 from inspect_ai.util import store
 from inspect_ai.util._sandbox import ExecRemoteAwaitableOptions
@@ -410,24 +410,9 @@ def antigravity_cli(
                     ]
                 )
 
-            agent_env = {
-                # The CLI's direct-Gemini-API route, pointed at the bridge. Both
-                # halves are required: the base URL alone leaves the CLI on its
-                # sign-in path, and the key alone leaves generation on Google's
-                # endpoint.
-                "GOOGLE_GEMINI_BASE_URL": f"http://localhost:{bridge.port}",
-                "GEMINI_API_KEY": "api-key",
-                # The CLI self-updates from its auto-updater service on startup.
-                # The actual native switch is the literal string "true"; "1" is
-                # ignored and lets a pinned binary replace itself.
-                "AGY_CLI_DISABLE_AUTO_UPDATE": "true",
-                # Keep logo art out of captured transcripts.
-                "AGY_CLI_HIDE_LOGO": "1",
-                "HOME": sandbox_home,
-                # No PATH: the CLI is a self-contained binary launched by
-                # absolute path, and overriding PATH would hide the image's
-                # toolchain from every command the agent runs.
-            } | (env or {})
+            agent_env = build_antigravity_agent_env(
+                bridge_port=bridge.port, sandbox_home=sandbox_home, env=env
+            )
 
             # Gate the launch on the bridged MCP endpoints actually serving
             # tools: the CLI blocks its first turn on MCP connect for headless
@@ -595,6 +580,63 @@ def build_antigravity_settings(*, unattended: bool = True) -> str:
     return json.dumps(settings, indent=2)
 
 
+def build_antigravity_agent_env(
+    *,
+    bridge_port: int,
+    sandbox_home: str,
+    env: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Environment for the Antigravity CLI subprocess.
+
+    Args:
+        bridge_port: Port of the in-sandbox bridge the agent's model calls
+            go to.
+        sandbox_home: Detected sandbox $HOME (the CLI resolves both its
+            settings and its global MCP registry relative to this).
+        env: Caller overrides. Applied for everything except the two keys
+            that define the credential boundary itself -- caller values win
+            on conflict there, same contract as `claude_code_agent_env` --
+            but `GOOGLE_GEMINI_BASE_URL` and `GEMINI_API_KEY` are forced
+            unconditionally. Unlike `ANTHROPIC_BASE_URL`/`ANTHROPIC_AUTH_TOKEN`
+            in `claude_code_agent_env`, where AGENTS.md documents caller
+            override of the model-provider route/credential as an accepted,
+            deliberate escape hatch, a caller here (e.g. one passing
+            `env=os.environ.copy()`) must not be able to silently redirect
+            generation off the bridge onto Google's real endpoint, or inject
+            a real Google credential into the sandbox: those two keys ARE the
+            boundary, not a convenience default.
+
+    Returns:
+        The merged environment. `GOOGLE_GEMINI_BASE_URL` and `GEMINI_API_KEY`
+        always point at the bridge; every other key follows the caller's
+        `env` when supplied.
+    """
+    return (
+        {
+            # The CLI self-updates from its auto-updater service on startup. The
+            # actual native switch is the literal string "true"; "1" is ignored
+            # and lets a pinned binary replace itself.
+            "AGY_CLI_DISABLE_AUTO_UPDATE": "true",
+            # Keep logo art out of captured transcripts.
+            "AGY_CLI_HIDE_LOGO": "1",
+            "HOME": sandbox_home,
+            # No PATH: the CLI is a self-contained binary launched by absolute
+            # path, and overriding PATH would hide the image's toolchain from
+            # every command the agent runs.
+        }
+        | (env or {})
+        | {
+            # The CLI's direct-Gemini-API route, pointed at the bridge. Both
+            # halves are required: the base URL alone leaves the CLI on its
+            # sign-in path, and the key alone leaves generation on Google's
+            # endpoint. Applied AFTER the caller's `env` so neither key can be
+            # silently overridden -- these two ARE the credential boundary.
+            "GOOGLE_GEMINI_BASE_URL": f"http://localhost:{bridge_port}",
+            "GEMINI_API_KEY": "api-key",
+        }
+    )
+
+
 def _workspace_settings(*, unattended: bool, workspace: str) -> str:
     """Build settings for exactly the workspace the CLI process will use."""
     settings: dict[str, Any] = json.loads(
@@ -640,9 +682,45 @@ def build_antigravity_mcp_config(
         eager_tools: Bridged tool names by server name (the bridge's
             `bridged_tools` registry). Only these servers are marked; anything
             the caller configured itself keeps the CLI's native lazy loading.
+
+    Raises:
+        ValueError: If a server carries transport credentials -- HTTP
+            `headers` or stdio `env` -- that would be written verbatim into
+            `$HOME/.gemini/config/mcp_config.json`. That file sits inside the
+            sandboxed CLI's own $HOME, where the evaluated agent's own tools
+            can read it just as readily as the CLI does, so a real credential
+            placed there crosses the sandbox credential boundary (AGENTS.md,
+            "Agent Guardrails"). Bridge-owned servers (built from
+            `bridged_tools`) never carry credentials, so this only affects
+            servers the caller passes directly via `mcp_servers`; route an
+            authenticated server through `bridged_tools` instead.
     """
     servers: dict[str, Any] = {}
     for server in mcp_servers:
+        if isinstance(server, MCPServerConfigHTTP) and server.headers:
+            raise ValueError(
+                f"MCP server {server.name!r} passed to `mcp_servers` carries "
+                "HTTP headers (e.g. an Authorization token). Antigravity CLI "
+                "persists this registry verbatim to "
+                "$HOME/.gemini/config/mcp_config.json inside the sandbox, "
+                "which the evaluated CLI -- and any of its tools -- can read, "
+                "so a real credential placed here crosses the credential "
+                "boundary (see AGENTS.md, 'Agent Guardrails'). Expose an "
+                "authenticated server via `bridged_tools` instead, which "
+                "keeps real credentials out of the sandbox entirely."
+            )
+        if isinstance(server, MCPServerConfigStdio) and server.env:
+            raise ValueError(
+                f"MCP server {server.name!r} passed to `mcp_servers` carries "
+                "an `env` map that may hold real credentials. Antigravity CLI "
+                "persists this registry verbatim to "
+                "$HOME/.gemini/config/mcp_config.json inside the sandbox, "
+                "which the evaluated CLI -- and any of its tools -- can read, "
+                "so a real credential placed here crosses the credential "
+                "boundary (see AGENTS.md, 'Agent Guardrails'). Expose an "
+                "authenticated server via `bridged_tools` instead, which "
+                "keeps real credentials out of the sandbox entirely."
+            )
         config = server.model_dump(exclude={"name", "tools", "type"}, exclude_none=True)
         if isinstance(server, MCPServerConfigHTTP) and "url" in config:
             config["serverUrl"] = config.pop("url")

--- a/src/inspect_swe/_antigravity_cli/antigravity_cli.py
+++ b/src/inspect_swe/_antigravity_cli/antigravity_cli.py
@@ -5,6 +5,7 @@ import uuid
 from pathlib import Path
 from textwrap import dedent
 from typing import Any, Iterable, Literal, Mapping, Sequence
+from urllib.parse import urlsplit
 
 from inspect_ai.agent import (
     Agent,
@@ -658,6 +659,39 @@ def _completed_onboarding() -> str:
     )
 
 
+# WHATWG 'special' schemes: a parser following that standard re-reads a missing `//`
+# into an authority for these, so a credential can hide behind the shorter spelling.
+_SPECIAL_URL_SCHEMES: frozenset[str] = frozenset({"http", "https", "ws", "wss", "ftp"})
+
+
+def _url_carries_credentials(url: str) -> bool:
+    """Whether an HTTP/SSE MCP URL embeds Basic credentials in its userinfo.
+
+    Parsed rather than pattern-matched: `urlsplit` isolates the authority, so a
+    password containing `@` or `/`, or a path or query that merely contains `@`,
+    is classified on structure instead of on the first matching character. A URL
+    too malformed to parse is treated as carrying credentials -- the sandbox
+    boundary is the wrong place to guess.
+
+    An http(s) URL with no `//` is treated the same way. `urlsplit` reads
+    `https:user:pw@host/mcp` as a scheme plus an opaque path, so it reports no
+    userinfo at all -- while a WHATWG special-URL parser, which is what a browser
+    or a JS/Go client uses, normalizes exactly that string back to
+    `https://user:pw@host/mcp` and sends the Basic credential. Refusing rather
+    than guessing which parser the CLI reaches for: either way the secret would
+    already be sitting in the sandbox-readable registry.
+    """
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        return True
+    if parts.scheme in _SPECIAL_URL_SCHEMES and not url[
+        len(parts.scheme) + 1 :
+    ].startswith("//"):
+        return True
+    return bool(parts.username or parts.password)
+
+
 def build_antigravity_mcp_config(
     mcp_servers: Sequence[MCPServerConfig],
     eager_tools: Mapping[str, Iterable[str]],
@@ -702,6 +736,24 @@ def build_antigravity_mcp_config(
                 f"MCP server {server.name!r} passed to `mcp_servers` carries "
                 "HTTP headers (e.g. an Authorization token). Antigravity CLI "
                 "persists this registry verbatim to "
+                "$HOME/.gemini/config/mcp_config.json inside the sandbox, "
+                "which the evaluated CLI -- and any of its tools -- can read, "
+                "so a real credential placed here crosses the credential "
+                "boundary (see AGENTS.md, 'Agent Guardrails'). Expose an "
+                "authenticated server via `bridged_tools` instead, which "
+                "keeps real credentials out of the sandbox entirely."
+            )
+        if isinstance(server, MCPServerConfigHTTP) and _url_carries_credentials(
+            server.url
+        ):
+            # Basic auth in the URL is the same credential as an Authorization
+            # header, and it lands in the same sandbox-readable file -- the
+            # header check above would otherwise be trivially bypassed by
+            # moving the secret into the userinfo component.
+            raise ValueError(
+                f"MCP server {server.name!r} passed to `mcp_servers` carries a "
+                "username or password in its URL (HTTP Basic credentials). "
+                "Antigravity CLI persists this registry verbatim to "
                 "$HOME/.gemini/config/mcp_config.json inside the sandbox, "
                 "which the evaluated CLI -- and any of its tools -- can read, "
                 "so a real credential placed here crosses the credential "

--- a/src/inspect_swe/_antigravity_cli/antigravity_cli.py
+++ b/src/inspect_swe/_antigravity_cli/antigravity_cli.py
@@ -49,6 +49,8 @@ AntigravityEffort = Literal["low", "medium", "high"]
 # the CLI's own state, MCP servers in the shared `~/.gemini/config` tree.
 _SETTINGS_DIR = ".gemini/antigravity-cli"
 _MCP_CONFIG_DIR = ".gemini/config"
+_ONBOARDING_CACHE_DIR = f"{_SETTINGS_DIR}/cache"
+_ONBOARDING_FILE = f"{_ONBOARDING_CACHE_DIR}/onboarding.json"
 
 # The CLI states the identity of its own conversation in every primary
 # request: official 1.1.27/1.1.28 requests carry exactly one system
@@ -332,11 +334,19 @@ def antigravity_cli(
             all_mcp_servers = list(mcp_servers or []) + list(bridge.mcp_server_configs)
 
             settings_dir = join_path(sandbox_home, _SETTINGS_DIR)
+            onboarding_cache_dir = join_path(sandbox_home, _ONBOARDING_CACHE_DIR)
             mcp_config_dir = join_path(sandbox_home, _MCP_CONFIG_DIR)
-            await sbox.exec(["mkdir", "-p", settings_dir, mcp_config_dir], user=user)
+            await sbox.exec(
+                ["mkdir", "-p", settings_dir, onboarding_cache_dir, mcp_config_dir],
+                user=user,
+            )
             await sbox.write_file(
                 join_path(settings_dir, "settings.json"),
-                build_antigravity_settings(unattended=centaur is False),
+                _workspace_settings(unattended=centaur is False, workspace=agent_cwd),
+            )
+            await sbox.write_file(
+                join_path(sandbox_home, _ONBOARDING_FILE),
+                _completed_onboarding(),
             )
             await sbox.write_file(
                 join_path(mcp_config_dir, "mcp_config.json"),
@@ -408,10 +418,9 @@ def antigravity_cli(
                 "GOOGLE_GEMINI_BASE_URL": f"http://localhost:{bridge.port}",
                 "GEMINI_API_KEY": "api-key",
                 # The CLI self-updates from its auto-updater service on startup.
-                # Left on, a run silently executes whatever version was stable
-                # that day rather than the pinned one -- the same
-                # eval-reproducibility hazard as an unpinned download.
-                "AGY_CLI_DISABLE_AUTO_UPDATE": "1",
+                # The actual native switch is the literal string "true"; "1" is
+                # ignored and lets a pinned binary replace itself.
+                "AGY_CLI_DISABLE_AUTO_UPDATE": "true",
                 # Keep logo art out of captured transcripts.
                 "AGY_CLI_HIDE_LOGO": "1",
                 "HOME": sandbox_home,
@@ -584,6 +593,27 @@ def build_antigravity_settings(*, unattended: bool = True) -> str:
         settings["toolPermission"] = "always-proceed"
         settings["artifactReviewPolicy"] = "always-proceed"
     return json.dumps(settings, indent=2)
+
+
+def _workspace_settings(*, unattended: bool, workspace: str) -> str:
+    """Build settings for exactly the workspace the CLI process will use."""
+    settings: dict[str, Any] = json.loads(
+        build_antigravity_settings(unattended=unattended)
+    )
+    settings["trustedWorkspaces"] = [workspace]
+    return json.dumps(settings, indent=2)
+
+
+def _completed_onboarding() -> str:
+    """Native onboarding state that keeps a fresh sandbox at its CLI prompt."""
+    return json.dumps(
+        {
+            "consumerOnboardingComplete": True,
+            "enterpriseOnboardingComplete": False,
+            "onboardingComplete": True,
+        },
+        indent=2,
+    )
 
 
 def build_antigravity_mcp_config(

--- a/src/inspect_swe/_codex_cli/_bundled_catalog.py
+++ b/src/inspect_swe/_codex_cli/_bundled_catalog.py
@@ -11,7 +11,7 @@ valid ``--model`` slugs for prefix matching, they just never count as "latest"
 (see ``latest_openai_slug``).
 
 Snapshot source: ``openai/codex`` ``codex-rs/models-manager/models.json``
-(``rust-v0.153.2``, September 2026). Refresh when bumping the default Codex
+(``rust-v0.153.4``, September 2026). Refresh when bumping the default Codex
 version; the live fetch keeps this exact when ``raw.githubusercontent.com`` is
 reachable, and ``tests/test_codex_agentbinary.py::test_bundled_catalog_tracks_live_latest``
 flags drift.
@@ -24,7 +24,7 @@ BUNDLED_CODEX_CATALOG: dict[str, Any] = {
         {
             "slug": "gpt-6-astra",
             "priority": 1,
-            "visibility": "hide",
+            "visibility": "list",
             "apply_patch_tool_type": "freeform",
             "supports_search_tool": True,
         },

--- a/src/inspect_swe/_registry.py
+++ b/src/inspect_swe/_registry.py
@@ -1,6 +1,7 @@
 # ruff: noqa: F401
 
 from ._antigravity.antigravity import antigravity
+from ._antigravity_cli.antigravity_cli import antigravity_cli
 from ._claude_code.claude_code import claude_code
 from ._codex_cli.codex_cli import codex_cli
 from ._gemini_cli.gemini_cli import gemini_cli
@@ -10,6 +11,7 @@ from ._opencode.opencode import opencode
 
 __all__ = [
     "antigravity",
+    "antigravity_cli",
     "codex_cli",
     "claude_code",
     "gemini_cli",

--- a/src/inspect_swe/_tools/download.py
+++ b/src/inspect_swe/_tools/download.py
@@ -2,6 +2,7 @@ import re
 from pathlib import Path
 from typing import Literal, NamedTuple, get_args
 
+from .._antigravity_cli.agentbinary import antigravity_cli_binary_source
 from .._claude_code.agentbinary import claude_code_binary_source
 from .._codex_cli.agentbinary import codex_cli_binary_source
 from .._kimi_code.agentbinary import kimi_code_binary_source
@@ -18,7 +19,9 @@ from .._util.sandbox import SandboxPlatform
 class AgentBinary(NamedTuple):
     """Agent binary."""
 
-    agent: Literal["claude_code", "codex_cli", "kimi_code", "opencode"]
+    agent: Literal[
+        "antigravity_cli", "claude_code", "codex_cli", "kimi_code", "opencode"
+    ]
     """Agent type."""
 
     version: str
@@ -54,13 +57,15 @@ class AgentBinaries(list[AgentBinary]):
 
 
 def download_agent_binary(
-    binary: Literal["claude_code", "codex_cli", "kimi_code", "opencode"],
+    binary: Literal[
+        "antigravity_cli", "claude_code", "codex_cli", "kimi_code", "opencode"
+    ],
     version: Literal["stable", "latest"] | str,
     platform: SandboxPlatform,
 ) -> None:
     """Download agent binary.
 
-    Download an agent binary. This version will be added to the cache of downloaded versions (which retains the 5 most recently downloaded versions).
+    Download an agent binary. This version will be added to the cache of downloaded versions (which retains the 3 most recently downloaded versions).
 
     Use this if you need to ensure that a specific version of an agent binary is downloaded in advance (e.g. if you are going to run your evaluations offline). After downloading, explicit requests for the downloaded version (e.g. `claude_code(version="1.0.98")`) will not require network access.
 
@@ -75,7 +80,10 @@ def download_agent_binary(
 
 
 def cached_agent_binaries(
-    binary: Literal["claude_code", "codex_cli", "kimi_code", "opencode"] | None = None,
+    binary: Literal[
+        "antigravity_cli", "claude_code", "codex_cli", "kimi_code", "opencode"
+    ]
+    | None = None,
     quiet: bool = False,
 ) -> AgentBinaries:
     """List the agent binaries which have been cached on this system.
@@ -90,7 +98,8 @@ def cached_agent_binaries(
     """
     if binary is None:
         return AgentBinaries(
-            cached_agent_binaries("claude_code")
+            cached_agent_binaries("antigravity_cli")
+            + cached_agent_binaries("claude_code")
             + cached_agent_binaries("codex_cli")
             + cached_agent_binaries("kimi_code")
             + cached_agent_binaries("opencode")
@@ -141,7 +150,9 @@ def cached_agent_binaries(
 
 
 def resolve_agent_version(
-    agent: Literal["claude_code", "codex_cli", "kimi_code", "opencode"],
+    agent: Literal[
+        "antigravity_cli", "claude_code", "codex_cli", "kimi_code", "opencode"
+    ],
     version: Literal["stable", "latest"] | str,
     platform: SandboxPlatform = "linux-x64",
 ) -> str:
@@ -171,9 +182,13 @@ def resolve_agent_version(
 
 
 def _agent_binary_source(
-    binary: Literal["claude_code", "codex_cli", "kimi_code", "opencode"],
+    binary: Literal[
+        "antigravity_cli", "claude_code", "codex_cli", "kimi_code", "opencode"
+    ],
 ) -> AgentBinarySource:
     match binary:
+        case "antigravity_cli":
+            return antigravity_cli_binary_source()
         case "claude_code":
             return claude_code_binary_source()
         case "codex_cli":
@@ -185,5 +200,5 @@ def _agent_binary_source(
         case _:
             raise ValueError(
                 f"Unsupported agent binary type: {binary} "
-                "(expected one of claude_code, codex_cli, kimi_code, opencode)"
+                "(expected one of antigravity_cli, claude_code, codex_cli, kimi_code, opencode)"
             )

--- a/src/inspect_swe/_util/centaur.py
+++ b/src/inspect_swe/_util/centaur.py
@@ -1,4 +1,7 @@
+from contextlib import AbstractContextManager, nullcontext
+
 from inspect_ai.agent import AgentState, human_cli, run
+from inspect_ai.util import sandbox_default
 from pydantic import BaseModel, Field
 
 
@@ -20,13 +23,42 @@ class CentaurOptions(BaseModel):
 
 
 async def run_centaur(
-    options: CentaurOptions, instructions: str, bashrc: str, state: AgentState
+    options: CentaurOptions,
+    instructions: str,
+    bashrc: str,
+    state: AgentState,
+    *,
+    user: str | None = None,
+    sandbox: str | None = None,
 ) -> None:
-    agent = human_cli(
-        answer=options.answer,
-        intermediate_scoring=options.intermediate_scoring,
-        record_session=options.record_session,
-        instructions=instructions,
-        bashrc=bashrc,
+    """Hand the session to the human, in the environment the agent resolved.
+
+    Args:
+        options: Options for centaur mode.
+        instructions: Instructions beyond the default task command instructions.
+        bashrc: Additional content for the human cli shell's .bashrc.
+        state: Agent state to run the human session against.
+        user: User to open the session as, or `None` for the sandbox
+            environment's own default.
+        sandbox: Name of the sandbox to run the session in, or `None` to leave
+            the ambient default alone.
+
+    A named sandbox has to become the default for the whole session, not just
+    for one call within it: `human_cli` installs the task tools and offers the
+    login through unnamed lookups of its own, so a wrapper that resolved a
+    named sandbox for its own launch would otherwise hand the human a terminal
+    in a different container from the one it installed into.
+    """
+    selected: AbstractContextManager[None] = (
+        sandbox_default(sandbox) if sandbox is not None else nullcontext()
     )
-    await run(agent, state)
+    with selected:
+        agent = human_cli(
+            answer=options.answer,
+            intermediate_scoring=options.intermediate_scoring,
+            record_session=options.record_session,
+            user=user,
+            instructions=instructions,
+            bashrc=bashrc,
+        )
+        await run(agent, state)

--- a/tests/agy_two_sandboxes_compose.yaml
+++ b/tests/agy_two_sandboxes_compose.yaml
@@ -1,0 +1,20 @@
+# Two identical containers, so that "which sandbox" is a question with a wrong
+# answer. `default` is a decoy: it is what an unnamed lookup resolves to, and
+# nothing in a run that selected `target` should ever touch it.
+#
+# Both services are the definition Inspect generates for a bare `sandbox="docker"`
+# (image, command, init, no network, short stop grace), so a test using this file
+# runs against the same container the rest of the suite does.
+services:
+  default:
+    image: "aisiuk/inspect-tool-support"
+    command: "tail -f /dev/null"
+    init: true
+    network_mode: none
+    stop_grace_period: 1s
+  target:
+    image: "aisiuk/inspect-tool-support"
+    command: "tail -f /dev/null"
+    init: true
+    network_mode: none
+    stop_grace_period: 1s

--- a/tests/test_antigravity_cli.py
+++ b/tests/test_antigravity_cli.py
@@ -1,0 +1,1419 @@
+"""End-to-end coverage for the native Antigravity CLI (`agy`) agent.
+
+`tests/test_antigravity_cli_config.py` and
+`tests/test_antigravity_cli_error_reporting.py` cover the on-disk configuration
+and the failure-reporting helper as pure units. Neither runs the CLI, so neither
+can catch the launch itself not working: a flag the binary rejects, a settings
+key that no longer selects the direct-Gemini route, or a tool call that reaches
+the CLI and executes nothing.
+
+The two round-trip tests here run the pinned binary for real. Only the *model* is
+scripted -- via the keyless `mockllm` provider, so no Google credentials and no
+network generation are involved -- and it is reached through the real
+`sandbox_agent_bridge` over loopback, exactly as a live run reaches a real
+model. The CLI, its tools, the bridge and the sandbox are all genuine.
+
+The first has the CLI execute its own `run_command` tool to write and read back
+a harmless fixture file, asserted against that file's real content in the
+sandbox. The second exposes a host-side Inspect tool over the bridge's MCP
+endpoint and has the CLI call it, asserted against that host tool's real return
+value arriving back in the sandbox.
+
+Both scripted argument sets are the ones the pinned CLI's own declarations mark
+required: `CommandLine`, `Cwd`, `WaitMsBeforeAsync`, `toolAction` and
+`toolSummary` for `run_command`; the tool's own `message` plus `toolSummary`
+and `toolAction` for the bridged tool, which the CLI declares under a
+server-qualified name of its own making rather than the host's. Omitting a
+required key, or using the host-side name, is rejected before the tool runs.
+
+Three further Docker tests inspect the launch rather than run one. They install
+the pinned binary for real and capture what the agent builds -- the command,
+the environment it carries and the settings file it writes -- to pin which
+controls belong to the unattended path, which of them are withheld from the
+command a human is handed in centaur mode, and that a disabled reasoning effort
+is really left off. They are launch-contract inspections, not native proof:
+the unattended two stop the run at the launch rather than let a CLI that never
+ran appear to have produced a result. `effort=None` cannot be a real launch at
+all -- the CLI's default model rejects the flag's absence -- which is the same
+reason these are inspections.
+
+A last test covers the shared agent-binary tooling and needs neither Docker nor
+the network.
+"""
+
+import json
+from collections.abc import Sequence
+from importlib import import_module
+from pathlib import Path
+from typing import Any, Literal
+from unittest.mock import patch
+
+import anyio
+import pytest
+from inspect_ai import Task, eval
+from inspect_ai.agent import Agent, AgentState, BridgedToolsSpec, agent, run
+from inspect_ai.dataset import Sample
+from inspect_ai.log import EvalSample, resolve_sample_attachments
+from inspect_ai.model import (
+    ChatMessage,
+    ChatMessageAssistant,
+    ChatMessageSystem,
+    ChatMessageTool,
+    ChatMessageUser,
+    GenerateConfig,
+    ModelOutput,
+    get_model,
+)
+from inspect_ai.scorer import Score, Scorer, Target, scorer
+from inspect_ai.solver import Generate, Solver, TaskState, solver
+from inspect_ai.tool import Tool, ToolChoice, ToolInfo, tool
+from inspect_ai.util import (
+    ExecRemoteAwaitableOptions,
+    ExecResult,
+    SandboxEnvironment,
+    sandbox,
+)
+from inspect_swe import antigravity_cli
+from inspect_swe._antigravity_cli import agentbinary
+from inspect_swe._antigravity_cli.antigravity_cli import (
+    AntigravityEffort,
+    _native_conversation_id,
+)
+from inspect_swe._tools import download as download_tool
+from inspect_swe._util import centaur as centaur_module
+from inspect_swe._util.sandbox import SANDBOX_INSTALL_DIR
+
+from tests.conftest import skip_if_no_docker
+
+# The package rebinds `antigravity_cli` to the agent factory, so both
+# `from inspect_swe._antigravity_cli import antigravity_cli` and
+# `import inspect_swe._antigravity_cli.antigravity_cli as m` hand back that
+# function rather than the module -- and `patch.object` on a function fails.
+# Naming a member, as the import above does, reaches the module properly;
+# resolve the module itself here for the launch tests to patch.
+agy_module = import_module("inspect_swe._antigravity_cli.antigravity_cli")
+
+# Pinned rather than "auto"/"latest" so the run is reproducible, and so an
+# upstream flag or tool-schema change surfaces here as a deliberate version
+# bump rather than as a test that quietly started exercising something else.
+_CLI_VERSION = "1.1.27"
+
+_MODEL = "mockllm/model"
+
+_FIXTURE_DIR = "/tmp"
+_FIXTURE_PATH = f"{_FIXTURE_DIR}/antigravity-cli-fixture.txt"
+_FIXTURE_CONTENT = "antigravity-cli-fixture"
+
+# Absolute paths inside the command, so what the assertions read back does not
+# depend on how the CLI resolves the tool's `Cwd`.
+_COMMAND_LINE = (
+    f"printf %s '{_FIXTURE_CONTENT}' > {_FIXTURE_PATH} && cat {_FIXTURE_PATH}"
+)
+
+_RUN_COMMAND_ARGS: dict[str, Any] = {
+    "CommandLine": _COMMAND_LINE,
+    "Cwd": _FIXTURE_DIR,
+    # Synchronous: wait for the command rather than backgrounding it, so its
+    # output lands in the tool result. 10000ms is the declared maximum.
+    "WaitMsBeforeAsync": 10000,
+    "toolAction": "Running command",
+    "toolSummary": "Command execution",
+}
+
+_FINAL_ANSWER = f"The fixture file contains {_FIXTURE_CONTENT}."
+
+
+class _ScriptedModel:
+    """Drive the CLI to one `run_command` call, then let it finish.
+
+    Scripted on conversation *state* rather than on call count: the tool call is
+    returned until a tool result comes back, then the final text. A CLI that
+    issues an extra request (a retry, a summarization turn) therefore cannot
+    desynchronize the script or exhaust it -- which a fixed list of outputs
+    would, since `mockllm` raises once its outputs run out.
+    """
+
+    def __init__(self) -> None:
+        self.declared_tools: list[str] = []
+        self.requests = 0
+
+    def __call__(
+        self,
+        input: list[ChatMessage],
+        tools: list[ToolInfo],
+        tool_choice: ToolChoice,
+        config: GenerateConfig,
+    ) -> ModelOutput:
+        self.requests += 1
+        if not self.declared_tools:
+            self.declared_tools = [info.name for info in tools]
+
+        answered = any(isinstance(message, ChatMessageTool) for message in input)
+        if answered:
+            return ModelOutput.from_content(model=_MODEL, content=_FINAL_ANSWER)
+        return ModelOutput.for_tool_call(
+            model=_MODEL,
+            tool_name="run_command",
+            tool_arguments=_RUN_COMMAND_ARGS,
+        )
+
+
+@scorer(metrics=[])
+def fixture_file_written() -> Scorer:
+    """Read the fixture file back out of the sandbox the CLI actually ran in."""
+
+    async def score(state: TaskState, target: Target) -> Score:
+        result = await sandbox().exec(["cat", _FIXTURE_PATH])
+        if not result.success:
+            return Score(
+                value=0,
+                explanation=(
+                    f"{_FIXTURE_PATH} was not created by the CLI: {result.stderr}"
+                ),
+            )
+        if result.stdout != _FIXTURE_CONTENT:
+            return Score(
+                value=0,
+                explanation=(
+                    f"{_FIXTURE_PATH} holds {result.stdout!r}, "
+                    f"expected {_FIXTURE_CONTENT!r}"
+                ),
+            )
+        return Score(value=1, explanation="the CLI wrote the fixture file")
+
+    return score
+
+
+def _bridged_requests(sample: EvalSample) -> list[list[Any]]:
+    """Every conversation the bridge served, in order, as the model saw it.
+
+    Read from the model events rather than from `sample.messages`.
+    `bridge.state` holds ONE conversation, and `agy` opens a second of its own:
+    a tool-free request with its own system prompt ("You are a conversation
+    title generator") carrying the task prompt as its user message. The
+    sample's own message list is whichever of the two the bridge ended up
+    bound to, which is not necessarily the task's -- in the run this was
+    written against it was the title generator's, so the task's tool result
+    and final answer were absent from `sample.messages` entirely while both
+    were plainly present in the requests.
+
+    Attachments are resolved first, exactly as `_env_block_counts` in
+    tests/test_multi_call.py does: a sample straight out of `eval()` carries
+    `attachment://` placeholders in place of long message text.
+    """
+    sample = resolve_sample_attachments(sample, "full")
+    return [
+        list(getattr(event, "input", []))
+        for event in sample.events
+        if getattr(event, "event", None) == "model"
+    ]
+
+
+@skip_if_no_docker
+@pytest.mark.slow
+def test_native_cli_executes_a_tool_call_over_the_bridge() -> None:
+    scripted = _ScriptedModel()
+    task = Task(
+        dataset=[
+            Sample(
+                input=(
+                    f"Write {_FIXTURE_CONTENT} to {_FIXTURE_PATH}, read it back, "
+                    "and tell me what it contains."
+                ),
+                target=_FIXTURE_CONTENT,
+            )
+        ],
+        solver=antigravity_cli(cwd=_FIXTURE_DIR, version=_CLI_VERSION),
+        scorer=fixture_file_written(),
+        sandbox="docker",
+    )
+
+    # Bounded on time for the reason conftest.run_example bounds its evals:
+    # nothing else caps a wedged CLI, and an unbounded stall reports as an
+    # opaque pytest timeout rather than as a failure. No token limit -- the
+    # scripted model reports no usage, so a token ceiling would never trip.
+    logs = eval(
+        task,
+        model=get_model(_MODEL, custom_outputs=scripted),
+        limit=1,
+        time_limit=300,
+    )
+
+    assert len(logs) == 1
+    log = logs[0]
+    assert log.status == "success", f"CLI run failed: {log.error}"
+    assert log.samples
+
+    # The CLI reached the bridge at all, and offered the model the tool this
+    # test drives: a CLI that stopped declaring `run_command` would otherwise
+    # be indistinguishable from a model that simply chose not to call it.
+    assert scripted.requests > 0, "the CLI made no bridged model request"
+    assert "run_command" in scripted.declared_tools, scripted.declared_tools
+
+    # The command really ran. This reads the file in the sandbox, not a
+    # transcript of an intent to write it.
+    sample = log.samples[0]
+    assert sample.scores
+    score_value = list(sample.scores.values())[0]
+    assert score_value.value == 1, score_value.explanation
+
+    # --- what the bridge carried (supplement) -----------------------------
+    #
+    # The requests are every conversation the bridge served. They localize a
+    # failure: if these pass and the canonical assertions below do not, the
+    # round trip worked and the eval lost it.
+    requests = _bridged_requests(sample)
+    assert requests, "the eval recorded no bridged model requests"
+
+    # The call the CLI executed is the call that was scripted. Only
+    # `CommandLine` is asserted: these messages are the CLI's own replay of its
+    # history, and which advisory fields it echoes there is not this contract.
+    #
+    # The ids are the CLI's, taken from that same replay. The bridge hands back
+    # an id of its own making and the CLI substitutes its own, so a result can
+    # only be paired to its call within one replay -- not against the id the
+    # bridge returned.
+    executed = {
+        call.id: call
+        for messages in requests
+        for message in messages
+        if isinstance(message, ChatMessageAssistant)
+        for call in (message.tool_calls or [])
+        if call.function == "run_command"
+    }
+    assert executed, "no run_command call was recorded"
+    assert any(
+        call.arguments.get("CommandLine") == _COMMAND_LINE for call in executed.values()
+    ), [call.arguments for call in executed.values()]
+
+    # ...and its output came back to the model through the bridge, linked by id
+    # to the call it answers rather than merely sharing its name.
+    tool_results = [
+        message
+        for messages in requests
+        for message in messages
+        if isinstance(message, ChatMessageTool)
+        and message.function == "run_command"
+        and message.tool_call_id in executed
+    ]
+    assert tool_results, "no run_command result was bridged back"
+    assert any(_FIXTURE_CONTENT in message.text for message in tool_results), [
+        message.text for message in tool_results
+    ]
+
+    # --- what the eval recorded (acceptance) ------------------------------
+    #
+    # `sample.output` and `sample.messages` are the canonical record: they are
+    # all an ordinary scorer ever sees, so `includes()` or `model_graded_qa()`
+    # would grade these and nothing else. A round trip the eval failed to
+    # record is not a round trip a user can score, which is why acceptance
+    # lives here and not on the requests above.
+    #
+    # `agy` also opens a tool-free "conversation title generator" conversation
+    # whose user message is the task prompt, and `bridge.state` can end up
+    # bound to that one instead of the task's. A sample recording it carries
+    # the title generator's system prompt, no tool result and no answer, and
+    # has to fail here.
+    assert _FINAL_ANSWER in sample.output.completion, (
+        "the sample did not record the answer the bridge served -- canonical "
+        f"state lost: {sample.output.completion!r}"
+    )
+
+    recorded_results = [
+        message
+        for message in sample.messages
+        if isinstance(message, ChatMessageTool) and message.function == "run_command"
+    ]
+    assert recorded_results, (
+        "the sample recorded no run_command result -- canonical state lost; "
+        f"roles recorded: {[message.role for message in sample.messages]}"
+    )
+    assert any(_FIXTURE_CONTENT in message.text for message in recorded_results), [
+        message.text for message in recorded_results
+    ]
+
+
+# --- bridged tools over MCP -------------------------------------------------
+
+# The CLI renames a bridged MCP tool rather than declaring it under the name
+# the host registered: `echo` on server `inspect-tools` reaches the model as
+# `mcp_inspect-tools_echo`. The server name is spliced in verbatim, hyphens and
+# all -- read off the tool declarations of a real run rather than inferred.
+# The hyphen is the point: the conventional name for the bridged server is
+# hyphenated, so an underscore-only stand-in leaves the path every caller
+# actually takes unexercised.
+#
+# The derived name is also the only name the CLI will execute. A call naming
+# anything it has not declared comes back as
+# `unknown tool: "<name>" -- check spelling`, delivered as a tool RESULT rather
+# than as a failed run, so nothing errors and the agent simply never gets its
+# answer. That is why the declared name is asserted rather than assumed.
+_MCP_SERVER = "inspect-tools"
+_ECHO_DECLARED_TOOL = "mcp_inspect-tools_echo"
+# The dispatcher the CLI declares INSTEAD of the tools themselves when they are
+# not exposed eagerly. With every host tool exposed, it has nothing left to
+# route and is absent from the declaration entirely.
+_LAZY_DISPATCHER = "call_mcp_tool"
+_ECHO_PREFIX = "echoed: "
+_ECHO_MESSAGE = "antigravity-mcp-round-trip"
+_ECHO_FINAL_ANSWER = "Done."
+
+# Every key the CLI's declaration of the bridged tool marks required: the
+# tool's own `message` argument, plus the two advisory strings the CLI attaches
+# to every tool it declares. The declaration sets additionalProperties=false.
+_ECHO_ARGS: dict[str, Any] = {
+    "message": _ECHO_MESSAGE,
+    "toolSummary": "MCP echo call",
+    "toolAction": "Calling MCP tool",
+}
+
+
+@tool
+def echo() -> Tool:
+    async def execute(message: str) -> str:
+        """Echo a message back verbatim.
+
+        Args:
+            message: The message to echo.
+        """
+        return f"{_ECHO_PREFIX}{message}"
+
+    return execute
+
+
+class _McpRoundTrip:
+    """Call the bridged echo tool once through the CLI, then finish.
+
+    Scripted on conversation state exactly as `_ScriptedModel` is, and for the
+    same reason. The declared names are recorded from the first request that
+    carries any: the CLI's opening request was observed to declare no tools,
+    and it issues auxiliary requests of its own, so no ordering beyond "the
+    first non-empty declaration" is assumed.
+    """
+
+    def __init__(self) -> None:
+        self.declared: list[str] = []
+
+    def __call__(
+        self,
+        input: list[ChatMessage],
+        tools: list[ToolInfo],
+        tool_choice: ToolChoice,
+        config: GenerateConfig,
+    ) -> ModelOutput:
+        if not self.declared:
+            self.declared = [info.name for info in tools]
+
+        if any(isinstance(message, ChatMessageTool) for message in input):
+            return ModelOutput.from_content(model=_MODEL, content=_ECHO_FINAL_ANSWER)
+        return ModelOutput.for_tool_call(
+            model=_MODEL,
+            tool_name=_ECHO_DECLARED_TOOL,
+            tool_arguments=_ECHO_ARGS,
+        )
+
+
+@skip_if_no_docker
+@pytest.mark.slow
+def test_native_cli_calls_a_bridged_tool_under_its_declared_name() -> None:
+    scripted = _McpRoundTrip()
+    task = Task(
+        dataset=[
+            Sample(
+                input=f"Echo {_ECHO_MESSAGE} using the {_MCP_SERVER} MCP server.",
+                target=_ECHO_MESSAGE,
+            )
+        ],
+        solver=antigravity_cli(
+            bridged_tools=[BridgedToolsSpec(name=_MCP_SERVER, tools=[echo()])],
+            cwd=_FIXTURE_DIR,
+            version=_CLI_VERSION,
+        ),
+        sandbox="docker",
+    )
+
+    logs = eval(
+        task,
+        model=get_model(_MODEL, custom_outputs=scripted),
+        limit=1,
+        time_limit=300,
+    )
+
+    assert len(logs) == 1
+    log = logs[0]
+    # Reaching the model proves the loopback MCP endpoint really served
+    # tools/list: with bridged tools present the agent gates its launch on
+    # wait_for_mcp_endpoints(required=True), so a dead endpoint errors the run
+    # before any generation happens.
+    assert log.status == "success", f"CLI run failed: {log.error}"
+    assert log.samples
+    assert scripted.declared, "the CLI made no bridged model request"
+
+    declared = sorted(scripted.declared)
+    # Recorded unconditionally: the declared surface IS the subject of this
+    # test, so a reader should never have to infer it from source or re-run to
+    # see what the CLI actually offered.
+    print(f"declared tools: {declared}")
+
+    # The bridged tool is declared, under the CLI's server-qualified name...
+    assert _ECHO_DECLARED_TOOL in declared, declared
+    # ...and the lazy dispatcher is not declared at all. A model that called it
+    # would get `unknown tool` back as a tool RESULT, not an error, so its
+    # absence has to be asserted rather than discovered.
+    assert _LAZY_DISPATCHER not in declared, declared
+
+    # --- what the bridge carried (supplement) -----------------------------
+    #
+    # As in the other round trip: these show what the bridge served, so a
+    # failure below separates "the round trip broke" from "the eval lost it".
+    sample = log.samples[0]
+    requests = _bridged_requests(sample)
+    assert requests, "the eval recorded no bridged model requests"
+
+    # The model reached the tool under the declared name, which is the only
+    # name the CLI will execute.
+    dispatched = {
+        call.id: call
+        for messages in requests
+        for message in messages
+        if isinstance(message, ChatMessageAssistant)
+        for call in (message.tool_calls or [])
+        if call.function == _ECHO_DECLARED_TOOL
+    }
+    assert dispatched, f"no {_ECHO_DECLARED_TOOL} call was recorded"
+    assert any(
+        call.arguments.get("message") == _ECHO_MESSAGE for call in dispatched.values()
+    ), [call.arguments for call in dispatched.values()]
+
+    # The host-side tool really ran, and its result is linked by id to that
+    # call. This is its return value, produced in the eval process and carried
+    # back into the sandbox over the bridge's MCP endpoint -- not text the CLI
+    # could have synthesized.
+    results = [
+        message
+        for messages in requests
+        for message in messages
+        if isinstance(message, ChatMessageTool)
+        and message.function == _ECHO_DECLARED_TOOL
+        and message.tool_call_id in dispatched
+    ]
+    assert results, f"no {_ECHO_DECLARED_TOOL} result was bridged back"
+    assert any(
+        f"{_ECHO_PREFIX}{_ECHO_MESSAGE}" in message.text for message in results
+    ), [message.text for message in results]
+
+    # ...and the eval recorded it, which is the only form a scorer can read.
+    # Acceptance, as in the other round trip; a sample bound to `agy`'s own
+    # title-generator conversation has none of this and fails here.
+    recorded = [
+        message
+        for message in sample.messages
+        if isinstance(message, ChatMessageTool)
+        and message.function == _ECHO_DECLARED_TOOL
+    ]
+    assert recorded, (
+        f"the sample recorded no {_ECHO_DECLARED_TOOL} result -- canonical "
+        f"state lost; roles recorded: {[message.role for message in sample.messages]}"
+    )
+    assert any(
+        f"{_ECHO_PREFIX}{_ECHO_MESSAGE}" in message.text for message in recorded
+    ), [message.text for message in recorded]
+    assert _ECHO_FINAL_ANSWER in sample.output.completion, (
+        "the sample did not record the answer the bridge served -- canonical "
+        f"state lost: {sample.output.completion!r}"
+    )
+
+
+# --- public download/cache API ----------------------------------------------
+
+
+def test_cached_agent_binaries_recognizes_the_antigravity_cli(tmp_path: Path) -> None:
+    """The shared binary tooling is this agent's only public install surface.
+
+    `antigravity_cli` is installed through the same `AgentBinarySource` flow as
+    `claude_code` and `codex_cli`, and its factory is module-private like
+    theirs, so `download_agent_binary` / `cached_agent_binaries` are the only
+    way a caller can pre-download or inspect its binaries.
+
+    Only the cache directory is redirected here: the artifacts are created at
+    the paths the source itself names, and found by the source's own listing.
+    The name written, the listing that finds it and the parse that reads a
+    version back out are one contract, and a mismatch anywhere in it leaves a
+    downloaded binary invisible to every caller and silently re-downloaded on
+    each run. It also pins the naming, which follows the binary
+    (`agy-<version>-<platform>`) rather than the agent.
+    """
+    with patch.object(agentbinary, "package_cache_dir", return_value=tmp_path):
+        source = agentbinary.antigravity_cli_binary_source()
+        for version in ("1.1.20", "1.1.27"):
+            source.cached_binary_path(version, "linux-x64").write_bytes(b"binary")
+
+        cached = download_tool.cached_agent_binaries("antigravity_cli")
+
+    # Newest first, and attributed to this agent.
+    assert [binary.version for binary in cached] == ["1.1.27", "1.1.20"]
+    assert {binary.agent for binary in cached} == {"antigravity_cli"}
+    assert {binary.path.name for binary in cached} == {
+        "agy-1.1.27-linux-x64",
+        "agy-1.1.20-linux-x64",
+    }
+    assert all(binary.path.exists() for binary in cached)
+
+
+# --- unattended vs centaur launch -------------------------------------------
+
+# Print-mode controls, and they belong to the unattended launch only. The task
+# prompt has to stay literal (one beginning with `/` would otherwise expand as
+# a slash command) and tool calls have to proceed unprompted. In centaur mode
+# the human at the terminal types their own prompts and is the approver, so
+# both are withheld from the command they are handed.
+_PRINT_MODE_FLAGS = ("--disable-slash-commands", "--dangerously-skip-permissions")
+
+
+_LAUNCH_INSPECTED = "antigravity launch inspected; the CLI is not run here"
+
+
+class _LaunchInspected(Exception):
+    """Ends a run at the launch, because there is no CLI result to carry on with.
+
+    The alternative is to hand back a result the CLI never produced, and a
+    result nobody can attribute to a real run is exactly what this agent's own
+    verification exists to reject. Rather than weaken that check for the tests
+    that never intended to run anything, the inspection stops here and says so
+    by name, so a run that failed for any other reason cannot be mistaken for
+    one of these.
+    """
+
+
+class _CaptureLaunch:
+    """The real sandbox, except the agent's launch is captured, not run.
+
+    Everything the agent does to prepare -- installing the binary, probing
+    `$HOME`, writing settings and the MCP registry -- goes through to the real
+    sandbox. `write_file` is recorded on its way through, so the settings the
+    CLI would read are the ones asserted on. Only `exec_remote`, the launch
+    itself, is intercepted, so the captured command and environment are the
+    ones the agent genuinely built.
+    """
+
+    def __init__(self, inner: SandboxEnvironment) -> None:
+        self._inner = inner
+        self.cmd: list[str] = []
+        self.env: dict[str, str] = {}
+        self.written: dict[str, str] = {}
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._inner, name)
+
+    async def write_file(self, file: str, contents: str | bytes) -> None:
+        if isinstance(contents, str):
+            self.written[file] = contents
+        await self._inner.write_file(file, contents)
+
+    async def exec_remote(
+        self,
+        cmd: list[str],
+        options: ExecRemoteAwaitableOptions | None = None,
+        *,
+        stream: Literal[False],
+    ) -> ExecResult[str]:
+        self.cmd = list(cmd)
+        self.env = dict(getattr(options, "env", None) or {})
+        raise _LaunchInspected(_LAUNCH_INSPECTED)
+
+
+def _settings_written(launch: _CaptureLaunch) -> dict[str, Any]:
+    """Read back the settings.json the agent wrote into the sandbox."""
+    paths = [path for path in launch.written if path.endswith("settings.json")]
+    assert len(paths) == 1, sorted(launch.written)
+    parsed: dict[str, Any] = json.loads(launch.written[paths[0]])
+    return parsed
+
+
+_LAUNCH_PROMPT = "Say nothing."
+
+
+def _launch_task(centaur: bool, effort: AntigravityEffort | None = "low") -> Task:
+    return Task(
+        dataset=[Sample(input=_LAUNCH_PROMPT, target="nothing")],
+        solver=antigravity_cli(
+            centaur=centaur, cwd=_FIXTURE_DIR, effort=effort, version=_CLI_VERSION
+        ),
+        sandbox="docker",
+    )
+
+
+def _unattended_launch(effort: AntigravityEffort | None) -> _CaptureLaunch:
+    """Take the agent as far as building its unattended launch, and capture it.
+
+    The run ends there, at the sentinel, rather than in a score: everything up
+    to the launch is real, and nothing after it happened at all.
+    """
+    launches: list[_CaptureLaunch] = []
+
+    def capture_sandbox(name: str | None = None) -> Any:
+        captured = _CaptureLaunch(sandbox(name))
+        launches.append(captured)
+        return captured
+
+    with patch.object(agy_module, "sandbox_env", capture_sandbox):
+        logs = eval(
+            _launch_task(centaur=False, effort=effort),
+            model=_MODEL,
+            limit=1,
+            time_limit=300,
+        )
+
+    # The sentinel, not merely "it failed": a broken image, a failed install or
+    # a bad settings file would also end the run, and none of those reached the
+    # launch this inspection is about.
+    error = logs[0].error
+    assert logs[0].status == "error" and error is not None, logs[0].status
+    reported = f"{error.message}\n{error.traceback}"
+    assert _LAUNCH_INSPECTED in reported, reported
+    assert launches, "the agent never resolved a sandbox"
+    launch = launches[0]
+    cmd = launch.cmd
+    assert cmd, "the agent never launched the CLI"
+    # The pinned binary was really installed and is what is being launched, so
+    # every assertion below reads a complete command rather than a stub. The
+    # version is matched as a substring: the artifact name ends in the sandbox
+    # platform, which differs on an arm64 host.
+    assert any(f"agy-{_CLI_VERSION}" in arg for arg in cmd), cmd
+
+    # The image's own PATH is left alone. The CLI is a self-contained binary
+    # launched by absolute path, so it needs nothing from PATH -- while every
+    # command the agent goes on to run needs the image's toolchain, which a
+    # replacement PATH would hide.
+    assert "PATH" not in launch.env, sorted(launch.env)
+    # Withheld, not "no environment was built": the bridge route is still set,
+    # which is what keeps generation on loopback instead of Google's endpoint.
+    assert launch.env["GOOGLE_GEMINI_BASE_URL"].startswith("http://localhost:")
+
+    # Nobody is watching an unattended run, so both approval policies have to
+    # be in the settings file the CLI reads.
+    settings = _settings_written(launch)
+    assert settings["toolPermission"] == "always-proceed"
+    assert settings["artifactReviewPolicy"] == "always-proceed"
+    return launch
+
+
+@skip_if_no_docker
+@pytest.mark.slow
+def test_unattended_launch_carries_the_print_mode_flags() -> None:
+    cmd = _unattended_launch(effort="low").cmd
+
+    for flag in _PRINT_MODE_FLAGS:
+        assert flag in cmd, cmd
+    # The prompt is delivered by the agent rather than typed by a human, and it
+    # is delivered as `--print`'s own argument. A `--print` whose prompt landed
+    # anywhere else leaves the CLI reading a stdin that is closed here, so it
+    # would answer nothing at all.
+    assert "--print" in cmd, cmd
+    assert _LAUNCH_PROMPT in cmd[cmd.index("--print") + 1], cmd
+    # Reasoning effort is passed as asked rather than left to the CLI's own
+    # default, which would otherwise decide what an eval measured.
+    assert "--effort" in cmd, cmd
+    assert cmd[cmd.index("--effort") + 1] == "low", cmd
+    # The headless result is read as the CLI's own JSON: identity and status
+    # come from that envelope, so `text` would leave nothing to verify the run
+    # against before it is scored.
+    assert "--output-format" in cmd, cmd
+    assert cmd[cmd.index("--output-format") + 1] == "json", cmd
+
+
+@skip_if_no_docker
+@pytest.mark.slow
+def test_disabling_effort_withholds_the_flag_entirely() -> None:
+    """`effort=None` is the escape hatch for a model that rejects the flag.
+
+    `agy --effort` is only adjustable on the model families the CLI defaults
+    to; passing it for any other model exits 1 before the run starts. A default
+    that leaked through would therefore break exactly the configuration the
+    option exists to serve, at launch rather than as a visible rejection of the
+    option itself.
+    """
+    cmd = _unattended_launch(effort=None).cmd
+
+    assert "--effort" not in cmd, cmd
+    # ...and not under some other spelling either.
+    assert "low" not in cmd, cmd
+    # Withheld, not "the command was never built".
+    assert "--model" in cmd, cmd
+    assert "--print" in cmd, cmd
+
+
+@skip_if_no_docker
+@pytest.mark.slow
+def test_centaur_launch_withholds_the_print_mode_flags() -> None:
+    handed: list[list[str]] = []
+    handed_env: list[dict[str, str]] = []
+    handed_cwd: list[str] = []
+    launches: list[_CaptureLaunch] = []
+
+    async def capture_centaur(
+        options: Any,
+        agy_cmd: list[str],
+        agent_env: dict[str, str],
+        state: Any,
+        *,
+        user: str | None,
+        sandbox: str | None,
+        cwd: str,
+    ) -> None:
+        handed.append(list(agy_cmd))
+        handed_env.append(dict(agent_env))
+        handed_cwd.append(cwd)
+
+    def capture_sandbox(name: str | None = None) -> Any:
+        captured = _CaptureLaunch(sandbox(name))
+        launches.append(captured)
+        return captured
+
+    with (
+        patch.object(agy_module, "sandbox_env", capture_sandbox),
+        patch.object(agy_module, "_run_antigravity_cli_centaur", capture_centaur),
+    ):
+        logs = eval(_launch_task(centaur=True), model=_MODEL, limit=1, time_limit=300)
+
+    assert logs[0].status == "success", f"CLI run failed: {logs[0].error}"
+    assert handed, "the agent never dispatched to centaur"
+    cmd = handed[0]
+
+    # The human is the approver here, which is the whole reason the print-mode
+    # flags below are withheld. The settings file is the other half of that: it
+    # is written before the human ever sees a terminal, and one that
+    # auto-approves everything would take the approval back from a file they
+    # have no reason to read.
+    settings = _settings_written(launches[0])
+    assert "toolPermission" not in settings, sorted(settings)
+    assert "artifactReviewPolicy" not in settings, sorted(settings)
+    # Withheld, not "no settings were written".
+    assert settings["modelProvider"] == "gemini"
+
+    # The image's PATH survives into the human's shell too.
+    assert "PATH" not in handed_env[0], sorted(handed_env[0])
+    # And the working directory this agent resolved is handed over with it: the
+    # human's session runs where the agent's own commands would have.
+    assert handed_cwd == [_FIXTURE_DIR], handed_cwd
+
+    for flag in _PRINT_MODE_FLAGS:
+        assert flag not in cmd, cmd
+    # No prompt is injected either -- the human supplies it. Both halves matter:
+    # the flag is gone, and so is the task text it would have carried.
+    assert "--print" not in cmd, cmd
+    assert not any(_LAUNCH_PROMPT in arg for arg in cmd), cmd
+    # The print-mode result format goes with them. The human reads the CLI's
+    # ordinary terminal output, and there is no headless envelope to parse.
+    assert "--output-format" not in cmd, cmd
+    # Still the real launch command -- the pinned binary, at that -- so the
+    # absences above mean "withheld", not "the command was never built".
+    assert f"agy-{_CLI_VERSION}" in cmd[0], cmd
+    assert "--model" in cmd, cmd
+
+
+# --- canonical producer identity --------------------------------------------
+#
+# `agy` opens a second conversation of its own to generate a title, and that
+# request can end up as the conversation the bridge binds -- see
+# `_bridged_requests` above, written against a run where exactly that happened
+# and the task's own tool result and final answer were absent from
+# `sample.messages` entirely. For a task with a single model call whose title
+# arrives last there is no continued main loop left to recover from, so the
+# only fix is to identify the native conversation and keep canonical state on
+# it.
+
+_LATE_TITLE_ANSWER = "The single answer."
+_TITLE_TEXT = "Fixture Task Title"
+# Producer identity is asserted on the id the model actually emitted, not on
+# matching text: text can coincide, and an id cannot be reconstructed by
+# anything that rebuilt state from the CLI's own output.
+_MAIN_MESSAGE_ID = "antigravity-main-answer"
+_RETRY_ANSWER = "Answered again."
+
+
+class _Handoff:
+    """A happens-after between the state filter and the title request.
+
+    The event is created on first touch rather than in the test body: an
+    `anyio.Event` binds to the running backend, and both touches here happen
+    inside the sample's own loop -- the filter is called synchronously from
+    `_track_state`, the title request from the model callback.
+    """
+
+    def __init__(self) -> None:
+        self._event: anyio.Event | None = None
+
+    def _ensure(self) -> anyio.Event:
+        if self._event is None:
+            self._event = anyio.Event()
+        return self._event
+
+    def signal(self) -> None:
+        self._ensure().set()
+
+    async def wait(self) -> None:
+        # Bounded so a broken ordering fails loudly rather than hanging until
+        # the eval's own time limit reports an opaque stall.
+        with anyio.fail_after(60):
+            await self._ensure().wait()
+
+
+class _AcceptanceSpy:
+    """The real native filter, signalling once it accepts a conversation."""
+
+    def __init__(self, inner: Any, handoff: _Handoff) -> None:
+        self._inner = inner
+        self._handoff = handoff
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._inner, name)
+
+    def accept(self, messages: Sequence[ChatMessage]) -> bool:
+        verdict: bool = self._inner.accept(messages)
+        if verdict:
+            self._handoff.signal()
+        return verdict
+
+
+class _LateTitleModel:
+    """One primary call plus the CLI's title call, ordered title-last.
+
+    The two are told apart by the CLI's own declaration, through the same
+    parser the agent uses: a primary request carries a system
+    `<user_information>` block naming its conversation, a title request carries
+    none. Nothing here classifies on title text or on tool presence.
+    """
+
+    def __init__(self, handoff: _Handoff) -> None:
+        self._handoff = handoff
+        self.conversation_ids: list[str] = []
+        self.title_requests = 0
+
+    async def __call__(
+        self,
+        input: list[ChatMessage],
+        tools: list[ToolInfo],
+        tool_choice: ToolChoice,
+        config: GenerateConfig,
+    ) -> ModelOutput:
+        conversation_id = _native_conversation_id(input)
+        if conversation_id is None:
+            self.title_requests += 1
+            await self._handoff.wait()
+            # Tool-free request, answered with text. Returning a tool call here
+            # would be traffic the CLI never asks this conversation for.
+            return ModelOutput.from_content(model=_MODEL, content=_TITLE_TEXT)
+
+        self.conversation_ids.append(conversation_id)
+        return ModelOutput.from_message(
+            ChatMessageAssistant(
+                content=_LATE_TITLE_ANSWER, id=_MAIN_MESSAGE_ID, model=_MODEL
+            )
+        )
+
+
+@skip_if_no_docker
+@pytest.mark.slow
+def test_a_late_title_does_not_displace_the_task_conversation() -> None:
+    handoff = _Handoff()
+    scripted = _LateTitleModel(handoff)
+    real_conversation = agy_module._NativeConversation
+
+    def spy(**kwargs: Any) -> Any:
+        return _AcceptanceSpy(real_conversation(**kwargs), handoff)
+
+    task = Task(
+        dataset=[Sample(input="Answer in one line.", target=_LATE_TITLE_ANSWER)],
+        solver=antigravity_cli(cwd=_FIXTURE_DIR, version=_CLI_VERSION),
+        sandbox="docker",
+    )
+
+    with patch.object(agy_module, "_NativeConversation", spy):
+        logs = eval(
+            task,
+            model=get_model(_MODEL, custom_outputs=scripted),
+            limit=1,
+            time_limit=300,
+        )
+
+    log = logs[0]
+    assert log.status == "success", f"CLI run failed: {log.error}"
+    assert log.samples
+    sample = resolve_sample_attachments(log.samples[0], "full")
+
+    # Both conversations really happened. Without the title request this test
+    # proves nothing, so its absence is a failure rather than a skip.
+    assert len(scripted.conversation_ids) == 1, scripted.conversation_ids
+    assert scripted.title_requests >= 1
+
+    # Excluding a conversation from canonical state does not suppress its
+    # generation: both requests are still recorded as model events.
+    assert len(_bridged_requests(sample)) >= 2
+
+    # Canonical state is the task's conversation, by producer identity.
+    assert sample.output.message.id == _MAIN_MESSAGE_ID
+    assert sample.output.completion == _LATE_TITLE_ANSWER
+
+    # ...and the title conversation is nowhere in it.
+    assert all(_TITLE_TEXT not in message.text for message in sample.messages), [
+        message.text for message in sample.messages
+    ]
+
+
+class _RecordLaunches:
+    """The real sandbox, with every CLI launch recorded on its way through.
+
+    Unlike `_CaptureLaunch` the launch is not short-circuited: the CLI really
+    runs both attempts, so the recorded commands are the ones a scored retry
+    actually issues and each result read back is the CLI's own.
+    """
+
+    def __init__(self, inner: SandboxEnvironment) -> None:
+        self._inner = inner
+        self.cmds: list[list[str]] = []
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._inner, name)
+
+    async def exec_remote(
+        self,
+        cmd: list[str],
+        options: ExecRemoteAwaitableOptions | None = None,
+        *,
+        stream: Literal[False],
+    ) -> ExecResult[str]:
+        self.cmds.append(list(cmd))
+        result = await self._inner.exec_remote(cmd=cmd, options=options, stream=stream)
+        return result
+
+
+@scorer(metrics=[])
+def always_incorrect() -> Scorer:
+    """Force the agent's retry path: no attempt is ever accepted."""
+
+    async def score(state: TaskState, target: Target) -> Score:
+        return Score(value=0, explanation="forcing a second attempt")
+
+    return score
+
+
+class _TwoAttemptModel:
+    """Answer every primary request with text, and title requests likewise."""
+
+    def __init__(self) -> None:
+        self.conversation_ids: list[str] = []
+
+    def __call__(
+        self,
+        input: list[ChatMessage],
+        tools: list[ToolInfo],
+        tool_choice: ToolChoice,
+        config: GenerateConfig,
+    ) -> ModelOutput:
+        conversation_id = _native_conversation_id(input)
+        if conversation_id is None:
+            return ModelOutput.from_content(model=_MODEL, content=_TITLE_TEXT)
+        self.conversation_ids.append(conversation_id)
+        return ModelOutput.from_content(model=_MODEL, content=_RETRY_ANSWER)
+
+
+@skip_if_no_docker
+@pytest.mark.slow
+def test_a_scored_retry_resumes_the_bound_conversation() -> None:
+    scripted = _TwoAttemptModel()
+    recorders: list[_RecordLaunches] = []
+
+    def record_sandbox(name: str | None = None) -> Any:
+        recorder = _RecordLaunches(sandbox(name))
+        recorders.append(recorder)
+        return recorder
+
+    task = Task(
+        dataset=[Sample(input="Answer in one line.", target=_RETRY_ANSWER)],
+        solver=antigravity_cli(attempts=2, cwd=_FIXTURE_DIR, version=_CLI_VERSION),
+        scorer=always_incorrect(),
+        sandbox="docker",
+    )
+
+    with patch.object(agy_module, "sandbox_env", record_sandbox):
+        logs = eval(
+            task,
+            model=get_model(_MODEL, custom_outputs=scripted),
+            limit=1,
+            time_limit=600,
+        )
+
+    log = logs[0]
+    assert log.status == "success", f"CLI run failed: {log.error}"
+    assert recorders, "the agent never resolved a sandbox"
+
+    cmds = recorders[0].cmds
+    assert len(cmds) == 2, cmds
+    first, retry = cmds
+    assert scripted.conversation_ids, "no primary request reached the model"
+    bound = scripted.conversation_ids[0]
+
+    # The retry names the conversation the first attempt bound, explicitly.
+    assert "--conversation" in retry, retry
+    assert retry[retry.index("--conversation") + 1] == bound, (retry, bound)
+    # Not `--continue`, not latest, not a fresh conversation: each of those
+    # resumes something this run never verified it owns.
+    assert "--continue" not in retry, retry
+    assert "--continue" not in first, first
+    # The first attempt cannot resume anything: the wrapper must not preassign
+    # a UUID, because an unknown-UUID probe warns and creates a different one.
+    assert "--conversation" not in first, first
+
+
+_REENTRY_FOLLOW_UP = "And once more, in one line."
+
+
+@solver
+def _reenter_the_agent() -> Solver:
+    """Invoke the agent twice within one sample, as a multi-call task does.
+
+    The second invocation gets a fresh agent state object but the accumulated
+    conversation, which is the only place the prior conversation's identity
+    survives: the id lives in the system message the bridge tracked, and the
+    agent reads that same `state.messages` to build its next prompt.
+    """
+
+    async def solve(state: TaskState, generate: Generate) -> TaskState:
+        cli = antigravity_cli(cwd=_FIXTURE_DIR, version=_CLI_VERSION)
+        agent_state = await run(cli, state.messages)
+        agent_state.messages.append(ChatMessageUser(content=_REENTRY_FOLLOW_UP))
+        agent_state = await run(cli, agent_state)
+        state.messages = agent_state.messages
+        state.output = agent_state.output
+        return state
+
+    return solve
+
+
+@skip_if_no_docker
+@pytest.mark.slow
+def test_reentering_the_agent_resumes_the_prior_conversation() -> None:
+    """A second invocation continues the conversation the first one ran.
+
+    `--continue` asks the CLI to pick a conversation for us. Naming the prior
+    id instead keeps the choice with the run that verified it, and it is
+    available without any new state: the id is in the canonical messages the
+    first invocation tracked, which is the same input the agent already reads
+    to decide there was a prior assistant response at all.
+    """
+    scripted = _TwoAttemptModel()
+    recorders: list[_RecordLaunches] = []
+
+    def record_sandbox(name: str | None = None) -> Any:
+        recorder = _RecordLaunches(sandbox(name))
+        recorders.append(recorder)
+        return recorder
+
+    task = Task(
+        dataset=[Sample(input="Answer in one line.", target=_RETRY_ANSWER)],
+        solver=_reenter_the_agent(),
+        sandbox="docker",
+    )
+
+    with patch.object(agy_module, "sandbox_env", record_sandbox):
+        logs = eval(
+            task,
+            model=get_model(_MODEL, custom_outputs=scripted),
+            limit=1,
+            time_limit=600,
+        )
+
+    log = logs[0]
+    assert log.status == "success", f"CLI run failed: {log.error}"
+    assert recorders, "the agent never resolved a sandbox"
+
+    # One launch per invocation, each through its own sandbox resolution.
+    cmds = [cmd for recorder in recorders for cmd in recorder.cmds]
+    assert len(cmds) == 2, cmds
+    first, second = cmds
+    assert scripted.conversation_ids, "no primary request reached the model"
+    prior = scripted.conversation_ids[0]
+
+    # The second invocation names the conversation the first one ran...
+    assert "--conversation" in second, second
+    assert second[second.index("--conversation") + 1] == prior, (second, prior)
+    # ...rather than handing the choice back to the CLI.
+    assert "--continue" not in second, second
+    # The first invocation has nothing to resume and must claim nothing.
+    assert "--conversation" not in first, first
+    assert "--continue" not in first, first
+
+
+@solver
+def _reenter_without_a_prior_conversation() -> Solver:
+    """Hand the agent assistant turns that did not come from this CLI."""
+
+    async def solve(state: TaskState, generate: Generate) -> TaskState:
+        cli = antigravity_cli(cwd=_FIXTURE_DIR, version=_CLI_VERSION)
+        transcript: list[ChatMessage] = [
+            ChatMessageUser(content="What is 1+1?"),
+            ChatMessageAssistant(content="2"),
+            ChatMessageUser(content=_REENTRY_FOLLOW_UP),
+        ]
+        agent_state = await run(cli, transcript)
+        state.messages = agent_state.messages
+        state.output = agent_state.output
+        return state
+
+    return solve
+
+
+@skip_if_no_docker
+@pytest.mark.slow
+def test_reentry_without_a_prior_conversation_fails_loudly() -> None:
+    """Neither guess nor start over when the prior identity is missing.
+
+    A caller can hand the agent assistant turns this CLI never produced -- a
+    synthesised or replayed transcript -- and then there is no native id to
+    resume. Both silent options are wrong. `--continue` resumes whatever
+    conversation the CLI happens to have cached, which may be unrelated to
+    this run; starting fresh silently drops the context those turns carry,
+    because the prompt the agent builds is only the user turns AFTER the last
+    assistant message. So it fails, while the cause is still visible.
+    """
+    recorders: list[_RecordLaunches] = []
+
+    def record_sandbox(name: str | None = None) -> Any:
+        recorder = _RecordLaunches(sandbox(name))
+        recorders.append(recorder)
+        return recorder
+
+    task = Task(
+        dataset=[Sample(input="Answer in one line.", target=_RETRY_ANSWER)],
+        solver=_reenter_without_a_prior_conversation(),
+        sandbox="docker",
+    )
+
+    with patch.object(agy_module, "sandbox_env", record_sandbox):
+        logs = eval(
+            task,
+            model=_MODEL,
+            limit=1,
+            time_limit=300,
+        )
+
+    log = logs[0]
+    assert log.status == "error", f"expected a loud failure, got: {log.status}"
+    assert "native conversation id" in str(log.error), log.error
+
+    # And it failed BEFORE launching: a run that launched and then complained
+    # would already have started a conversation nobody asked for.
+    assert recorders, "the agent never resolved a sandbox"
+    assert all(not recorder.cmds for recorder in recorders), [
+        recorder.cmds for recorder in recorders
+    ]
+
+
+# --- centaur accumulation ---------------------------------------------------
+#
+# Centaur mode's contract is that the human may start or resume several
+# conversations in one session, and the existing accumulation contract keeps
+# all of them in canonical state. A centaur state therefore carries more than
+# one native system block legitimately. That is not an ambiguous declaration
+# to resolve: centaur never resumes by id, because its filtering is per
+# request and every conversation in the session is the human's.
+
+_CENTAUR_CID_A = "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d"
+_CENTAUR_CID_B = "c9bf9e57-1685-4c89-bafb-ff5af830be8a"
+
+
+def _native_system_message(conversation_id: str) -> ChatMessageSystem:
+    """A primary request's system message, in the shape the bridge tracks."""
+    return ChatMessageSystem(
+        content="\n".join(
+            [
+                "<identity>You are a coding assistant.</identity>",
+                "<user_information>",
+                f"Conversation ID: {conversation_id}",
+                "</user_information>",
+            ]
+        )
+    )
+
+
+@solver
+def _resume_two_native_conversations() -> Solver:
+    """Run the agent on a state that accumulated two native conversations."""
+
+    async def solve(state: TaskState, generate: Generate) -> TaskState:
+        cli = antigravity_cli(centaur=True, cwd=_FIXTURE_DIR, version=_CLI_VERSION)
+        accumulated: list[ChatMessage] = [
+            _native_system_message(_CENTAUR_CID_A),
+            ChatMessageUser(content="What is 1+1?"),
+            ChatMessageAssistant(content="2"),
+            _native_system_message(_CENTAUR_CID_B),
+            ChatMessageUser(content=_REENTRY_FOLLOW_UP),
+        ]
+        agent_state = await run(cli, accumulated)
+        state.messages = agent_state.messages
+        state.output = agent_state.output
+        return state
+
+    return solve
+
+
+@skip_if_no_docker
+@pytest.mark.slow
+def test_centaur_launches_on_an_accumulated_multi_conversation_state() -> None:
+    """Two native conversations in a centaur state is normal, not ambiguous.
+
+    Deriving one prior conversation id to resume makes sense only where a run
+    resumes by id, which centaur does not. Reading an accumulated centaur state
+    as a single declaration turns the documented accumulation contract into a
+    launch failure before the human is ever handed a terminal.
+    """
+    handed: list[list[str]] = []
+
+    async def capture_centaur(
+        options: Any,
+        agy_cmd: list[str],
+        agent_env: dict[str, str],
+        state: Any,
+        *,
+        user: str | None,
+        sandbox: str | None,
+        cwd: str,
+    ) -> None:
+        handed.append(list(agy_cmd))
+
+    task = Task(
+        dataset=[Sample(input="Answer in one line.", target=_RETRY_ANSWER)],
+        solver=_resume_two_native_conversations(),
+        sandbox="docker",
+    )
+
+    with patch.object(agy_module, "_run_antigravity_cli_centaur", capture_centaur):
+        logs = eval(task, model=_MODEL, limit=1, time_limit=300)
+
+    log = logs[0]
+    assert log.status == "success", f"centaur run failed: {log.error}"
+    assert handed, "the agent never dispatched to centaur"
+
+    # ...and it resumes nothing by id: the human's own command decides.
+    cmd = handed[0]
+    assert "--conversation" not in cmd, cmd
+
+
+# --- which sandbox the human is handed --------------------------------------
+#
+# A task can define several containers, and this agent takes a `sandbox` name
+# to say which one is its own. Unattended, every step names it. A centaur
+# session cannot: `human_cli` installs the task tools and offers the login
+# through an unnamed lookup, so it lands in whichever container is the default
+# -- and the human ends up in a terminal that is not where the agent installed
+# the CLI, wrote its settings, or would have run.
+#
+# The compose file gives the run two identical containers precisely so that
+# "which one" has a wrong answer to catch.
+
+_TARGET_SANDBOX = "target"
+_DECOY_SANDBOX = "default"
+_TWO_SANDBOXES = str(Path(__file__).parent / "agy_two_sandboxes_compose.yaml")
+_HUMAN_WAS_HERE = "/tmp/agy-centaur-session.marker"
+_HUMAN_BASHRC = "/tmp/agy-centaur-session.bashrc"
+
+
+class _RecordedHumanSession:
+    """Stands in for the human's terminal, and looks around from inside it."""
+
+    def __init__(self) -> None:
+        self.handed: list[dict[str, Any]] = []
+        self.cwd: list[str] = []
+
+    def __call__(self, **kwargs: Any) -> Agent:
+        self.handed.append(dict(kwargs))
+        bashrc = str(kwargs["bashrc"])
+
+        @agent
+        def session() -> Agent:
+            async def execute(state: AgentState) -> AgentState:
+                # An unnamed lookup is what `human_cli` itself does to install
+                # the task tools and to offer the login, so whichever container
+                # answers here is the one the human would be working in.
+                sbox = sandbox()
+                await sbox.write_file(_HUMAN_WAS_HERE, "the human was here")
+
+                # Where the human lands is a fact about running their shell,
+                # not about the text of it: the file is sourced in the
+                # container the session was given, from a directory that is
+                # deliberately not the answer, and the shell is then asked
+                # where it is. Reading the bashrc for a `cd` instead would pin
+                # one spelling of the command and fail on every other.
+                await sbox.write_file(_HUMAN_BASHRC, bashrc)
+                landed = await sbox.exec(
+                    ["bash", "-c", f". {_HUMAN_BASHRC}; pwd"], cwd="/"
+                )
+                self.cwd.append(landed.stdout.strip())
+                return state
+
+            return execute
+
+        return session()
+
+
+@solver
+def _centaur_in_the_named_sandbox(session: _RecordedHumanSession) -> Solver:
+    async def solve(state: TaskState, generate: Generate) -> TaskState:
+        cli = antigravity_cli(
+            centaur=True,
+            cwd=_FIXTURE_DIR,
+            sandbox=_TARGET_SANDBOX,
+            version=_CLI_VERSION,
+        )
+        with patch.object(centaur_module, "human_cli", session):
+            await run(cli, [ChatMessageUser(content="Look around.")])
+
+        # Read both containers while they are still up: which one was touched
+        # is a fact to check rather than infer from the launch.
+        for name in (_TARGET_SANDBOX, _DECOY_SANDBOX):
+            visited = await sandbox(name).exec(["test", "-f", _HUMAN_WAS_HERE])
+            installed = await sandbox(name).exec(
+                ["sh", "-c", f"ls -d {SANDBOX_INSTALL_DIR}/agy-* 2>/dev/null"]
+            )
+            state.metadata[f"{name}_visited"] = visited.success
+            state.metadata[f"{name}_installed"] = installed.success
+        state.metadata["human_shell_cwd"] = session.cwd[-1] if session.cwd else ""
+        return state
+
+    return solve
+
+
+@skip_if_no_docker
+@pytest.mark.slow
+def test_centaur_runs_the_human_session_in_the_named_sandbox() -> None:
+    """The human works where the agent installed, not wherever is default."""
+    session = _RecordedHumanSession()
+    task = Task(
+        dataset=[Sample(input="Look around.", target="nothing")],
+        solver=_centaur_in_the_named_sandbox(session),
+        sandbox=("docker", _TWO_SANDBOXES),
+    )
+
+    logs = eval(task, model=_MODEL, limit=1, time_limit=600)
+    log = logs[0]
+    assert log.status == "success", f"centaur run failed: {log.error}"
+    assert log.samples
+    found = log.samples[0].metadata
+
+    # The named container is the one the agent installed the CLI into...
+    assert found[f"{_TARGET_SANDBOX}_installed"] is True, found
+    # ...and the one the human's own session reached without naming it.
+    assert found[f"{_TARGET_SANDBOX}_visited"] is True, found
+    # The decoy is untouched. Both halves matter: the install proves the agent
+    # never strayed, and the visit proves the session followed it.
+    assert found[f"{_DECOY_SANDBOX}_installed"] is False, found
+    assert found[f"{_DECOY_SANDBOX}_visited"] is False, found
+
+    # And the shell the human is handed starts where the agent's own commands
+    # would have run: sourced in the selected container from `/`, it leaves the
+    # shell in the resolved working directory. The alias alone is not enough --
+    # `agy` resolves relative paths, reads its project state, and writes its
+    # artifacts against the working directory.
+    assert session.handed, "the human session was never created"
+    assert found["human_shell_cwd"] == _FIXTURE_DIR, found

--- a/tests/test_antigravity_cli.py
+++ b/tests/test_antigravity_cli.py
@@ -812,6 +812,64 @@ def test_centaur_launch_withholds_the_print_mode_flags() -> None:
     assert "--model" in cmd, cmd
 
 
+@skip_if_no_docker
+@pytest.mark.slow
+def test_centaur_provisions_native_onboarding_and_workspace_trust() -> None:
+    """A new sandbox reaches the human prompt without native setup questions."""
+    handed_env: list[dict[str, str]] = []
+    launches: list[_CaptureLaunch] = []
+
+    async def capture_centaur(
+        options: Any,
+        agy_cmd: list[str],
+        agent_env: dict[str, str],
+        state: Any,
+        *,
+        user: str | None,
+        sandbox: str | None,
+        cwd: str,
+    ) -> None:
+        handed_env.append(dict(agent_env))
+
+    def capture_sandbox(name: str | None = None) -> Any:
+        captured = _CaptureLaunch(sandbox(name))
+        launches.append(captured)
+        return captured
+
+    with (
+        patch.object(agy_module, "sandbox_env", capture_sandbox),
+        patch.object(agy_module, "_run_antigravity_cli_centaur", capture_centaur),
+    ):
+        logs = eval(_launch_task(centaur=True), model=_MODEL, limit=1, time_limit=300)
+
+    assert logs[0].status == "success", f"CLI run failed: {logs[0].error}"
+    assert len(launches) == 1
+    assert len(handed_env) == 1
+
+    settings = _settings_written(launches[0])
+    # Trust exactly the resolved workspace. A wildcard would give the human
+    # terminal more trust than the native CLI needs to skip its first-run gate.
+    assert settings["trustedWorkspaces"] == [_FIXTURE_DIR]
+    # The CLI's defaults remain its interactive approval policy.
+    assert "toolPermission" not in settings
+    assert "artifactReviewPolicy" not in settings
+    assert settings["enableTelemetry"] is False
+
+    onboarding_paths = [
+        path
+        for path in launches[0].written
+        if path.endswith(".gemini/antigravity-cli/cache/onboarding.json")
+    ]
+    assert len(onboarding_paths) == 1, sorted(launches[0].written)
+    assert json.loads(launches[0].written[onboarding_paths[0]]) == {
+        "consumerOnboardingComplete": True,
+        "enterpriseOnboardingComplete": False,
+        "onboardingComplete": True,
+    }
+    # 1.1.27's native updater recognizes the literal "true", not "1".
+    assert handed_env[0]["AGY_CLI_DISABLE_AUTO_UPDATE"] == "true"
+
+
 # --- canonical producer identity --------------------------------------------
 #
 # `agy` opens a second conversation of its own to generate a title, and that

--- a/tests/test_antigravity_cli_config.py
+++ b/tests/test_antigravity_cli_config.py
@@ -338,6 +338,65 @@ def test_authenticated_http_server_is_rejected() -> None:
         )
 
 
+@pytest.mark.parametrize(
+    "url",
+    [
+        pytest.param(
+            "https://user:sentinel-password@mcp.example.test/mcp",
+            id="user-and-password",
+        ),
+        pytest.param("https://user@mcp.example.test/mcp", id="user-only"),
+        pytest.param(
+            "https:user:sentinel-password@mcp.example.test/mcp", id="no-slashes"
+        ),
+        pytest.param(
+            "https:/user:sentinel-password@mcp.example.test/mcp", id="one-slash"
+        ),
+        pytest.param(
+            "https://user:p%40ss%2Fword@mcp.example.test/mcp", id="encoded-password"
+        ),
+    ],
+)
+def test_http_server_with_url_credentials_is_rejected(url: str) -> None:
+    """The same credential boundary, reached through the URL instead of a header.
+
+    HTTP Basic credentials in the userinfo component are the same secret as an
+    `Authorization` header and land in the same sandbox-readable
+    `$HOME/.gemini/config/mcp_config.json`. Refusing only `headers` left the
+    guard bypassable by moving the secret into the URL, where it was persisted
+    verbatim as `serverUrl`.
+    """
+    with pytest.raises(ValueError, match="bridged_tools"):
+        build_antigravity_mcp_config(
+            [MCPServerConfigHTTP(type="http", name="inspect-tools", url=url)],
+            eager_tools={"inspect-tools": ["submit"]},
+        )
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        pytest.param("https://mcp.example.test/mcp", id="plain"),
+        pytest.param("https://mcp.example.test/a@b/mcp", id="at-in-path"),
+        pytest.param("https://mcp.example.test/mcp?to=a@b", id="at-in-query"),
+    ],
+)
+def test_http_server_without_url_credentials_is_accepted(url: str) -> None:
+    """An `@` outside the authority is not a credential.
+
+    The check parses the URL rather than scanning for `@`, so a path or query
+    that legitimately contains one still reaches the registry. A guard that
+    rejected these would push callers toward disabling it.
+    """
+    config = json.loads(
+        build_antigravity_mcp_config(
+            [MCPServerConfigHTTP(type="http", name="inspect-tools", url=url)],
+            eager_tools={},
+        )
+    )
+    assert config["mcpServers"]["inspect-tools"]["serverUrl"] == url
+
+
 def test_authenticated_stdio_server_is_rejected() -> None:
     """Same credential boundary as the HTTP case above, for stdio transport.
 

--- a/tests/test_antigravity_cli_config.py
+++ b/tests/test_antigravity_cli_config.py
@@ -37,6 +37,7 @@ from inspect_swe._antigravity_cli import agentbinary
 from inspect_swe._antigravity_cli.antigravity_cli import (
     _native_conversation_id,
     _NativeConversation,
+    build_antigravity_agent_env,
     build_antigravity_mcp_config,
     build_antigravity_settings,
 )
@@ -107,6 +108,48 @@ def test_boolean_settings_are_json_booleans(key: str) -> None:
 )
 def test_enum_settings_use_the_cli_vocabulary(key: str, expected: str) -> None:
     assert _settings()[key] == expected
+
+
+def test_agent_env_defaults_have_no_caller_env() -> None:
+    # Byte-identical baseline: with no caller `env`, the merged environment is
+    # exactly the five wrapper-owned keys.
+    result = build_antigravity_agent_env(bridge_port=3000, sandbox_home="/root")
+    assert result == {
+        "GOOGLE_GEMINI_BASE_URL": "http://localhost:3000",
+        "GEMINI_API_KEY": "api-key",
+        "AGY_CLI_DISABLE_AUTO_UPDATE": "true",
+        "AGY_CLI_HIDE_LOGO": "1",
+        "HOME": "/root",
+    }
+
+
+def test_caller_env_cannot_redirect_the_bridge_or_inject_a_credential() -> None:
+    # Credential boundary: a caller passing a full environment snapshot (the
+    # realistic `env=os.environ.copy()` case) must not be able to silently
+    # point the CLI at Google's real endpoint or supply a real Google
+    # credential in place of the bridge's placeholder.
+    caller_env = {
+        "GOOGLE_GEMINI_BASE_URL": "https://generativelanguage.googleapis.com",
+        "GEMINI_API_KEY": "real-google-api-key",
+    }
+    result = build_antigravity_agent_env(
+        bridge_port=3000, sandbox_home="/root", env=caller_env
+    )
+    assert result["GOOGLE_GEMINI_BASE_URL"] == "http://localhost:3000"
+    assert result["GEMINI_API_KEY"] == "api-key"
+
+
+def test_caller_env_still_overrides_the_cosmetic_defaults() -> None:
+    # Everything that is NOT the credential boundary keeps the established
+    # repo-wide "caller wins" contract (matches `claude_code_agent_env`):
+    # a caller may still override HOME or opt back into the auto-updater.
+    result = build_antigravity_agent_env(
+        bridge_port=3000,
+        sandbox_home="/root",
+        env={"HOME": "/home/custom", "AGY_CLI_DISABLE_AUTO_UPDATE": "false"},
+    )
+    assert result["HOME"] == "/home/custom"
+    assert result["AGY_CLI_DISABLE_AUTO_UPDATE"] == "false"
 
 
 def test_http_mcp_servers_use_server_url() -> None:
@@ -270,8 +313,18 @@ def test_eager_tool_names_are_written_verbatim() -> None:
     }
 
 
-def test_eager_marking_leaves_every_other_field_intact() -> None:
-    servers = _servers(
+def test_authenticated_http_server_is_rejected() -> None:
+    """Credential boundary.
+
+    `MCPServerConfigHTTP.headers` (e.g. an Authorization bearer token) would
+    otherwise be written verbatim into `$HOME/.gemini/config/mcp_config.json`
+    inside the sandbox -- a file the evaluated CLI, and any of its own tools,
+    can read back out at any point during the run.
+    `build_antigravity_mcp_config` must refuse a caller-supplied server
+    carrying headers rather than persist a real credential where the
+    sandboxed agent can read it.
+    """
+    with pytest.raises(ValueError, match="bridged_tools"):
         build_antigravity_mcp_config(
             [
                 MCPServerConfigHTTP(
@@ -283,13 +336,28 @@ def test_eager_marking_leaves_every_other_field_intact() -> None:
             ],
             eager_tools={"inspect-tools": ["submit"]},
         )
-    )
 
-    server = servers["inspect-tools"]
-    assert server["serverUrl"] == _BRIDGE_URL
-    assert server["headers"] == {"Authorization": "Bearer token"}
-    assert "url" not in server
-    assert set(server) == {"serverUrl", "headers", "tools"}
+
+def test_authenticated_stdio_server_is_rejected() -> None:
+    """Same credential boundary as the HTTP case above, for stdio transport.
+
+    `MCPServerConfigStdio.env` would land verbatim in the same
+    sandbox-readable `mcp_config.json`, so a real credential passed through
+    it must be refused rather than persisted where the sandboxed agent can
+    read it back out.
+    """
+    with pytest.raises(ValueError, match="bridged_tools"):
+        build_antigravity_mcp_config(
+            [
+                MCPServerConfigStdio(
+                    type="stdio",
+                    name="local",
+                    command="server",
+                    env={"API_TOKEN": "secret"},
+                )
+            ],
+            eager_tools={},
+        )
 
 
 def test_user_supplied_servers_keep_the_cli_default() -> None:

--- a/tests/test_antigravity_cli_config.py
+++ b/tests/test_antigravity_cli_config.py
@@ -1,0 +1,814 @@
+"""Unit tests for the Antigravity CLI agent's on-disk configuration.
+
+Both builders encode behaviour that was measured against the real `agy` binary
+(1.1.20) rather than read off the documentation, and in both cases getting it
+wrong fails SILENTLY -- the CLI keeps running with the setting or the server
+ignored. That is what these tests exist to catch. The eager-tool marking is
+read off 1.1.27's own config struct and changelog rather than the (silent on
+it) published schema; that the CLI then declares the tool natively is proven
+by the CLI-level test, not here.
+
+The binary source is covered here too -- which release archive is installed,
+what it is verified against, and under what name it lands. None of that needs
+Docker or the network: the GitHub release lookup is the only thing stubbed.
+"""
+
+import json
+import tarfile
+from io import BytesIO
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import anyio
+import pytest
+from inspect_ai.model import (
+    ChatMessage,
+    ChatMessageAssistant,
+    ChatMessageSystem,
+    ChatMessageUser,
+)
+from inspect_ai.tool import Tool, ToolDef, tool
+from inspect_ai.tool._mcp._config import (
+    MCPServerConfigHTTP,
+    MCPServerConfigStdio,
+)
+from inspect_swe._antigravity_cli import agentbinary
+from inspect_swe._antigravity_cli.antigravity_cli import (
+    _native_conversation_id,
+    _NativeConversation,
+    build_antigravity_mcp_config,
+    build_antigravity_settings,
+)
+from inspect_swe._util.agentbinary import AgentBinaryVersion
+from inspect_swe._util.sandbox import SandboxPlatform
+
+
+def _settings(unattended: bool = True) -> dict[str, Any]:
+    parsed: dict[str, Any] = json.loads(
+        build_antigravity_settings(unattended=unattended)
+    )
+    return parsed
+
+
+def test_settings_select_the_direct_gemini_api_route() -> None:
+    # the load-bearing key: without it the CLI blocks on OAuth sign-in and
+    # never reads GEMINI_API_KEY / GOOGLE_GEMINI_BASE_URL at all.
+    assert _settings()["modelProvider"] == "gemini"
+
+
+def test_centaur_settings_withhold_the_approval_policies() -> None:
+    # The human at the terminal is the approver in centaur mode, which is the
+    # whole reason --dangerously-skip-permissions is withheld from the command
+    # they are handed. A persisted settings file that auto-approves everything
+    # would take that back silently, from a file they never see.
+    centaur = _settings(unattended=False)
+
+    assert "toolPermission" not in centaur
+    assert "artifactReviewPolicy" not in centaur
+    # Withheld, not "no settings were written": the direct-Gemini route and the
+    # rest of the headless hygiene still apply to whatever the human launches,
+    # so the CLI still reaches the bridge rather than a sign-in page.
+    assert centaur["modelProvider"] == "gemini"
+    assert centaur["enableTelemetry"] is False
+    assert centaur["altScreenMode"] == "never"
+
+    # ...and those two keys are the ONLY difference between the modes. An
+    # unattended run has nobody to answer a prompt, so it keeps both.
+    unattended = _settings()
+    assert set(unattended) - set(centaur) == {
+        "toolPermission",
+        "artifactReviewPolicy",
+    }
+    assert all(centaur[key] == unattended[key] for key in centaur)
+
+
+@pytest.mark.parametrize(
+    "key",
+    ["enableTelemetry", "showTips", "showFeedbackSurvey", "enableTerminalSandbox"],
+)
+def test_boolean_settings_are_json_booleans(key: str) -> None:
+    # These four are documented with "on"/"off" wording, but the CLI only
+    # accepts real booleans: a string is dropped on load with no error and
+    # without rewriting settings.json, so the file reads "off" while /config
+    # still reports the default (telemetry ON).
+    value = _settings()[key]
+    assert isinstance(value, bool), f"{key} must be a JSON boolean, got {value!r}"
+    assert value is False
+
+
+@pytest.mark.parametrize(
+    ("key", "expected"),
+    [
+        ("toolPermission", "always-proceed"),
+        ("artifactReviewPolicy", "always-proceed"),
+        ("altScreenMode", "never"),
+    ],
+)
+def test_enum_settings_use_the_cli_vocabulary(key: str, expected: str) -> None:
+    assert _settings()[key] == expected
+
+
+def test_http_mcp_servers_use_server_url() -> None:
+    # The CLI's remote schema is `serverUrl`. `url`/`httpUrl` are accepted by the
+    # JSON parser and then ignored, which presents as a configured server that
+    # never connects.
+    config = json.loads(
+        build_antigravity_mcp_config(
+            [
+                MCPServerConfigHTTP(
+                    type="http",
+                    name="remote-tools",
+                    url="http://localhost:8901/mcp",
+                )
+            ],
+            eager_tools={},
+        )
+    )
+    server = config["mcpServers"]["remote-tools"]
+    assert server["serverUrl"] == "http://localhost:8901/mcp"
+    assert "url" not in server
+    assert "httpUrl" not in server
+
+
+def test_stdio_mcp_servers_keep_command_and_args() -> None:
+    config = json.loads(
+        build_antigravity_mcp_config(
+            [
+                MCPServerConfigStdio(
+                    type="stdio", name="local", command="server", args=["--flag"]
+                )
+            ],
+            eager_tools={},
+        )
+    )
+    server = config["mcpServers"]["local"]
+    assert server["command"] == "server"
+    assert server["args"] == ["--flag"]
+
+
+def test_stdio_cwd_is_written_as_a_string() -> None:
+    # `MCPServerConfigStdio.cwd` accepts a Path and `json.dumps` refuses one, so
+    # an unconverted Path is not a bad registry but no registry at all: the
+    # write raises and the run dies before the CLI is ever launched.
+    config = json.loads(
+        build_antigravity_mcp_config(
+            [
+                MCPServerConfigStdio(
+                    type="stdio",
+                    name="local",
+                    command="server",
+                    cwd=Path("/srv/mcp"),
+                )
+            ],
+            eager_tools={},
+        )
+    )
+
+    assert config["mcpServers"]["local"]["cwd"] == str(Path("/srv/mcp"))
+
+
+def test_no_mcp_servers_still_writes_an_empty_registry() -> None:
+    # The CLI reads the file unconditionally; an absent `mcpServers` object is a
+    # parse error it reports as a broken configuration.
+    empty = build_antigravity_mcp_config([], eager_tools={})
+    assert json.loads(empty) == {"mcpServers": {}}
+
+
+# --- eager bridged tools ----------------------------------------------------
+#
+# `agy` loads MCP tools LAZILY by default: it declares a single native
+# dispatcher whose own description reads "Call a lazy-loaded MCP tool. Read the
+# tool's schema file to understand the tool's arguments and usage", and routes
+# every MCP tool through it. A host-bridged Inspect tool therefore never
+# appears as a tool the model can call by name, which is what the rest of the
+# CLI wrappers give it.
+#
+# The CLI's own per-server config carries the switch: a `tools` map whose
+# values hold an `eager` boolean (1.1.27 config struct: `Eager *bool
+# "json:\"eager,omitempty,omitzero\""` beside `Background`, inside the entry's
+# `tools` map; named in the shipped changelog as "`tools.eager` from
+# `mcp_config.json`"). An eager tool is "registered as native tools under the
+# name `%s`. Call eager tools directly."
+#
+# The map key is the tool name the SERVER serves -- the namespace the
+# documented `disabledTools` list and the `mcp(server/tool)` permission syntax
+# also use. The model-facing `mcp_<server>_<tool>` name (`mcp_secrets_
+# secret_lookup` for gemini_cli, `mcp_chrome_devtools_new_page` in agy's own
+# browser server) is derived by the CLI, so a key written in that spelling
+# marks nothing and silently leaves the tool lazy.
+#
+# Bridged servers are the only ones marked: a user's own MCP server keeps the
+# CLI's native lazy behaviour, since Inspect's MCPServerConfig has no way to
+# ask for anything else.
+
+_BRIDGE_URL = "http://localhost:3001/mcp/inspect-tools"
+
+
+def _servers(config: str) -> dict[str, Any]:
+    parsed: dict[str, Any] = json.loads(config)["mcpServers"]
+    return parsed
+
+
+@tool
+def secret_lookup() -> Tool:
+    async def execute(name: str) -> str:
+        """Look up a secret.
+
+        Args:
+            name: Secret to look up.
+        """
+        return name
+
+    return execute
+
+
+def test_bridged_tools_are_marked_eager_under_their_own_server() -> None:
+    servers = _servers(
+        build_antigravity_mcp_config(
+            [MCPServerConfigHTTP(type="http", name="inspect-tools", url=_BRIDGE_URL)],
+            eager_tools={"inspect-tools": ["bash", "submit"]},
+        )
+    )
+
+    assert servers["inspect-tools"]["tools"] == {
+        "bash": {"eager": True},
+        "submit": {"eager": True},
+    }
+
+
+def test_eager_marking_accepts_the_bridge_registry_verbatim() -> None:
+    # `SandboxAgentBridge.bridged_tools` is dict[server, dict[tool, Tool]], and
+    # its keys are exactly the names the bridge's own `tools/list` serves
+    # (`ToolDef(tool).name`), so it is passed through with no transformation.
+    registry = {"inspect-tools": {ToolDef(secret_lookup()).name: secret_lookup()}}
+
+    servers = _servers(
+        build_antigravity_mcp_config(
+            [MCPServerConfigHTTP(type="http", name="inspect-tools", url=_BRIDGE_URL)],
+            eager_tools=registry,
+        )
+    )
+
+    assert servers["inspect-tools"]["tools"] == {"secret_lookup": {"eager": True}}
+
+
+def test_eager_tool_names_are_written_verbatim() -> None:
+    # No prefixing and no rewriting: the CLI matches these against what the
+    # server serves, and derives the native `mcp_<server>_<tool>` name itself.
+    servers = _servers(
+        build_antigravity_mcp_config(
+            [MCPServerConfigHTTP(type="http", name="inspect-tools", url=_BRIDGE_URL)],
+            eager_tools={"inspect-tools": ["read-file", "web.search", "run_command"]},
+        )
+    )
+
+    assert set(servers["inspect-tools"]["tools"]) == {
+        "read-file",
+        "web.search",
+        "run_command",
+    }
+
+
+def test_eager_marking_leaves_every_other_field_intact() -> None:
+    servers = _servers(
+        build_antigravity_mcp_config(
+            [
+                MCPServerConfigHTTP(
+                    type="http",
+                    name="inspect-tools",
+                    url=_BRIDGE_URL,
+                    headers={"Authorization": "Bearer token"},
+                )
+            ],
+            eager_tools={"inspect-tools": ["submit"]},
+        )
+    )
+
+    server = servers["inspect-tools"]
+    assert server["serverUrl"] == _BRIDGE_URL
+    assert server["headers"] == {"Authorization": "Bearer token"}
+    assert "url" not in server
+    assert set(server) == {"serverUrl", "headers", "tools"}
+
+
+def test_user_supplied_servers_keep_the_cli_default() -> None:
+    # Nothing the caller passes in `mcp_servers` is bridged, so nothing there
+    # is marked: those servers behave exactly as the CLI configures them.
+    servers = _servers(
+        build_antigravity_mcp_config(
+            [
+                MCPServerConfigStdio(
+                    type="stdio", name="local", command="server", args=["--flag"]
+                ),
+                MCPServerConfigHTTP(
+                    type="http", name="remote", url="https://mcp.example.com/mcp"
+                ),
+                MCPServerConfigHTTP(type="http", name="inspect-tools", url=_BRIDGE_URL),
+            ],
+            eager_tools={"inspect-tools": ["submit"]},
+        )
+    )
+
+    assert "tools" not in servers["local"]
+    assert "tools" not in servers["remote"]
+    assert servers["local"]["command"] == "server"
+    assert servers["remote"]["serverUrl"] == "https://mcp.example.com/mcp"
+    assert servers["inspect-tools"]["tools"] == {"submit": {"eager": True}}
+
+
+def test_inspect_tool_filter_never_becomes_the_cli_tools_map() -> None:
+    # Inspect's own `tools` field is a filter (`"all"` or a list). The CLI's
+    # `tools` is a map of per-tool options, so a list landing there is a schema
+    # mismatch the CLI drops on load, taking the eager marking with it.
+    servers = _servers(
+        build_antigravity_mcp_config(
+            [
+                MCPServerConfigHTTP(
+                    type="http",
+                    name="remote",
+                    url="https://mcp.example.com/mcp",
+                    tools=["lookup"],
+                )
+            ],
+            eager_tools={},
+        )
+    )
+
+    assert "tools" not in servers["remote"]
+
+
+def test_bridged_server_with_no_tools_gets_no_tools_key() -> None:
+    # A zero-tool bridged server is a valid configuration (the readiness gate
+    # skips probing one); an empty `tools` map would claim otherwise.
+    servers = _servers(
+        build_antigravity_mcp_config(
+            [MCPServerConfigHTTP(type="http", name="inspect-tools", url=_BRIDGE_URL)],
+            eager_tools={"inspect-tools": []},
+        )
+    )
+
+    assert "tools" not in servers["inspect-tools"]
+
+
+# --- binary source ----------------------------------------------------------
+
+
+def test_binary_source_installs_under_the_agy_name() -> None:
+    source = agentbinary.antigravity_cli_binary_source()
+    # The release tarball's single member is named `antigravity`; the sandbox
+    # binary (and the `version="sandbox"` probe) is `agy`.
+    assert source.binary == "agy"
+
+
+def test_the_downloaded_archive_is_unpacked_to_its_single_member() -> None:
+    # The published asset is a tar.gz whose one member is the executable, so
+    # something has to unpack it on the way in: installed as downloaded, the
+    # sandbox writes an archive to the binary path and chmods it, and every
+    # launch dies with an exec-format error. Asserted as behaviour -- these
+    # bytes in, that member's bytes out -- rather than as which helper happens
+    # to be wired up, since a replacement that unpacks correctly is fine and a
+    # helper that stops unpacking is not.
+    executable = b"\x7fELF\x02\x01\x01" + b"agy" * 64
+    archive = BytesIO()
+    with tarfile.open(fileobj=archive, mode="w:gz") as tar:
+        member = tarfile.TarInfo(name="antigravity")
+        member.size = len(executable)
+        tar.addfile(member, BytesIO(executable))
+    packed = archive.getvalue()
+
+    source = agentbinary.antigravity_cli_binary_source()
+
+    assert source.post_download is not None, "the archive would install as-is"
+    assert source.post_download(packed) == executable
+
+
+def test_binary_source_rejects_musl_platforms() -> None:
+    # Only glibc assets are published. Installing the glibc binary on a musl
+    # image fails at exec time with an opaque loader error, so refuse up front.
+    source = agentbinary.antigravity_cli_binary_source()
+    with pytest.raises(ValueError, match="Unsupported platform"):
+        anyio.run(source.resolve_version, "1.1.20", "linux-x64-musl")
+
+
+# --- release resolution -----------------------------------------------------
+#
+# `resolve_version` decides which archive is installed and what it is checked
+# against, and every mistake it can make lands somewhere other than here: the
+# wrong architecture dies at exec time inside the sandbox, an unverified digest
+# is a download nothing ever checks, and a floating version left unresolved
+# names a cache entry no later run can hit. The release lookup is stubbed;
+# nothing else is.
+
+_RELEASE: dict[str, Any] = {
+    "assets": [
+        {
+            "name": "agy_cli_linux_x64.tar.gz",
+            "digest": "sha256:1111",
+            "browser_download_url": "https://example.com/agy_cli_linux_x64.tar.gz",
+        },
+        {
+            "name": "agy_cli_linux_arm64.tar.gz",
+            "digest": "sha256:2222",
+            "browser_download_url": "https://example.com/agy_cli_linux_arm64.tar.gz",
+        },
+    ]
+}
+
+
+def _resolve(
+    platform: SandboxPlatform,
+    release: dict[str, Any] | None = None,
+    version: str = "1.1.27",
+) -> AgentBinaryVersion:
+    source = agentbinary.antigravity_cli_binary_source()
+    with patch.object(
+        agentbinary, "_fetch_release", AsyncMock(return_value=release or _RELEASE)
+    ):
+        return anyio.run(source.resolve_version, version, platform)
+
+
+@pytest.mark.parametrize(
+    ("platform", "asset", "checksum"),
+    [
+        ("linux-x64", "agy_cli_linux_x64.tar.gz", "1111"),
+        ("linux-arm64", "agy_cli_linux_arm64.tar.gz", "2222"),
+    ],
+)
+def test_each_architecture_resolves_to_its_own_asset(
+    platform: SandboxPlatform, asset: str, checksum: str
+) -> None:
+    resolved = _resolve(platform)
+
+    assert resolved.download_url.endswith(asset)
+    # The digest of THAT asset, with GitHub's `sha256:` prefix stripped: the
+    # installer compares this against the archive's own sha256, so a prefix
+    # left on matches nothing, and a digest read off the wrong asset condemns
+    # one of the two architectures to a checksum failure on every download.
+    assert resolved.expected_checksum == checksum
+    assert resolved.version == "1.1.27"
+    # A single binary, never a package archive: this source defines no
+    # package_entrypoint, and claiming one raises during install.
+    assert resolved.package is False
+
+
+def test_a_release_missing_the_platform_asset_is_rejected() -> None:
+    # e.g. a release that shipped x64 only. Naming the missing asset is the
+    # point: the alternative is an install that reports a missing binary from
+    # inside the sandbox, one layer away from the release that lacks it.
+    x64_only: dict[str, Any] = {"assets": [_RELEASE["assets"][0]]}
+
+    with pytest.raises(RuntimeError, match="No asset agy_cli_linux_arm64.tar.gz"):
+        _resolve("linux-arm64", release=x64_only)
+
+
+@pytest.mark.parametrize("digest", ["", "md5:1111", "1111"])
+def test_a_release_without_a_sha256_digest_is_rejected(digest: str) -> None:
+    # Older releases carry no `digest` field at all. Accepting one would install
+    # the archive unverified -- a checksum check that passes by having nothing
+    # to compare is worse than none, because it still reads as verified.
+    release: dict[str, Any] = {"assets": [{**_RELEASE["assets"][0], "digest": digest}]}
+
+    with pytest.raises(RuntimeError, match="Invalid digest"):
+        _resolve("linux-x64", release=release)
+
+
+@pytest.mark.parametrize("requested", ["stable", "latest"])
+def test_a_floating_version_resolves_to_a_concrete_release(requested: str) -> None:
+    # The concrete version is what the release lookup, the cache filename and
+    # the sandbox install path are all built from. Left as "latest" it asks
+    # GitHub for a release tagged "latest" and caches under a name no pinned
+    # run can ever match.
+    source = agentbinary.antigravity_cli_binary_source()
+    with (
+        patch.object(
+            agentbinary, "_fetch_latest_version", AsyncMock(return_value="1.1.27")
+        ),
+        patch.object(
+            agentbinary, "_fetch_release", AsyncMock(return_value=_RELEASE)
+        ) as fetch_release,
+    ):
+        resolved = anyio.run(source.resolve_version, requested, "linux-x64")
+
+    assert resolved.version == "1.1.27"
+    fetch_release.assert_awaited_once_with("1.1.27")
+
+
+# --- native conversation identity -------------------------------------------
+#
+# A title-generation request can displace the native task's canonical
+# `AgentState`, and for a single-call task whose title arrives last there is no
+# continued main loop left to recover from. The CLI's own declaration is what
+# separates them: official 1.1.27/1.1.28 primary requests carry exactly one
+# system `<user_information>` block containing `Conversation ID: <UUID>`, and
+# title requests carry no such block at all.
+#
+# This is deliberately NOT a title-text or tool-presence classifier. Those
+# guess; this reads the identity the CLI states. And because the wrapper cannot
+# preassign a UUID -- an unknown-UUID `--conversation` probe warns and creates
+# a different one -- the parser must never invent or normalise an ID: anything
+# it cannot read unambiguously raises instead.
+
+_CID = "3f2504e0-4f89-11d3-9a0c-0305e82c3301"
+_OTHER_CID = "16fd2706-8baf-433b-82eb-8c7fada847da"
+
+
+def _block(body: str) -> str:
+    return f"<user_information>\n{body}\n</user_information>"
+
+
+def _native_system(cid: str = _CID) -> ChatMessageSystem:
+    """A primary request's system message, block embedded in other content."""
+    return ChatMessageSystem(
+        content="\n".join(
+            [
+                "<identity>You are a coding assistant.</identity>",
+                _block(f"Conversation ID: {cid}"),
+                "<rules>Be brief.</rules>",
+            ]
+        )
+    )
+
+
+def _primary(cid: str = _CID) -> list[ChatMessage]:
+    return [_native_system(cid), ChatMessageUser(content="Do the task.")]
+
+
+def _auxiliary() -> list[ChatMessage]:
+    """The title generator's request: its own system prompt, and no block."""
+    return [
+        ChatMessageSystem(content="You are a conversation title generator"),
+        ChatMessageUser(content="Do the task."),
+    ]
+
+
+def test_a_primary_request_yields_its_conversation_id() -> None:
+    assert _native_conversation_id(_primary()) == _CID
+
+
+def test_the_id_is_read_from_the_block_not_the_whole_message() -> None:
+    # The block sits inside a much larger system prompt, and a bare UUID can
+    # appear elsewhere in it (a task prompt, a path, a pasted log). Only the
+    # block's own line counts.
+    messages: list[ChatMessage] = [
+        _native_system(),
+        ChatMessageUser(content=f"Compare against run {_OTHER_CID} please."),
+    ]
+    assert _native_conversation_id(messages) == _CID
+
+
+def test_an_auxiliary_request_has_no_conversation_id() -> None:
+    # No block is the positive signal for "not the native task", not an error.
+    assert _native_conversation_id(_auxiliary()) is None
+
+
+def test_a_user_message_block_is_not_a_native_declaration() -> None:
+    # Only SYSTEM messages carry the CLI's declaration. Honouring one from
+    # user content would let task text nominate the canonical conversation.
+    messages: list[ChatMessage] = [
+        ChatMessageSystem(content="You are a conversation title generator"),
+        ChatMessageUser(content=_block(f"Conversation ID: {_CID}")),
+    ]
+    assert _native_conversation_id(messages) is None
+
+
+def test_a_malformed_uuid_raises_rather_than_being_accepted() -> None:
+    # Accepting a non-UUID would bind the run to an identity the CLI's final
+    # result can never match, turning a parse bug into a scoring failure two
+    # layers away.
+    with pytest.raises(ValueError):
+        _native_conversation_id(_primary("not-a-uuid"))
+
+
+def test_a_native_block_without_an_id_raises() -> None:
+    # The block is present, so this IS a primary request -- treating it as
+    # auxiliary would silently exclude the real task from canonical state.
+    messages: list[ChatMessage] = [
+        ChatMessageSystem(content=_block("Workspace: /repo")),
+        ChatMessageUser(content="Do the task."),
+    ]
+    with pytest.raises(ValueError):
+        _native_conversation_id(messages)
+
+
+def test_two_blocks_in_one_message_are_ambiguous_and_raise() -> None:
+    content = "\n".join(
+        [_block(f"Conversation ID: {_CID}"), _block(f"Conversation ID: {_OTHER_CID}")]
+    )
+    with pytest.raises(ValueError):
+        _native_conversation_id([ChatMessageSystem(content=content)])
+
+
+def test_two_native_system_messages_are_ambiguous_and_raise() -> None:
+    messages: list[ChatMessage] = [_native_system(_CID), _native_system(_OTHER_CID)]
+    with pytest.raises(ValueError):
+        _native_conversation_id(messages)
+
+
+# --- binding the native conversation ----------------------------------------
+#
+# `_NativeConversation.accept` is what the agent hands to the bridge as
+# `state_filter`, so its signature is the core contract's:
+# `Callable[[Sequence[ChatMessage]], bool]`.
+
+
+def test_unattended_binds_the_first_native_conversation() -> None:
+    conversation = _NativeConversation(unattended=True)
+    assert conversation.bound_id is None
+
+    assert conversation.accept(_primary()) is True
+    assert conversation.bound_id == _CID
+    # The same conversation keeps being canonical across its whole invocation.
+    assert conversation.accept(_primary()) is True
+
+
+def test_unattended_rejects_a_second_native_conversation() -> None:
+    # One CLI invocation, one canonical conversation. A second native UUID is
+    # not the task the run is scoring, and the binding must not follow it.
+    conversation = _NativeConversation(unattended=True)
+    assert conversation.accept(_primary(_CID)) is True
+    assert conversation.accept(_primary(_OTHER_CID)) is False
+    assert conversation.bound_id == _CID
+
+
+def test_an_auxiliary_request_never_binds_and_is_never_canonical() -> None:
+    # The defect in one line: the title request arrives first, and must neither
+    # become canonical nor consume the binding the primary request needs.
+    conversation = _NativeConversation(unattended=True)
+    assert conversation.accept(_auxiliary()) is False
+    assert conversation.bound_id is None
+
+    assert conversation.accept(_primary()) is True
+    assert conversation.bound_id == _CID
+
+
+def test_centaur_accepts_every_native_conversation() -> None:
+    # The human may start or resume several conversations in one session, and
+    # the existing internal accumulation contract preserves them all.
+    conversation = _NativeConversation(unattended=False)
+    assert conversation.accept(_primary(_CID)) is True
+    assert conversation.accept(_primary(_OTHER_CID)) is True
+
+
+def test_centaur_still_excludes_auxiliary_requests() -> None:
+    conversation = _NativeConversation(unattended=False)
+    assert conversation.accept(_auxiliary()) is False
+
+
+@pytest.mark.parametrize("unattended", [True, False])
+def test_an_unreadable_declaration_propagates_out_of_the_filter(
+    unattended: bool,
+) -> None:
+    # The core contract propagates a callback exception rather than swallowing
+    # it, so a run against a CLI whose declaration has drifted fails loudly
+    # instead of quietly scoring the wrong conversation.
+    conversation = _NativeConversation(unattended=unattended)
+    with pytest.raises(ValueError):
+        conversation.accept(_primary("not-a-uuid"))
+
+
+def test_messages_with_no_system_message_have_no_conversation_id() -> None:
+    # The shape a re-entry carries when the prior turns did not come from this
+    # CLI at all -- a synthesised or replayed transcript. Distinct from the
+    # title request, which does have a system message.
+    messages: list[ChatMessage] = [
+        ChatMessageUser(content="What is 1+1?"),
+        ChatMessageAssistant(content="2"),
+        ChatMessageUser(content="And 2+2?"),
+    ]
+    assert _native_conversation_id(messages) is None
+
+
+# --- resuming a prior conversation ------------------------------------------
+#
+# On re-entry the conversation to keep canonical is the one the PREVIOUS
+# invocation ran, and its id is recoverable from the canonical system block the
+# previous invocation tracked. Binding it at construction rather than on the
+# first accepted request matters: the CLI's title conversation can be the first
+# request to arrive, and a tracker that binds whatever comes first would make
+# it canonical before the resumed conversation ever speaks.
+
+
+def test_a_prior_conversation_can_be_bound_before_any_request() -> None:
+    conversation = _NativeConversation(unattended=True, bound_id=_CID)
+    assert conversation.bound_id == _CID
+
+    # Another conversation arriving first does not take the binding...
+    assert conversation.accept(_primary(_OTHER_CID)) is False
+    assert conversation.bound_id == _CID
+    # ...and the resumed one is canonical whenever it arrives.
+    assert conversation.accept(_primary(_CID)) is True
+
+
+def test_a_prior_binding_still_excludes_auxiliary_requests() -> None:
+    conversation = _NativeConversation(unattended=True, bound_id=_CID)
+    assert conversation.accept(_auxiliary()) is False
+    assert conversation.bound_id == _CID
+
+
+def test_centaur_keeps_accepting_every_conversation_when_resuming() -> None:
+    # Resuming does not narrow centaur mode: the human still owns whatever
+    # conversations they start or resume in that session.
+    conversation = _NativeConversation(unattended=False, bound_id=_CID)
+    assert conversation.accept(_primary(_OTHER_CID)) is True
+    assert conversation.accept(_primary(_CID)) is True
+
+
+# --- native declaration framing ---------------------------------------------
+#
+# The block is found by matching an opener to a closer, so text that opens a
+# declaration without closing it -- or closes one without opening it -- matches
+# nothing at all. Both silent outcomes are wrong, and in opposite ways:
+#
+#   * no match at all reads as "no block", which is the positive signal for the
+#     CLI's auxiliary title request. A malformed primary request would then be
+#     excluded from canonical state, and the run would bind to whatever
+#     conversation came next -- or score nothing at all.
+#   * a match that stops early reads as "exactly one block", so a second,
+#     unterminated declaration is never counted and the ambiguity rule that
+#     exists to catch exactly that never fires.
+#
+# So the delimiters have to be counted and ordered before their contents are
+# read: whatever the framing fault is, it is not an auxiliary request and it is
+# not an unambiguous declaration.
+
+
+def test_an_unclosed_block_is_not_read_as_an_auxiliary_request() -> None:
+    # The dangerous direction. This request declares an identity; dropping it
+    # for want of a closing delimiter hands the task's conversation to the
+    # filter as though it were the CLI's own title traffic.
+    unclosed = ChatMessageSystem(
+        content="\n".join(
+            [
+                "<identity>You are a coding assistant.</identity>",
+                "<user_information>",
+                f"Conversation ID: {_CID}",
+                "<rules>Be brief.</rules>",
+            ]
+        )
+    )
+    with pytest.raises(ValueError):
+        _native_conversation_id([unclosed, ChatMessageUser(content="Do the task.")])
+
+
+def test_a_complete_block_followed_by_an_unclosed_one_raises() -> None:
+    # Two declarations, one of them truncated. Reading the first and ignoring
+    # the remainder is a guess: the id that survives may not be the one the
+    # CLI's own result reports, and a mismatch scores an unattributable run.
+    truncated_second = ChatMessageSystem(
+        content="\n".join(
+            [
+                _block(f"Conversation ID: {_CID}"),
+                "<user_information>",
+                f"Conversation ID: {_OTHER_CID}",
+            ]
+        )
+    )
+    with pytest.raises(ValueError):
+        _native_conversation_id(
+            [truncated_second, ChatMessageUser(content="Do the task.")]
+        )
+
+
+def test_a_stray_closing_delimiter_is_not_read_as_an_auxiliary_request() -> None:
+    stray = ChatMessageSystem(
+        content=f"Conversation ID: {_CID}\n</user_information>",
+    )
+    with pytest.raises(ValueError):
+        _native_conversation_id([stray, ChatMessageUser(content="Do the task.")])
+
+
+def test_a_repeated_opening_delimiter_raises() -> None:
+    # One closer for two openers: the match runs from the first opener, so the
+    # second is swallowed into the block's own body and the count still reads
+    # as one. Order and count of delimiters is what makes a block complete.
+    nested = ChatMessageSystem(
+        content="\n".join(
+            [
+                "<user_information>",
+                "<user_information>",
+                f"Conversation ID: {_CID}",
+                "</user_information>",
+            ]
+        )
+    )
+    with pytest.raises(ValueError):
+        _native_conversation_id([nested, ChatMessageUser(content="Do the task.")])
+
+
+def test_an_unclosed_block_before_a_complete_one_raises() -> None:
+    # This one already raises, by way of the two ids the swallowing match ends
+    # up carrying. It is asserted so that framing validation, once it counts
+    # the delimiters properly, keeps rejecting it rather than resolving it to
+    # the one complete block.
+    swallowed = ChatMessageSystem(
+        content="\n".join(
+            [
+                "<user_information>",
+                f"Conversation ID: {_OTHER_CID}",
+                _block(f"Conversation ID: {_CID}"),
+            ]
+        )
+    )
+    with pytest.raises(ValueError):
+        _native_conversation_id([swallowed, ChatMessageUser(content="Do the task.")])

--- a/tests/test_antigravity_cli_error_reporting.py
+++ b/tests/test_antigravity_cli_error_reporting.py
@@ -1,0 +1,235 @@
+"""Unit tests for the Antigravity CLI agent's failure reporting.
+
+When `agy` exits non-zero the only record of why is what this helper returns:
+it becomes the RuntimeError message, which is what lands in the Inspect eval
+log. Getting it wrong fails SILENTLY -- the run still errors, it just errors
+without a cause, and on a large eval set there is nothing left to diagnose
+from. That is what these tests exist to catch.
+
+Measured against the real `agy` binary (1.1.20): on failure the CLI writes its
+reasoning stream to stdout as ~2KB base64 Gemini thought signatures, one per
+turn, and the actual reason ("Error: timeout waiting for response") to stderr.
+"""
+
+import json
+
+import pytest
+from inspect_swe._antigravity_cli.antigravity_cli import (
+    _MAX_ERROR_LEN,
+    _clean_antigravity_error,
+    _verify_native_result,
+)
+
+REASON = "Error: timeout waiting for response"
+# Shaped like what agy actually prints: base64 signature then a closing tag on
+# its own line. The old filter only dropped lines STARTING with "<think", so
+# nothing here was filtered.
+SIGNATURE = "Ep8QCpwQAR" + "Zm9vYmFy" * 300
+
+
+def test_real_reason_survives_a_stdout_full_of_thought_signatures() -> None:
+    # Given: many turns' worth of opaque payload on stdout, the reason on stderr
+    stdout = "\n".join(f"{SIGNATURE}\n</think>" for _ in range(25))
+
+    # When: the failure output is cleaned for the traceback
+    cleaned = _clean_antigravity_error(stdout, f"{REASON}\n")
+
+    # Then: the reason is present and leads, rather than being truncated away.
+    assert REASON in cleaned
+    assert cleaned.startswith("STDERR:")
+    # And: no raw signature survives to crowd it out.
+    assert SIGNATURE not in cleaned
+
+
+def test_opaque_payloads_are_replaced_not_merely_truncated() -> None:
+    cleaned = _clean_antigravity_error(SIGNATURE, "")
+
+    assert SIGNATURE not in cleaned
+    assert "opaque payload" in cleaned
+
+
+def test_the_reason_survives_a_stdout_that_overruns_the_budget() -> None:
+    # The same failure, with no filter to save it: a CLI that failed late
+    # prints far more ordinary output than one error message can carry, and no
+    # scrubbing removes prose. Only leading with stderr keeps the reason inside
+    # the budget -- putting stdout first is exactly how a failed run once
+    # surfaced with no cause in it at all.
+    stdout = "\n".join(f"reading file {index}" for index in range(20_000))
+    assert len(stdout) > _MAX_ERROR_LEN
+
+    cleaned = _clean_antigravity_error(stdout, f"{REASON}\n")
+
+    assert cleaned.startswith(f"STDERR:\n{REASON}")
+    # Bounded, and it says where it stopped rather than leaving a clipped tail
+    # the reader cannot tell is missing.
+    assert len(cleaned) <= _MAX_ERROR_LEN + len("... (truncated)")
+    assert cleaned.endswith("... (truncated)")
+
+
+def test_ordinary_output_is_preserved_verbatim() -> None:
+    cleaned = _clean_antigravity_error("a note on stdout", "a reason on stderr")
+
+    assert "a reason on stderr" in cleaned
+    assert "a note on stdout" in cleaned
+    # Neither is dropped, and the reason still leads: ordering is the whole
+    # reason this helper exists, so it is asserted where nothing is truncated
+    # as well as where something is.
+    assert cleaned.index("a reason on stderr") < cleaned.index("a note on stdout")
+
+
+def test_no_output_is_reported_as_such() -> None:
+    assert _clean_antigravity_error("", "") == "Unknown error (no output)"
+
+
+# --- native result verification ---------------------------------------------
+#
+# A headless run's stdout is the CLI's own JSON result, and process exit status
+# alone does not describe it: the CLI can report a failed conversation while
+# exiting zero. Two things therefore have to hold before a run is scored or
+# returned -- the native status is SUCCESS, and the conversation the result
+# names is the one this invocation bound. A post-hoc mismatch is a failure,
+# never a fallback: scoring a conversation we did not run is worse than
+# erroring, because it produces a number nobody can attribute.
+#
+# The aggregate `response` in this envelope is deliberately never consulted.
+# Canonical output stays the bridge's real `ModelOutput`, messages, IDs and
+# usage; this parser only adjudicates identity and status.
+#
+# The shape below is the factory result envelope of a real 1.1.27 headless run
+# -- one JSON object, `conversation_id` in snake case, `status` at the top
+# level beside `response`, `duration_seconds`, `num_turns` and `usage`. The
+# CLI's STREAM json is a different envelope and is not what this reads.
+
+_RESULT_CID = "3f2504e0-4f89-11d3-9a0c-0305e82c3301"
+_OTHER_CID = "16fd2706-8baf-433b-82eb-8c7fada847da"
+
+
+def _result(status: str = "SUCCESS", conversation_id: str | None = _RESULT_CID) -> str:
+    """The CLI's final JSON result, in the shape a real 1.1.27 run prints."""
+    payload: dict[str, object] = {}
+    if conversation_id is not None:
+        payload["conversation_id"] = conversation_id
+    payload["status"] = status
+    payload["response"] = "an aggregate the wrapper must not adopt"
+    payload["duration_seconds"] = 4.712014882
+    payload["num_turns"] = 1
+    payload["usage"] = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "thinking_tokens": 0,
+        "cache_read_tokens": 0,
+        "total_tokens": 0,
+    }
+    return json.dumps(payload)
+
+
+def test_a_successful_result_for_the_bound_conversation_verifies() -> None:
+    # The only shape that may proceed to scoring.
+    _verify_native_result(_result(), _RESULT_CID)
+
+
+def test_a_result_naming_another_conversation_fails() -> None:
+    # The run bound one conversation; a result describing a different one is
+    # not evidence about this run at all.
+    with pytest.raises(RuntimeError):
+        _verify_native_result(_result(conversation_id=_OTHER_CID), _RESULT_CID)
+
+
+def test_a_result_without_a_conversation_id_fails() -> None:
+    # Unverifiable identity is treated as mismatched, not as "probably ours".
+    with pytest.raises(RuntimeError):
+        _verify_native_result(_result(conversation_id=None), _RESULT_CID)
+
+
+def test_a_non_success_status_fails_even_though_the_process_exited_zero() -> None:
+    # The specific silent path: returncode 0, so nothing in the launch looks
+    # wrong, while the CLI's own result says the conversation errored.
+    with pytest.raises(RuntimeError):
+        _verify_native_result(_result(status="ERROR"), _RESULT_CID)
+
+
+def test_an_absent_status_fails() -> None:
+    payload = json.dumps({"conversation_id": _RESULT_CID})
+    with pytest.raises(RuntimeError):
+        _verify_native_result(payload, _RESULT_CID)
+
+
+@pytest.mark.parametrize("stdout", ["", "   ", "not json at all", "{unclosed"])
+def test_stdout_that_carries_no_readable_result_fails(stdout: str) -> None:
+    # No result is not an implicit success. This is the shape a wedged or
+    # truncated run produces, and it must not reach a scorer.
+    with pytest.raises(RuntimeError):
+        _verify_native_result(stdout, _RESULT_CID)
+
+
+def test_a_malformed_final_result_is_not_rescued_by_an_earlier_one() -> None:
+    # A run that printed a result and then died mid-write leaves a truncated
+    # object after it. The FINAL result is the run's result: reaching back past
+    # the broken one reports SUCCESS for an attempt whose own result never
+    # arrived, which is the same unattributable score a mismatch would produce.
+    #
+    # There is also no evidence for tolerating a suffix at all -- the real
+    # `--output-format json` artifact is exactly one JSON object -- so a second
+    # object of any kind means something went wrong that this must not paper
+    # over.
+    with pytest.raises(RuntimeError):
+        _verify_native_result(f"{_result()}\n" + "{unclosed", _RESULT_CID)
+
+
+def test_the_failure_names_the_conversation_it_expected() -> None:
+    # Same reason the rest of this file exists: the raised message is the only
+    # record of why, and "identity mismatch" with neither ID in it cannot be
+    # diagnosed from an eval log.
+    with pytest.raises(RuntimeError) as failure:
+        _verify_native_result(_result(conversation_id=_OTHER_CID), _RESULT_CID)
+
+    message = str(failure.value)
+    assert _RESULT_CID in message
+    assert _OTHER_CID in message
+
+
+# --- an absent identity is not a matching one -------------------------------
+#
+# Both sides of the comparison are optional in their own right: a run has no
+# bound conversation until the CLI makes its first request, and a result object
+# need not carry `conversation_id` at all. Comparing them directly makes those
+# two absences agree with each other, so the one run with no identity anywhere
+# -- the CLI exiting SUCCESS having never opened a conversation the bridge saw
+# -- is the one run that passes unchallenged. It is the worst case to admit,
+# because there is no transcript behind it to attribute the score to.
+
+
+def test_a_result_naming_no_conversation_fails_when_none_was_bound() -> None:
+    with pytest.raises(RuntimeError):
+        _verify_native_result(_result(conversation_id=None), None)
+
+
+def test_a_named_conversation_fails_when_none_was_bound() -> None:
+    # The other half: the CLI ran something, and this run cannot say it was
+    # the thing being scored, because it never saw the conversation open.
+    with pytest.raises(RuntimeError):
+        _verify_native_result(_result(conversation_id=_RESULT_CID), None)
+
+
+def test_a_result_naming_no_conversation_fails_when_one_was_bound() -> None:
+    with pytest.raises(RuntimeError):
+        _verify_native_result(_result(conversation_id=None), _RESULT_CID)
+
+
+def test_a_non_string_conversation_id_fails() -> None:
+    # An id of the wrong type is not a near miss to compare: it means the
+    # envelope is not the one this parser adjudicates, whatever it says next.
+    payload = json.dumps({"conversation_id": 42, "status": "SUCCESS"})
+    with pytest.raises(RuntimeError):
+        _verify_native_result(payload, _RESULT_CID)
+
+
+def test_the_missing_identity_failure_says_which_side_is_missing() -> None:
+    # Same reason as the mismatch message: an eval log carrying only "identity
+    # mismatch" cannot tell whether the CLI named nothing or this run bound
+    # nothing, and those are different faults with different causes.
+    with pytest.raises(RuntimeError) as failure:
+        _verify_native_result(_result(conversation_id=None), None)
+
+    message = str(failure.value)
+    assert "conversation" in message

--- a/tests/test_antigravity_cli_factory.py
+++ b/tests/test_antigravity_cli_factory.py
@@ -1,0 +1,385 @@
+"""Focused contracts for the Antigravity CLI factory."""
+
+import asyncio
+import importlib
+import json
+from collections.abc import AsyncIterator, Callable, Sequence
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from typing import Literal, cast, overload
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from inspect_ai.agent import AgentState
+from inspect_ai.model import (
+    ChatMessage,
+    ChatMessageAssistant,
+    ChatMessageSystem,
+    ChatMessageUser,
+)
+from inspect_ai.tool._mcp._config import MCPServerConfigHTTP
+from inspect_ai.util import ExecResult, SandboxEnvironment
+from inspect_ai.util._sandbox import (
+    ExecRemoteAwaitableOptions,
+    ExecRemoteProcess,
+    ExecRemoteStreamingOptions,
+    SandboxEnvironmentConfigType,
+)
+from inspect_swe._util.centaur import CentaurOptions, CentaurSession, CommandsFilter
+
+_CID = "eccac0fd-d2b5-4b39-9888-175170faece0"
+_OTHER_CID = "16fd2706-8baf-433b-82eb-8c7fada847da"
+_NATIVE_RESULT = (
+    '{"conversation_id":"eccac0fd-d2b5-4b39-9888-175170faece0",'
+    '"status":"SUCCESS","response":"tool call for tool run_command\\n'
+    'FINAL_NATIVE_STORE_JSON\\n","duration_seconds":4.712014882,"num_turns":1,'
+    '"usage":{"input_tokens":0,"output_tokens":0,"thinking_tokens":0,'
+    '"cache_read_tokens":0,"total_tokens":0}}'
+)
+
+
+class _Sandbox(SandboxEnvironment):
+    def __init__(self) -> None:
+        super().__init__()
+        self.files: dict[str, str | bytes] = {}
+        self.remote_calls: list[tuple[list[str], ExecRemoteAwaitableOptions, bool]] = []
+        self.state_filter: Callable[[Sequence[ChatMessage]], bool] | None = None
+
+    async def exec(
+        self,
+        cmd: list[str],
+        input: str | bytes | None = None,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        user: str | None = None,
+        timeout: int | None = None,
+        timeout_retry: bool = True,
+        concurrency: bool = True,
+    ) -> ExecResult[str]:
+        if cmd == ["sh", "-c", "echo $HOME"]:
+            return ExecResult(
+                success=True, returncode=0, stdout="/home/agent\n", stderr=""
+            )
+        assert cmd == [
+            "mkdir",
+            "-p",
+            "/home/agent/.gemini/antigravity-cli",
+            # The onboarding cache. Provisioning creates it up front because the CLI
+            # writes onboarding.json into it on first launch, and a missing parent is
+            # what stalled a real hosted Drive session at the onboarding prompt.
+            "/home/agent/.gemini/antigravity-cli/cache",
+            "/home/agent/.gemini/config",
+        ]
+        return ExecResult(success=True, returncode=0, stdout="", stderr="")
+
+    async def write_file(self, file: str, contents: str | bytes) -> None:
+        self.files[file] = contents
+
+    @overload
+    async def read_file(self, file: str, text: Literal[True] = True) -> str: ...
+
+    @overload
+    async def read_file(self, file: str, text: Literal[False]) -> bytes: ...
+
+    async def read_file(self, file: str, text: bool = True) -> str | bytes:
+        contents = self.files[file]
+        if text:
+            return contents if isinstance(contents, str) else contents.decode()
+        return contents if isinstance(contents, bytes) else contents.encode()
+
+    @overload
+    async def exec_remote(
+        self,
+        cmd: list[str],
+        options: ExecRemoteStreamingOptions | None = None,
+        *,
+        stream: Literal[True] = True,
+    ) -> ExecRemoteProcess: ...
+
+    @overload
+    async def exec_remote(
+        self,
+        cmd: list[str],
+        options: ExecRemoteAwaitableOptions | None = None,
+        *,
+        stream: Literal[False],
+    ) -> ExecResult[str]: ...
+
+    async def exec_remote(
+        self,
+        cmd: list[str],
+        options: ExecRemoteStreamingOptions | ExecRemoteAwaitableOptions | None = None,
+        *,
+        stream: bool = True,
+    ) -> ExecRemoteProcess | ExecResult[str]:
+        assert stream is False
+        assert isinstance(options, ExecRemoteAwaitableOptions)
+        self.remote_calls.append((cmd, options, stream))
+        assert self.state_filter is not None
+        assert self.state_filter(_primary())
+        return ExecResult(success=True, returncode=0, stdout=_NATIVE_RESULT, stderr="")
+
+    @classmethod
+    async def sample_cleanup(
+        cls,
+        task_name: str,
+        config: SandboxEnvironmentConfigType | None,
+        environments: dict[str, SandboxEnvironment],
+        interrupted: bool,
+    ) -> None:
+        raise AssertionError("factory contract double must not clean a sample")
+
+
+def _primary(cid: str = _CID) -> list[ChatMessage]:
+    return [
+        ChatMessageSystem(
+            content=(f"<user_information>\nConversation ID: {cid}\n</user_information>")
+        ),
+        ChatMessageUser(content="Write files."),
+    ]
+
+
+def _auxiliary() -> list[ChatMessage]:
+    return [
+        ChatMessageSystem(content="You are a conversation title generator"),
+        ChatMessageUser(content="Write files."),
+    ]
+
+
+class _Store:
+    def get(self, key: str, default: int) -> int:
+        assert key == "antigravity_cli_model_port"
+        return default
+
+    def set(self, key: str, value: int) -> None:
+        assert key == "antigravity_cli_model_port"
+        assert value == 3001
+
+
+def test_unattended_factory_passes_all_bridge_contracts_and_verifies_result() -> None:
+    module = importlib.import_module("inspect_swe._antigravity_cli.antigravity_cli")
+    state = AgentState(messages=[])
+    sbox = _Sandbox()
+    bridge_options: dict[str, object] = {}
+    resolver = MagicMock()
+    request_filter = MagicMock()
+
+    @asynccontextmanager
+    async def bridge_context(
+        *_args: object, **kwargs: object
+    ) -> AsyncIterator[SimpleNamespace]:
+        bridge_options.update(kwargs)
+        sbox.state_filter = cast(
+            Callable[[Sequence[ChatMessage]], bool], kwargs["state_filter"]
+        )
+        yield SimpleNamespace(
+            port=8901,
+            mcp_server_configs=[],
+            bridged_tools={},
+            state=state,
+        )
+
+    with (
+        patch.object(module, "sandbox_env", return_value=sbox),
+        patch.object(module, "store", return_value=_Store()),
+        patch.object(module, "resolve_agent_cwd", AsyncMock(return_value="/workspace")),
+        patch.object(
+            module, "ensure_agent_binary_installed", AsyncMock(return_value="/opt/agy")
+        ),
+        patch.object(module, "sandbox_agent_bridge", bridge_context),
+        patch.object(module, "build_user_prompt", return_value=("write files", False)),
+    ):
+        assert (
+            asyncio.run(
+                module.antigravity_cli(
+                    version="1.1.27",
+                    model_resolver=resolver,
+                    filter=request_filter,
+                    accumulate_conversations=True,
+                )(state)
+            )
+            is state
+        )
+
+    assert bridge_options["model_resolver"] is resolver
+    assert bridge_options["filter"] is request_filter
+    assert bridge_options["accumulate_conversations"] is True
+    state_filter = cast(
+        Callable[[Sequence[ChatMessage]], bool], bridge_options["state_filter"]
+    )
+    assert state_filter(_auxiliary()) is False
+    assert state_filter(_primary(_OTHER_CID)) is False
+
+    assert len(sbox.remote_calls) == 1
+    command, options, stream = sbox.remote_calls[0]
+    assert command == [
+        "bash",
+        "-c",
+        'exec 0</dev/null; "$@"',
+        "bash",
+        "/opt/agy",
+        "--model",
+        "gemini-3.6-flash",
+        "--effort",
+        "low",
+        "--disable-slash-commands",
+        "--dangerously-skip-permissions",
+        "--output-format",
+        "json",
+        "--print",
+        "write files",
+    ]
+    assert options.cwd == "/workspace"
+    assert options.user is None
+    assert options.concurrency is False
+    assert options.env is not None
+    assert "PATH" not in options.env
+    assert stream is False
+
+
+def test_centaur_factory_preserves_session_and_scopes_the_named_sandbox() -> None:
+    module = importlib.import_module("inspect_swe._antigravity_cli.antigravity_cli")
+    state = AgentState(messages=[*_primary(), *_primary(_OTHER_CID)])
+    sbox = _Sandbox()
+    bridge_options: dict[str, object] = {}
+    handed: dict[str, object] = {}
+    commands_filter = MagicMock()
+    endpoint = MCPServerConfigHTTP(
+        type="http", name="inspect-tools", url="http://localhost:3001/mcp"
+    )
+    bridge = SimpleNamespace(
+        port=8901,
+        mcp_server_configs=[endpoint],
+        bridged_tools={"inspect-tools": ["echo"]},
+        state=state,
+    )
+
+    @asynccontextmanager
+    async def bridge_context(
+        *_args: object, **kwargs: object
+    ) -> AsyncIterator[SimpleNamespace]:
+        bridge_options.update(kwargs)
+        yield bridge
+
+    async def capture_centaur(
+        options: CentaurOptions,
+        agy_cmd: list[str],
+        agent_env: dict[str, str],
+        session: CentaurSession,
+        commands_filter: CommandsFilter | None = None,
+    ) -> AgentState:
+        handed.update(
+            options=options,
+            command=agy_cmd,
+            environment=agent_env,
+            session=session,
+            commands_filter=commands_filter,
+        )
+        state_filter = cast(
+            Callable[[Sequence[ChatMessage]], bool], bridge_options["state_filter"]
+        )
+        assert state_filter(_primary()) is True
+        assert state_filter(_primary(_OTHER_CID)) is True
+        assert state_filter(_auxiliary()) is False
+        return session.state
+
+    wait_for_mcp_endpoints = AsyncMock()
+    options = CentaurOptions()
+    with (
+        patch.object(module, "sandbox_env", return_value=sbox) as sandbox_env,
+        patch.object(module, "store", return_value=_Store()),
+        patch.object(module, "resolve_agent_cwd", AsyncMock(return_value="/workspace")),
+        patch.object(
+            module, "ensure_agent_binary_installed", AsyncMock(return_value="/opt/agy")
+        ),
+        patch.object(module, "sandbox_agent_bridge", bridge_context),
+        patch.object(module, "build_user_prompt", return_value=("write files", False)),
+        patch.object(module, "wait_for_mcp_endpoints", wait_for_mcp_endpoints),
+        patch.object(module, "_run_antigravity_cli_centaur", capture_centaur),
+    ):
+        assert (
+            asyncio.run(
+                module.antigravity_cli(
+                    centaur=options,
+                    version="1.1.27",
+                    sandbox="target",
+                    cwd="/workspace",
+                    user="agent",
+                    commands_filter=commands_filter,
+                )(state)
+            )
+            is state
+        )
+
+    sandbox_env.assert_called_once_with("target")
+    wait_for_mcp_endpoints.assert_awaited_once_with(
+        [endpoint],
+        bridge,
+        sandbox="target",
+        timeout=module.DEFAULT_MCP_READY_TIMEOUT,
+        required=True,
+    )
+    session = cast(CentaurSession, handed["session"])
+    assert session.state is state
+    assert session.sandbox is sbox
+    assert session.sandbox_name == "target"
+    assert session.user == "agent"
+    assert session.cwd == "/workspace"
+    assert handed["commands_filter"] is commands_filter
+    assert handed["command"] == [
+        "/opt/agy",
+        "--model",
+        "gemini-3.6-flash",
+        "--effort",
+        "low",
+    ]
+    environment = cast(dict[str, str], handed["environment"])
+    assert "PATH" not in environment
+    assert "toolPermission" not in json.loads(
+        next(
+            contents
+            for path, contents in sbox.files.items()
+            if path.endswith("settings.json")
+        )
+    )
+
+
+def test_unattended_reentry_resumes_only_the_seeded_native_conversation() -> None:
+    module = importlib.import_module("inspect_swe._antigravity_cli.antigravity_cli")
+    state = AgentState(
+        messages=[
+            *_primary(),
+            ChatMessageAssistant(content="The first turn completed."),
+        ]
+    )
+    sbox = _Sandbox()
+
+    @asynccontextmanager
+    async def bridge_context(
+        *_args: object, **kwargs: object
+    ) -> AsyncIterator[SimpleNamespace]:
+        sbox.state_filter = cast(
+            Callable[[Sequence[ChatMessage]], bool], kwargs["state_filter"]
+        )
+        yield SimpleNamespace(
+            port=8901,
+            mcp_server_configs=[],
+            bridged_tools={},
+            state=state,
+        )
+
+    with (
+        patch.object(module, "sandbox_env", return_value=sbox),
+        patch.object(module, "store", return_value=_Store()),
+        patch.object(module, "resolve_agent_cwd", AsyncMock(return_value="/workspace")),
+        patch.object(
+            module, "ensure_agent_binary_installed", AsyncMock(return_value="/opt/agy")
+        ),
+        patch.object(module, "sandbox_agent_bridge", bridge_context),
+        patch.object(module, "build_user_prompt", return_value=("retry", True)),
+    ):
+        assert asyncio.run(module.antigravity_cli(version="1.1.27")(state)) is state
+
+    assert len(sbox.remote_calls) == 1
+    command = sbox.remote_calls[0][0]
+    assert command[command.index("--conversation") + 1] == _CID
+    assert "--continue" not in command

--- a/tests/test_centaur.py
+++ b/tests/test_centaur.py
@@ -1,0 +1,145 @@
+"""Unit tests for the shared centaur runner's user and sandbox handling.
+
+`run_centaur` is the one seam every native CLI wrapper hands its human session
+to. Two things a wrapper resolves for its own launch have to reach that session
+as well: which user to act as, and which of several sandboxes to act in.
+Neither is a preference. A terminal in the wrong container, or opened as the
+wrong user, is not the environment the agent would have run in, and the files a
+human produces there are not the files the task goes on to score.
+
+The wrapping is asserted here; that it really redirects an unnamed `sandbox()`
+lookup is asserted against two live containers in `test_antigravity_cli.py`.
+"""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from functools import partial
+from typing import Any
+from unittest.mock import patch
+
+import anyio
+from inspect_ai.agent import Agent, AgentState, agent
+from inspect_ai.model import ChatMessageUser
+from inspect_swe._util import centaur as centaur_module
+from inspect_swe._util.centaur import CentaurOptions, run_centaur
+
+_USER = "agent"
+_SANDBOX = "target"
+_INSTRUCTIONS = "You may also use the CLI via the 'agy' command."
+_BASHRC = "alias agy='/var/tmp/agy --print'"
+
+
+class _RecordedSession:
+    """Stands in for the human's terminal, recording what it was handed.
+
+    The trace records the order of the two things that matter: that the session
+    was both built and run inside the sandbox selection, and that the selection
+    was given back afterwards rather than left set for whatever runs next.
+    """
+
+    def __init__(self) -> None:
+        self.handed: list[dict[str, Any]] = []
+        self.trace: list[str] = []
+
+    def human_cli(self, **kwargs: Any) -> Agent:
+        self.handed.append(dict(kwargs))
+        self.trace.append("built")
+
+        @agent
+        def session() -> Agent:
+            async def execute(state: AgentState) -> AgentState:
+                self.trace.append("ran")
+                return state
+
+            return execute
+
+        return session()
+
+    @contextmanager
+    def sandbox_default(self, name: str) -> Iterator[None]:
+        self.trace.append(f"selected:{name}")
+        try:
+            yield
+        finally:
+            self.trace.append(f"released:{name}")
+
+
+def _run_centaur(session: _RecordedSession, **kwargs: Any) -> None:
+    state = AgentState(messages=[ChatMessageUser(content="Work on the task.")])
+    with (
+        patch.object(centaur_module, "human_cli", session.human_cli),
+        # create=True: the runner has to reach for this by name for a named
+        # sandbox to be selectable at all, and the test says which name.
+        patch.object(
+            centaur_module, "sandbox_default", session.sandbox_default, create=True
+        ),
+    ):
+        anyio.run(
+            partial(
+                run_centaur,
+                CentaurOptions(),
+                _INSTRUCTIONS,
+                _BASHRC,
+                state,
+                **kwargs,
+            )
+        )
+
+
+def test_the_human_session_runs_as_the_selected_user() -> None:
+    # A wrapper told to act as a particular user acts as that user everywhere,
+    # or the human is handed a shell that cannot read what the agent wrote.
+    session = _RecordedSession()
+    _run_centaur(session, user=_USER, sandbox=None)
+
+    assert session.handed, "the human session was never created"
+    assert session.handed[0]["user"] == _USER
+
+
+def test_the_human_session_defaults_to_the_sandbox_user_when_unset() -> None:
+    # Withheld, not invented: no selected user means the sandbox's own default,
+    # which is what `human_cli` already does with `None`.
+    session = _RecordedSession()
+    _run_centaur(session, user=None, sandbox=None)
+
+    assert session.handed[0]["user"] is None
+
+
+def test_the_whole_human_session_runs_in_the_named_sandbox() -> None:
+    # Both halves are inside the selection: `human_cli` installs the task tools
+    # when it is built, and offers the login when it runs, and each resolves
+    # the default sandbox for itself.
+    session = _RecordedSession()
+    _run_centaur(session, user=None, sandbox=_SANDBOX)
+
+    assert session.trace == [
+        f"selected:{_SANDBOX}",
+        "built",
+        "ran",
+        f"released:{_SANDBOX}",
+    ]
+
+
+def test_an_unnamed_sandbox_leaves_the_ambient_default_alone() -> None:
+    # The single-container case, which is nearly every task: there is nothing
+    # to select, and a selection made anyway would name a sandbox the caller
+    # never asked for.
+    session = _RecordedSession()
+    _run_centaur(session, user=None, sandbox=None)
+
+    assert session.trace == ["built", "ran"]
+
+
+def test_the_session_still_gets_its_options_and_shell_content() -> None:
+    # The rest of what the runner has always forwarded, asserted so that adding
+    # the two above cannot quietly drop any of it.
+    session = _RecordedSession()
+    _run_centaur(session, user=_USER, sandbox=_SANDBOX)
+
+    handed = session.handed[0]
+    options = CentaurOptions()
+    assert handed["answer"] == options.answer
+    assert handed["intermediate_scoring"] == options.intermediate_scoring
+    assert handed["record_session"] == options.record_session
+    assert handed["instructions"] == _INSTRUCTIONS
+    assert handed["bashrc"] == _BASHRC

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -12,6 +12,7 @@ from inspect_swe import (
     download_wheels_tarball,
     resolve_agent_version,
 )
+from inspect_swe._util.agentbinary import AgentBinaryVersion
 from inspect_swe._util.download import download_file
 
 
@@ -99,8 +100,62 @@ def test_resolve_agent_version_rejects_unknown_platform() -> None:
 
 @pytest.mark.parametrize("version", ["stable", "1.2.3"])
 def test_resolve_agent_version_rejects_unknown_agent(version: str) -> None:
-    with pytest.raises(ValueError, match="claude_code, codex_cli, kimi_code"):
+    # The whole allowed list, not a prefix of it: the message is how a caller
+    # discovers which agents this accepts, so an entry silently dropped from it
+    # is a supported agent nobody can find.
+    with pytest.raises(
+        ValueError,
+        match="antigravity_cli, claude_code, codex_cli, kimi_code, opencode",
+    ):
         resolve_agent_version("gemini_cli", version)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("version", ["1.1.27", "auto", "sandbox"])
+def test_resolve_agent_version_passes_antigravity_versions_through(
+    version: str,
+) -> None:
+    # An explicit version is already concrete, and "auto" / "sandbox" name
+    # whatever the sandbox happens to hold, so none of the three can be
+    # resolved on the host and none should cost a release lookup. Asserted as
+    # "no resolution was attempted": a passthrough that quietly reached the
+    # network would still return the right string, while making every pinned
+    # run depend on GitHub being up.
+    from inspect_swe._tools import download as download_tool
+
+    resolve = AsyncMock()
+    with patch.object(download_tool, "resolve_agent_binary_version", resolve):
+        assert resolve_agent_version("antigravity_cli", version) == version
+
+    resolve.assert_not_awaited()
+
+
+@pytest.mark.parametrize("version", ["stable", "latest"])
+def test_resolve_agent_version_resolves_antigravity_floating_versions(
+    version: str,
+) -> None:
+    # The two that do cost a lookup, and the reason the API exists: pin once at
+    # setup so every sample installs the same binary. The caller gets back the
+    # concrete version, resolved against the Antigravity source -- not whichever
+    # source the shared factory would otherwise fall through to.
+    from inspect_swe._tools import download as download_tool
+
+    resolve = AsyncMock(
+        return_value=AgentBinaryVersion(
+            "1.1.27", "digest", "https://example.com/agy_cli_linux_arm64.tar.gz"
+        )
+    )
+    with patch.object(download_tool, "resolve_agent_binary_version", resolve):
+        resolved = resolve_agent_version("antigravity_cli", version, "linux-arm64")
+
+    assert resolved == "1.1.27"
+    assert resolve.await_args is not None
+    source, requested, platform = resolve.await_args.args
+    # `agy` is the binary name, and the cache key resolution is stored under.
+    assert source.binary == "agy"
+    # Passed on as asked: resolving "stable" against the "latest" manifest, or
+    # against another platform's, silently pins the wrong build.
+    assert requested == version
+    assert platform == "linux-arm64"
 
 
 @pytest.mark.slow

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -2,7 +2,7 @@ from inspect_ai import Task, eval, task
 from inspect_ai.dataset import Sample
 from inspect_swe import claude_code
 
-from tests.conftest import skip_if_no_k8s
+from tests.conftest import skip_if_no_anthropic, skip_if_no_k8s
 
 
 @task
@@ -14,6 +14,11 @@ def t() -> Task:
     )
 
 
+# Reaches a live Anthropic model, so it needs the key as well as the cluster.
+# Without the provider gate this is the one test in the suite that bills a real
+# generation from a bare `pytest`, and on a keyless machine it fails rather than
+# skipping -- which is how it turned up.
+@skip_if_no_anthropic
 @skip_if_no_k8s
 def test_k8s() -> None:
     log = eval(

--- a/uv.lock
+++ b/uv.lock
@@ -266,7 +266,7 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "cffi", marker = "python_full_version >= '3.14'" },
+    { name = "cffi" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/e9/184b8ccce6683b0aa2fbb7ba5683ea4b9c5763f1356347f1312c32e3c66e/argon2-cffi-bindings-21.2.0.tar.gz", hash = "sha256:bb89ceffa6c791807d1305ceb77dbfacc5aa499891d2c55661c6459651fc39e3", size = 1779911, upload-time = "2021-12-01T08:52:55.68Z" }
 wheels = [
@@ -292,7 +292,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "cffi", marker = "python_full_version < '3.14'" },
+    { name = "cffi" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5c/2d/db8af0df73c1cf454f71b2bbe5e356b8c1f8041c979f505b3d3186e520a9/argon2_cffi_bindings-25.1.0.tar.gz", hash = "sha256:b957f3e6ea4d55d820e40ff76f450952807013d361a65d7f28acc0acbf29229d", size = 1783441, upload-time = "2025-07-30T10:02:05.147Z" }
 wheels = [
@@ -452,15 +452,6 @@ wheels = [
 ]
 
 [[package]]
-name = "cachetools"
-version = "5.5.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6c/81/3747dad6b14fa2cf53fcf10548cf5aea6913e96fab41a3c198676f8948a5/cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4", size = 28380, upload-time = "2025-02-20T21:01:19.524Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/76/20fa66124dbe6be5cafeb312ece67de6b61dd91a0247d1ea13db4ebb33c2/cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a", size = 10080, upload-time = "2025-02-20T21:01:16.647Z" },
-]
-
-[[package]]
 name = "certifi"
 version = "2025.8.3"
 source = { registry = "https://pypi.org/simple" }
@@ -471,59 +462,112 @@ wheels = [
 
 [[package]]
 name = "cffi"
-version = "1.17.1"
+version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz", hash = "sha256:1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824", size = 516621, upload-time = "2024-09-04T20:45:21.852Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/ef/008a1939e372c06329a3fce4279c02f328488f3526744906eeec3da7ad5f/cffi-2.1.1.tar.gz", hash = "sha256:dd31f52ea1086513bb9df30f8fcee9b8918323ae067a3d5b78bc826a000712be", size = 530807, upload-time = "2026-08-03T21:21:18.939Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/07/f44ca684db4e4f08a3fdc6eeb9a0d15dc6883efc7b8c90357fdbf74e186c/cffi-1.17.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:df8b1c11f177bc2313ec4b2d46baec87a5f3e71fc8b45dab2ee7cae86d9aba14", size = 182191, upload-time = "2024-09-04T20:43:30.027Z" },
-    { url = "https://files.pythonhosted.org/packages/08/fd/cc2fedbd887223f9f5d170c96e57cbf655df9831a6546c1727ae13fa977a/cffi-1.17.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8f2cdc858323644ab277e9bb925ad72ae0e67f69e804f4898c070998d50b1a67", size = 178592, upload-time = "2024-09-04T20:43:32.108Z" },
-    { url = "https://files.pythonhosted.org/packages/de/cc/4635c320081c78d6ffc2cab0a76025b691a91204f4aa317d568ff9280a2d/cffi-1.17.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:edae79245293e15384b51f88b00613ba9f7198016a5948b5dddf4917d4d26382", size = 426024, upload-time = "2024-09-04T20:43:34.186Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/7b/3b2b250f3aab91abe5f8a51ada1b717935fdaec53f790ad4100fe2ec64d1/cffi-1.17.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:45398b671ac6d70e67da8e4224a065cec6a93541bb7aebe1b198a61b58c7b702", size = 448188, upload-time = "2024-09-04T20:43:36.286Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/48/1b9283ebbf0ec065148d8de05d647a986c5f22586b18120020452fff8f5d/cffi-1.17.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ad9413ccdeda48c5afdae7e4fa2192157e991ff761e7ab8fdd8926f40b160cc3", size = 455571, upload-time = "2024-09-04T20:43:38.586Z" },
-    { url = "https://files.pythonhosted.org/packages/40/87/3b8452525437b40f39ca7ff70276679772ee7e8b394934ff60e63b7b090c/cffi-1.17.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5da5719280082ac6bd9aa7becb3938dc9f9cbd57fac7d2871717b1feb0902ab6", size = 436687, upload-time = "2024-09-04T20:43:40.084Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/fb/4da72871d177d63649ac449aec2e8a29efe0274035880c7af59101ca2232/cffi-1.17.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bb1a08b8008b281856e5971307cc386a8e9c5b625ac297e853d36da6efe9c17", size = 446211, upload-time = "2024-09-04T20:43:41.526Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/a0/62f00bcb411332106c02b663b26f3545a9ef136f80d5df746c05878f8c4b/cffi-1.17.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:045d61c734659cc045141be4bae381a41d89b741f795af1dd018bfb532fd0df8", size = 461325, upload-time = "2024-09-04T20:43:43.117Z" },
-    { url = "https://files.pythonhosted.org/packages/36/83/76127035ed2e7e27b0787604d99da630ac3123bfb02d8e80c633f218a11d/cffi-1.17.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:6883e737d7d9e4899a8a695e00ec36bd4e5e4f18fabe0aca0efe0a4b44cdb13e", size = 438784, upload-time = "2024-09-04T20:43:45.256Z" },
-    { url = "https://files.pythonhosted.org/packages/21/81/a6cd025db2f08ac88b901b745c163d884641909641f9b826e8cb87645942/cffi-1.17.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:6b8b4a92e1c65048ff98cfe1f735ef8f1ceb72e3d5f0c25fdb12087a23da22be", size = 461564, upload-time = "2024-09-04T20:43:46.779Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/fe/4d41c2f200c4a457933dbd98d3cf4e911870877bd94d9656cc0fcb390681/cffi-1.17.1-cp310-cp310-win32.whl", hash = "sha256:c9c3d058ebabb74db66e431095118094d06abf53284d9c81f27300d0e0d8bc7c", size = 171804, upload-time = "2024-09-04T20:43:48.186Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/b6/0b0f5ab93b0df4acc49cae758c81fe4e5ef26c3ae2e10cc69249dfd8b3ab/cffi-1.17.1-cp310-cp310-win_amd64.whl", hash = "sha256:0f048dcf80db46f0098ccac01132761580d28e28bc0f78ae0d58048063317e15", size = 181299, upload-time = "2024-09-04T20:43:49.812Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/f4/927e3a8899e52a27fa57a48607ff7dc91a9ebe97399b357b85a0c7892e00/cffi-1.17.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a45e3c6913c5b87b3ff120dcdc03f6131fa0065027d0ed7ee6190736a74cd401", size = 182264, upload-time = "2024-09-04T20:43:51.124Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/f5/6c3a8efe5f503175aaddcbea6ad0d2c96dad6f5abb205750d1b3df44ef29/cffi-1.17.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:30c5e0cb5ae493c04c8b42916e52ca38079f1b235c2f8ae5f4527b963c401caf", size = 178651, upload-time = "2024-09-04T20:43:52.872Z" },
-    { url = "https://files.pythonhosted.org/packages/94/dd/a3f0118e688d1b1a57553da23b16bdade96d2f9bcda4d32e7d2838047ff7/cffi-1.17.1-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f75c7ab1f9e4aca5414ed4d8e5c0e303a34f4421f8a0d47a4d019ceff0ab6af4", size = 445259, upload-time = "2024-09-04T20:43:56.123Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/ea/70ce63780f096e16ce8588efe039d3c4f91deb1dc01e9c73a287939c79a6/cffi-1.17.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a1ed2dd2972641495a3ec98445e09766f077aee98a1c896dcb4ad0d303628e41", size = 469200, upload-time = "2024-09-04T20:43:57.891Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/a0/a4fa9f4f781bda074c3ddd57a572b060fa0df7655d2a4247bbe277200146/cffi-1.17.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:46bf43160c1a35f7ec506d254e5c890f3c03648a4dbac12d624e4490a7046cd1", size = 477235, upload-time = "2024-09-04T20:44:00.18Z" },
-    { url = "https://files.pythonhosted.org/packages/62/12/ce8710b5b8affbcdd5c6e367217c242524ad17a02fe5beec3ee339f69f85/cffi-1.17.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a24ed04c8ffd54b0729c07cee15a81d964e6fee0e3d4d342a27b020d22959dc6", size = 459721, upload-time = "2024-09-04T20:44:01.585Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/6b/d45873c5e0242196f042d555526f92aa9e0c32355a1be1ff8c27f077fd37/cffi-1.17.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:610faea79c43e44c71e1ec53a554553fa22321b65fae24889706c0a84d4ad86d", size = 467242, upload-time = "2024-09-04T20:44:03.467Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/52/d9a0e523a572fbccf2955f5abe883cfa8bcc570d7faeee06336fbd50c9fc/cffi-1.17.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:a9b15d491f3ad5d692e11f6b71f7857e7835eb677955c00cc0aefcd0669adaf6", size = 477999, upload-time = "2024-09-04T20:44:05.023Z" },
-    { url = "https://files.pythonhosted.org/packages/44/74/f2a2460684a1a2d00ca799ad880d54652841a780c4c97b87754f660c7603/cffi-1.17.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:de2ea4b5833625383e464549fec1bc395c1bdeeb5f25c4a3a82b5a8c756ec22f", size = 454242, upload-time = "2024-09-04T20:44:06.444Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/4a/34599cac7dfcd888ff54e801afe06a19c17787dfd94495ab0c8d35fe99fb/cffi-1.17.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:fc48c783f9c87e60831201f2cce7f3b2e4846bf4d8728eabe54d60700b318a0b", size = 478604, upload-time = "2024-09-04T20:44:08.206Z" },
-    { url = "https://files.pythonhosted.org/packages/34/33/e1b8a1ba29025adbdcda5fb3a36f94c03d771c1b7b12f726ff7fef2ebe36/cffi-1.17.1-cp311-cp311-win32.whl", hash = "sha256:85a950a4ac9c359340d5963966e3e0a94a676bd6245a4b55bc43949eee26a655", size = 171727, upload-time = "2024-09-04T20:44:09.481Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/97/50228be003bb2802627d28ec0627837ac0bf35c90cf769812056f235b2d1/cffi-1.17.1-cp311-cp311-win_amd64.whl", hash = "sha256:caaf0640ef5f5517f49bc275eca1406b0ffa6aa184892812030f04c2abf589a0", size = 181400, upload-time = "2024-09-04T20:44:10.873Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/84/e94227139ee5fb4d600a7a4927f322e1d4aea6fdc50bd3fca8493caba23f/cffi-1.17.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:805b4371bf7197c329fcb3ead37e710d1bca9da5d583f5073b799d5c5bd1eee4", size = 183178, upload-time = "2024-09-04T20:44:12.232Z" },
-    { url = "https://files.pythonhosted.org/packages/da/ee/fb72c2b48656111c4ef27f0f91da355e130a923473bf5ee75c5643d00cca/cffi-1.17.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:733e99bc2df47476e3848417c5a4540522f234dfd4ef3ab7fafdf555b082ec0c", size = 178840, upload-time = "2024-09-04T20:44:13.739Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/b6/db007700f67d151abadf508cbfd6a1884f57eab90b1bb985c4c8c02b0f28/cffi-1.17.1-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1257bdabf294dceb59f5e70c64a3e2f462c30c7ad68092d01bbbfb1c16b1ba36", size = 454803, upload-time = "2024-09-04T20:44:15.231Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/df/f8d151540d8c200eb1c6fba8cd0dfd40904f1b0682ea705c36e6c2e97ab3/cffi-1.17.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da95af8214998d77a98cc14e3a3bd00aa191526343078b530ceb0bd710fb48a5", size = 478850, upload-time = "2024-09-04T20:44:17.188Z" },
-    { url = "https://files.pythonhosted.org/packages/28/c0/b31116332a547fd2677ae5b78a2ef662dfc8023d67f41b2a83f7c2aa78b1/cffi-1.17.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d63afe322132c194cf832bfec0dc69a99fb9bb6bbd550f161a49e9e855cc78ff", size = 485729, upload-time = "2024-09-04T20:44:18.688Z" },
-    { url = "https://files.pythonhosted.org/packages/91/2b/9a1ddfa5c7f13cab007a2c9cc295b70fbbda7cb10a286aa6810338e60ea1/cffi-1.17.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f79fc4fc25f1c8698ff97788206bb3c2598949bfe0fef03d299eb1b5356ada99", size = 471256, upload-time = "2024-09-04T20:44:20.248Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/d5/da47df7004cb17e4955df6a43d14b3b4ae77737dff8bf7f8f333196717bf/cffi-1.17.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b62ce867176a75d03a665bad002af8e6d54644fad99a3c70905c543130e39d93", size = 479424, upload-time = "2024-09-04T20:44:21.673Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/ac/2a28bcf513e93a219c8a4e8e125534f4f6db03e3179ba1c45e949b76212c/cffi-1.17.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:386c8bf53c502fff58903061338ce4f4950cbdcb23e2902d86c0f722b786bbe3", size = 484568, upload-time = "2024-09-04T20:44:23.245Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/38/ca8a4f639065f14ae0f1d9751e70447a261f1a30fa7547a828ae08142465/cffi-1.17.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:4ceb10419a9adf4460ea14cfd6bc43d08701f0835e979bf821052f1805850fe8", size = 488736, upload-time = "2024-09-04T20:44:24.757Z" },
-    { url = "https://files.pythonhosted.org/packages/86/c5/28b2d6f799ec0bdecf44dced2ec5ed43e0eb63097b0f58c293583b406582/cffi-1.17.1-cp312-cp312-win32.whl", hash = "sha256:a08d7e755f8ed21095a310a693525137cfe756ce62d066e53f502a83dc550f65", size = 172448, upload-time = "2024-09-04T20:44:26.208Z" },
-    { url = "https://files.pythonhosted.org/packages/50/b9/db34c4755a7bd1cb2d1603ac3863f22bcecbd1ba29e5ee841a4bc510b294/cffi-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:51392eae71afec0d0c8fb1a53b204dbb3bcabcb3c9b807eedf3e1e6ccf2de903", size = 181976, upload-time = "2024-09-04T20:44:27.578Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/f8/dd6c246b148639254dad4d6803eb6a54e8c85c6e11ec9df2cffa87571dbe/cffi-1.17.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f3a2b4222ce6b60e2e8b337bb9596923045681d71e5a082783484d845390938e", size = 182989, upload-time = "2024-09-04T20:44:28.956Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/f1/672d303ddf17c24fc83afd712316fda78dc6fce1cd53011b839483e1ecc8/cffi-1.17.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0984a4925a435b1da406122d4d7968dd861c1385afe3b45ba82b750f229811e2", size = 178802, upload-time = "2024-09-04T20:44:30.289Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/2d/eab2e858a91fdff70533cab61dcff4a1f55ec60425832ddfdc9cd36bc8af/cffi-1.17.1-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d01b12eeeb4427d3110de311e1774046ad344f5b1a7403101878976ecd7a10f3", size = 454792, upload-time = "2024-09-04T20:44:32.01Z" },
-    { url = "https://files.pythonhosted.org/packages/75/b2/fbaec7c4455c604e29388d55599b99ebcc250a60050610fadde58932b7ee/cffi-1.17.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:706510fe141c86a69c8ddc029c7910003a17353970cff3b904ff0686a5927683", size = 478893, upload-time = "2024-09-04T20:44:33.606Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/b7/6e4a2162178bf1935c336d4da8a9352cccab4d3a5d7914065490f08c0690/cffi-1.17.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de55b766c7aa2e2a3092c51e0483d700341182f08e67c63630d5b6f200bb28e5", size = 485810, upload-time = "2024-09-04T20:44:35.191Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/8a/1d0e4a9c26e54746dc08c2c6c037889124d4f59dffd853a659fa545f1b40/cffi-1.17.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c59d6e989d07460165cc5ad3c61f9fd8f1b4796eacbd81cee78957842b834af4", size = 471200, upload-time = "2024-09-04T20:44:36.743Z" },
-    { url = "https://files.pythonhosted.org/packages/26/9f/1aab65a6c0db35f43c4d1b4f580e8df53914310afc10ae0397d29d697af4/cffi-1.17.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd398dbc6773384a17fe0d3e7eeb8d1a21c2200473ee6806bb5e6a8e62bb73dd", size = 479447, upload-time = "2024-09-04T20:44:38.492Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/e4/fb8b3dd8dc0e98edf1135ff067ae070bb32ef9d509d6cb0f538cd6f7483f/cffi-1.17.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3edc8d958eb099c634dace3c7e16560ae474aa3803a5df240542b305d14e14ed", size = 484358, upload-time = "2024-09-04T20:44:40.046Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/47/d7145bf2dc04684935d57d67dff9d6d795b2ba2796806bb109864be3a151/cffi-1.17.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:72e72408cad3d5419375fc87d289076ee319835bdfa2caad331e377589aebba9", size = 488469, upload-time = "2024-09-04T20:44:41.616Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/ee/f94057fa6426481d663b88637a9a10e859e492c73d0384514a17d78ee205/cffi-1.17.1-cp313-cp313-win32.whl", hash = "sha256:e03eab0a8677fa80d646b5ddece1cbeaf556c313dcfac435ba11f107ba117b5d", size = 172475, upload-time = "2024-09-04T20:44:43.733Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/fc/6a8cb64e5f0324877d503c854da15d76c1e50eb722e320b15345c4d0c6de/cffi-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:f6a16c31041f09ead72d69f583767292f750d24913dadacf5756b966aacb3f1a", size = 182009, upload-time = "2024-09-04T20:44:45.309Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/d2/2cde336b375f55c76ca670f0be3978cc048e31e24f3b4d7ce8473150a388/cffi-2.1.1-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:baed1e86cc735622097354b9d1281406caf42ff42a886d29faa8e8d1630333be", size = 183779, upload-time = "2026-08-03T21:19:15.602Z" },
+    { url = "https://files.pythonhosted.org/packages/94/1a/4b2f7c92293ba05cbd4a9a1b28faaf0326272d9488e6354657571c48a7aa/cffi-2.1.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ca82be1a1d406ecfe1d25dc16cb33488e5a16bf4438c9fb590484ea29d92478b", size = 184178, upload-time = "2026-08-03T21:19:16.67Z" },
+    { url = "https://files.pythonhosted.org/packages/17/0b/ba385d8ccedf926c3cd06e8e2f327027da5afe5f0eb30f1f7bc43ac55125/cffi-2.1.1-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:42e2f76b9455f5a9a844f770bf3e200ed3da0e15f5df3db9c31fe80b04b3d004", size = 211037, upload-time = "2026-08-03T21:19:17.705Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/b9/0f2e58b2cefa33255bff36935d42b13180fe559bba82596540eb404bde7d/cffi-2.1.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5a59cc1c4442bc3d5c703bf720b51138d0bfc173618807c9ee2490a7541dd3d9", size = 218652, upload-time = "2026-08-03T21:19:18.735Z" },
+    { url = "https://files.pythonhosted.org/packages/37/15/180e0dab27b9312c7479003d14c9e547634b7dcb934e2cc4650e1b131a7a/cffi-2.1.1-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:9f8d177621de5cb38ee3e731eda45d421db093ec0739f46a5594babda7987a98", size = 205422, upload-time = "2026-08-03T21:19:19.96Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d4/03026f0c850cbbaa9030750490225b4a7f4d524ea4df72c3cc740a90f4ef/cffi-2.1.1-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:75f80557d1389eddbd0de2681f6a390a0c5338c31ddaa821381c203fc3fd50d9", size = 205444, upload-time = "2026-08-03T21:19:21.246Z" },
+    { url = "https://files.pythonhosted.org/packages/75/77/60bebf6f818bec84210ac5b6979ce4eeadce6fbbaabc9c7ab23e506d1ce5/cffi-2.1.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:194cffa889098ced9976c3fc6340305e43f6303657d298da55366907c05c22d6", size = 218742, upload-time = "2026-08-03T21:19:22.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ae/679bf47e73fd77b352171727f07de559a003f14de5d02b904a6ec1fa73ca/cffi-2.1.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:5bb4e7ea95dcd6a014a6fef62e62467d67d8e582326443f3d68e71d6320a9fcf", size = 221054, upload-time = "2026-08-03T21:19:23.694Z" },
+    { url = "https://files.pythonhosted.org/packages/09/b8/eefc0e06913b70aa153bf74c946094a18f58fd4aff11b7f372bfdfdca050/cffi-2.1.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:3d22a20b1fb1632cc72c22f95f7b0d2961c3e1c235f245ba4c606c4771035659", size = 213489, upload-time = "2026-08-03T21:19:24.922Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/13/4e56852824a03cdf68523a35686f1c28eacd4bd30a7b0a78e682e6e6e1d3/cffi-2.1.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:1dea0e4d7d4f11f619fe8c1d76caf49e24405b4b5743c0e3be16a500ecd930c9", size = 220241, upload-time = "2026-08-03T21:19:26.214Z" },
+    { url = "https://files.pythonhosted.org/packages/99/7f/040f9e163e4acac3ee3d85b02d00b2576e7ca980d8785f0a3a5f1a9bf7f5/cffi-2.1.1-cp310-cp310-win32.whl", hash = "sha256:7ce713ace7c0e4520535b42b77eaa742c16dab813978064913e5a3cf82973b41", size = 174578, upload-time = "2026-08-03T21:19:27.338Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/0b/644a2ec1a4eaba49c2939410bb1eb1d25b09d6d0582f5d2f95c537043725/cffi-2.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:a48d62ab9d6f4f98c983223a547af44be6ca3691074c31cecced6facd3ba2dc1", size = 185082, upload-time = "2026-08-03T21:19:28.409Z" },
+    { url = "https://files.pythonhosted.org/packages/70/d2/16d99a0c4948febc0ebd133a13b2f688ff7f8cb04da971e1128872ce0c03/cffi-2.1.1-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:c8d2c9fd1f2d16f780d15127abb050d13d1a76c03a4bd87d7e4980e45e511e12", size = 183838, upload-time = "2026-08-03T21:19:29.637Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/95/31b535a9f0220ae9f357de4a08d57ce89cb417653c2fd9f075f50822a388/cffi-2.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:398aff33cee2767e3e781d2554c54bd0dff386bb437581e0d8011fde1a942ec1", size = 184168, upload-time = "2026-08-03T21:19:30.764Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/5a/4707a0dc1f203f5dde5a907b0d4e3c25d71120241048bd5bc6f1bb9d4e71/cffi-2.1.1-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:154852545011f779917b11c78db2358d095da62a9a172b78ad0a583ee5adc0d0", size = 211805, upload-time = "2026-08-03T21:19:31.867Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/66/c19feabb28485b6e0bbaaafa90837a1ef5d302e90f2178bd33f17a49879b/cffi-2.1.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3311ed60d36f83378794e1009ac6258bafbf81f7888b4caa7b35a521e3f95813", size = 218716, upload-time = "2026-08-03T21:19:32.896Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/92/500760486c8baab49a7a8a58ba7fc3355ec3974b454b8a09e528efde9e1d/cffi-2.1.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6e192623c49c94421616a5778fba35cf0d5a8d000650c1967ef4448ee5cdd990", size = 205569, upload-time = "2026-08-03T21:19:34.142Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/a7/a67c733254d6e7373f7822f8082d8d6beade791e0cf12a7611f376fa61c7/cffi-2.1.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a6e721d4b0e45d5b65e87534470e67b18dcd092c83f68fba09f152b9cbc061af", size = 204907, upload-time = "2026-08-03T21:19:35.174Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a4/4399daaf8f7dfee9d7c3327fdb0426ee041cc63edc358b93911ceb2bfc7a/cffi-2.1.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:34e261f78cb6ceaaa36f42f2613f4380d94d9c759a9c73c769ee6e0247364632", size = 217807, upload-time = "2026-08-03T21:19:36.286Z" },
+    { url = "https://files.pythonhosted.org/packages/28/f7/dabe6da2466ecbd82dc62e7342dc6b1065dad990c06f00f0ede9ebf2a0ed/cffi-2.1.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7225e4514edb64eb6740324353e0da0711954fd8d7da4576755b1c6e09b697cd", size = 221252, upload-time = "2026-08-03T21:19:37.416Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/87/616202d8e51342c07d2534c510111c4cc37201775ce8f60802c9335d1edd/cffi-2.1.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:df913725b79db7bcf03448f36b7bf8815363417d5b58deecf9305e3e30f0f21a", size = 214214, upload-time = "2026-08-03T21:19:38.507Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/c6/ab025d75d2c26c19b087c0124e75ee31cb65032f4fe345d356d8c507ab97/cffi-2.1.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f5cfbc5fe74540d335175b656c725d74d90e3730c626d92575eea35029d9afaa", size = 219408, upload-time = "2026-08-03T21:19:39.809Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e2/7e8109f65445bdc673a7b54f02c677de462db75674220fd1335efc8eb598/cffi-2.1.1-cp311-cp311-win32.whl", hash = "sha256:f8ec5e643a9a937f64e1999eb9f75d072263751912dc5cd06d3c85f8f44be7c3", size = 174470, upload-time = "2026-08-03T21:19:41.246Z" },
+    { url = "https://files.pythonhosted.org/packages/73/c0/77ba02423c2f7d7091143c45cd49e0e6575c4c1967394bb542bd923a9b74/cffi-2.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:42f6930c31dc7f50732c9ae793c2786c7b6b044195967bbdde40bb9be81c4cc0", size = 185096, upload-time = "2026-08-03T21:19:42.615Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/47/9f1f85f9672ceda4984dc6c4f8824e8558992a2972c3d3c81fb8eb28d4ba/cffi-2.1.1-cp311-cp311-win_arm64.whl", hash = "sha256:c7659f22557c5a0bc4855cd635f55edec690cc008a40768527762cb9fb263455", size = 179941, upload-time = "2026-08-03T21:19:43.747Z" },
+    { url = "https://files.pythonhosted.org/packages/10/69/43965eccfdead3b9220015fd1320e117be8c6ed01a62ffab76eeb752f5d5/cffi-2.1.1-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:c8c69575568085ba0b1b10c0249d779a214aea6f6522e949a0fc9fb0fcb449d0", size = 184821, upload-time = "2026-08-03T21:19:44.887Z" },
+    { url = "https://files.pythonhosted.org/packages/54/7d/16e5a096677b5e313ca80cd5e5170efa3ea44624a82bb111925522da64b1/cffi-2.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f81b3b8f3d4e343550fa4baa0e479bba9f2d29ce9c2e9b51d1ce1718d7442fcf", size = 184719, upload-time = "2026-08-03T21:19:46.129Z" },
+    { url = "https://files.pythonhosted.org/packages/56/e6/8941622732edec876dd17d0453dce07317ae96db34f2ec1436c9d3785986/cffi-2.1.1-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:811bd1e21d32de12efca32393a0ab3f5133b54fce9bd44b8bd77ab07da14bf6a", size = 214799, upload-time = "2026-08-03T21:19:47.218Z" },
+    { url = "https://files.pythonhosted.org/packages/44/de/f98430906df1545ffde0d543dd124a7a439bc2cd32b36b9c53f805df7333/cffi-2.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:68e62fe11f30d5ca8289242866f0a5291402d8529ca2178ab8afc5c9694ae890", size = 222389, upload-time = "2026-08-03T21:19:48.331Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/5b/717f1526b9957b34456313c31645c5b82b8fb5c3fe9e4752999be7128bfc/cffi-2.1.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:4a7c934f7360e8cd64fe9efadcbd10c7c6364f531e432b9a4bf5ccbc9e0e8b50", size = 210249, upload-time = "2026-08-03T21:19:49.543Z" },
+    { url = "https://files.pythonhosted.org/packages/64/b3/f8aa4f3e34986c7e4ec45072d1b1b9dd295b6b18007b45518d79726dd725/cffi-2.1.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:3143d81e29e1e20a9ce10901ec369012947876596f75a222235965f2b7ae832e", size = 208775, upload-time = "2026-08-03T21:19:50.918Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/db/dceb9dd5b231e1da801793f8acc9f3c52a7e1afe40bb1aae37e02b0faad5/cffi-2.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c1453022f490d2459a11819d83ad1d586e9ff65a12ac3e705ffebd46d3685dcf", size = 221822, upload-time = "2026-08-03T21:19:52.054Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d2/6cd24ae3be000a634109c247d1475d62e5616d0dc78c82770942ec384248/cffi-2.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:208f941bb9d18e768138677f0a6d2ce01f590df56043dda1df1535ac57c88517", size = 225232, upload-time = "2026-08-03T21:19:53.109Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/52/3fa190537004dd7f0ab860a6dc7c0175b8667f68d1e618a46f5498d30250/cffi-2.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:210019b6c7cf07f081b4c54635c8cf744377001350e29cc0f81c4377b4797735", size = 223597, upload-time = "2026-08-03T21:19:54.515Z" },
+    { url = "https://files.pythonhosted.org/packages/80/fb/0bb75b7039588c074b37ae99f40d9bfddf990ecb2fbc346ebccd2e56b9be/cffi-2.1.1-cp312-cp312-win32.whl", hash = "sha256:046bfc24911b37851ee1b51aab8bffe713d89c68c6a057b09484ce9fd5f69b4e", size = 175292, upload-time = "2026-08-03T21:19:55.566Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/79/615cc094e2fb508cade7de88d3b4f6c4ec2bab695c97bce9153dc65aadf5/cffi-2.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:f53e442b08449d42821fa4a4fba000095af9f62742a500f978a9f557ec44339a", size = 185919, upload-time = "2026-08-03T21:19:56.89Z" },
+    { url = "https://files.pythonhosted.org/packages/70/c6/d0ea84713fe46b243a436a18fcd47d639732747e21635c8a27191b06dc30/cffi-2.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:7bde5e4cc5c10140859842b9d383af292b22639a4dffb725314baf45968cef80", size = 180093, upload-time = "2026-08-03T21:19:58.155Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f4/035513d4117049066b4779dc3b7c0c0fdad175fa13731c9f4003f1cd1478/cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:b5bdfd1c873d4e093aabc0ca84c4ca6dbc4f752afb5c86f146d9742580c9da2e", size = 194248, upload-time = "2026-08-03T21:19:59.399Z" },
+    { url = "https://files.pythonhosted.org/packages/76/af/2aeb4dbb5fc41a04161ae9ff1518de7cec08e164f44a8ce6a4cf7fd2cd1d/cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:31348097ff5bbe827ccc41795d4dd099d9f0625e7def00ee653c137a490c2a6c", size = 196908, upload-time = "2026-08-03T21:20:00.746Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/46/2e5fdde8555706dd98139a910ca11be02809f3f605ce956f655d0214e100/cffi-2.1.1-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:9d2055050ea716bd38b7f7f1579c275386646b4894c155a3e2f3cd62ed41b7c6", size = 184805, upload-time = "2026-08-03T21:20:02.02Z" },
+    { url = "https://files.pythonhosted.org/packages/55/41/4c7042f317b9217502988f0873af87e16ad606dc20f84e546e3e6ce9764c/cffi-2.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:19ee6127ee34de7d83ce3d371ebc5ed91addbdcc39f9ab15ce4eb35a4e534971", size = 184764, upload-time = "2026-08-03T21:20:03.141Z" },
+    { url = "https://files.pythonhosted.org/packages/43/1f/1c3d90d91811c8f86ced9ed637956c54bfe5b79ca98fe976d7f8c8979f6b/cffi-2.1.1-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:6a8dddef476fab96d066d578fc88526767b836ab5ab21754e1d5bf3879c31c7c", size = 214722, upload-time = "2026-08-03T21:20:04.377Z" },
+    { url = "https://files.pythonhosted.org/packages/37/6f/3b5ce4c3b2192d250f04908f2bfd91ef34552ec8f7716a5d4abdb8d67bb2/cffi-2.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f16c709686a78c727bbbf059f92b0bf41c6fc60deec706d2dc19f529175a6125", size = 222369, upload-time = "2026-08-03T21:20:05.544Z" },
+    { url = "https://files.pythonhosted.org/packages/02/10/4b3c75dde3d9663c9e02ba05c2668b954f671d4bbe346413ca8c696b295a/cffi-2.1.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:fcd22650c908d7b7da162bbfaab594a1227a15d1643a98c68b122ac642fa2264", size = 210175, upload-time = "2026-08-03T21:20:06.75Z" },
+    { url = "https://files.pythonhosted.org/packages/df/62/14f74b9543e605d17701dc797b815958b8bb70b7624ce1b832ddad48ed6c/cffi-2.1.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:aa9511c62d14da7aacc9b4bf51f3f697a621e83b2d6919008243c3aad168eea3", size = 208670, upload-time = "2026-08-03T21:20:08.04Z" },
+    { url = "https://files.pythonhosted.org/packages/95/95/86342356ff5953b3fb06f7ef7c5bee212d45e770abc7218d451b9148313c/cffi-2.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a931079504ecc49efed7744c476a5c343a92fabf66dec2db95edb1b2fdc770e2", size = 221824, upload-time = "2026-08-03T21:20:09.274Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ff/7b3429ff53aafe931ed8a5fc69f481bbef7ba6de87ddcbb63d08f483f613/cffi-2.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a2d7755bef5a12ed488f4ef1f1b69ee9191d7396083b755a5d2295f6edb4768b", size = 225148, upload-time = "2026-08-03T21:20:10.7Z" },
+    { url = "https://files.pythonhosted.org/packages/34/34/a95870b9221e09cf4f2ce3178b1a210abdfe63a1bd357da940418d7b8d15/cffi-2.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e0bcb7e0f677f543555d2adff3bf19c05f66cdb4796e5ff602442ab2fe3c4ef7", size = 223564, upload-time = "2026-08-03T21:20:12.165Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/839b50531021a647fb5e929f72cf97bc1ff702b5472166164b5b6e76b851/cffi-2.1.1-cp313-cp313-win32.whl", hash = "sha256:334644fbac4eff73d985a17a91226df55d0f394160c4cfb880e084c8f7161cac", size = 175263, upload-time = "2026-08-03T21:20:13.559Z" },
+    { url = "https://files.pythonhosted.org/packages/60/a6/8b149b2c3f2e11aaa1618ef64500b45f50f22c57a977a4dff1aff1f91042/cffi-2.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:1aa5645c30469b09530c4ebca77ebf8f17618293c58f8549cb1a543a50236e7d", size = 185688, upload-time = "2026-08-03T21:20:14.69Z" },
+    { url = "https://files.pythonhosted.org/packages/01/9a/11f687cb39d6a3504060d5242f04f48c735afb4d3d533958a20594890cb2/cffi-2.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:63bbfd5ded17c4840ac07cd8f1c21ba9d9708141f840b324f422f41b207e3973", size = 180078, upload-time = "2026-08-03T21:20:15.917Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/7b/d6bbf82b8b96e7391438898c42f5bd96dd02030fd5b64937d248220003e2/cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:7dbb61fe3a7699468030f71bbe5f8a0e326a151daa91beb11a6fc1f980c55e1c", size = 194064, upload-time = "2026-08-03T21:20:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/94/e6/bcc91b283be94735e268487a054004f0aa19947b6348fa367db53230abc8/cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:f24fb43132a4c6b4cb4eb029492919b2db645be6808d738f244fd146c03c32cb", size = 196720, upload-time = "2026-08-03T21:20:18.268Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/99/c4b0c17cacdc9c3b8f280026286a9826d6a208c0f047591a3c3ce99b91fd/cffi-2.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d28630f5854ab07ab1fd4aba756de52326c82e6be15d414b12793f1975048b54", size = 184964, upload-time = "2026-08-03T21:20:19.708Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/a9/9db617d05d7367c1ad0ab00b3aa6e6f9281edd689b4ee9ea0e5a84e89c97/cffi-2.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:661c298b4821edebead0c91edd2b00374d67ad7c5a1f7a91d4442633b79d6a72", size = 184962, upload-time = "2026-08-03T21:20:20.833Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b8/b42132ca113dc567d37684437b46ca1dafc885902b02a110a02d5b511857/cffi-2.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:58acb8ab8e295e6c5ea12f888cbb13cf21511ef2a3303a23f4325c29d17fe5c1", size = 222328, upload-time = "2026-08-03T21:20:22.118Z" },
+    { url = "https://files.pythonhosted.org/packages/80/10/c5c0cbf0a657aecf59ef511409734230bf556f05a0d6c9eed7aa5c0a0166/cffi-2.1.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:456a61fa52d579ebf9df2e9552ead5129855dbaff6c1e5a9b1bc408809bdc062", size = 209985, upload-time = "2026-08-03T21:20:23.401Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/6c/bfa0b87b03b9238148beca990292843c9396ba069b54496596594173de7b/cffi-2.1.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a4f00aa42f75d6e4595e8866e748cc1705adc0cddfeb2ca86d0d03993d63ba03", size = 208530, upload-time = "2026-08-03T21:20:24.628Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/02/4e7d553a7ac4b4238b38b3c1b80d486e9d4436f8d2acbf87a0997fe3f402/cffi-2.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b0431303acaea1089ad4b3e9ce4e6518193def1118d4073ca848635ee4ea2e96", size = 221525, upload-time = "2026-08-03T21:20:25.758Z" },
+    { url = "https://files.pythonhosted.org/packages/82/1d/a4aaf9babd75acb4d5f223bff71533bee748dd770a382619a798960ee9ba/cffi-2.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:64faea20f4e2613363a1a9b9c7dd73058f3ecd00133a511e72ad7c511658f527", size = 225053, upload-time = "2026-08-03T21:20:26.985Z" },
+    { url = "https://files.pythonhosted.org/packages/81/10/5dc0e7bdd18e22107054288283380fc97a06ae3f1656a106908d666a3c88/cffi-2.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5c58fe613dc5e5336357eff555824a314d8e43282600435c8d1cb6a7a2fedd13", size = 223213, upload-time = "2026-08-03T21:20:28.277Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e9/d0061c364cde06ee43168a0d076ac1da512cbc380d44767b844ba34fe2b6/cffi-2.1.1-cp314-cp314-win32.whl", hash = "sha256:1a18a57b58cfb21fc28d72e876acf10eaed67a1ed96226f92af4df681d571c4c", size = 177682, upload-time = "2026-08-03T21:20:44.288Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/06/1c3e01e3ba14c39f6d10bfbac52753b7e22259e38088e5cfe1d704918690/cffi-2.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:3222ba5d678f80a030e6afbcc33dc1ae5cb45facabb61cee2c7016b8432fde48", size = 187949, upload-time = "2026-08-03T21:20:45.623Z" },
+    { url = "https://files.pythonhosted.org/packages/87/5b/da4e39efe18eeb89cf580ea9cfc66b6a7c3eadb808fc0cc1d3a295cb5a5d/cffi-2.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:ab36d55f9ed2d067327667c2fea18dda018eb628dd6347aa01dda6cf1f5d3836", size = 182947, upload-time = "2026-08-03T21:20:46.955Z" },
+    { url = "https://files.pythonhosted.org/packages/23/59/40338bf421c5accea1d45158170c87006ef1cd371b05c077e76476949728/cffi-2.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7750c6449dff7864bb9bb27ddfb0267756189201a3afc911d82b3caacd70dfc3", size = 188504, upload-time = "2026-08-03T21:20:29.495Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/47/5ecf1023850036e674c77ec4de86182d309ae344e39e7cba984b7df5d647/cffi-2.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0beceaabe56af686895136a2de78db54ecd8e4046b236b8fd6d6cb61389e9bf2", size = 188259, upload-time = "2026-08-03T21:20:31.291Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/9c/92934c3bea9f785b23eba304538c0b4d37a2a96d2431eb3a1bc87a11aa19/cffi-2.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:49cbc70e6542d4ccccb936558d1064a8012541e78f821f955cff24e357776c94", size = 223864, upload-time = "2026-08-03T21:20:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/45/ba4c93527bc38616a8bd36488acb69a2212d60486794f0c1f318949bbb76/cffi-2.1.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e2d65b31f36619cda3999b78b2aa9632e76b78448e7a56fc4240824200e7c4fc", size = 211538, upload-time = "2026-08-03T21:20:33.808Z" },
+    { url = "https://files.pythonhosted.org/packages/80/e9/b6ef565e452acb932fb0cb5443f44a78efbd1233e566f02b5a83855e9115/cffi-2.1.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:28907ab9bfb6aa13184cfc17c6b8e1023c5ab6fd7076d8c20a35e59fe04f8f29", size = 210688, upload-time = "2026-08-03T21:20:34.974Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/95/eff5f0cee78d2eabc7eebffec40d3fc1876b5f3c95582e018bb4b99601f2/cffi-2.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:51b31d1c98274844cfd7838ce00bfc27c7423a4dc00fc0772fc3331c2cc90676", size = 223803, upload-time = "2026-08-03T21:20:36.564Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/01/579d39fb8bef00a335a23d83757b44feb24cd6345a2c451b64cb67b9c362/cffi-2.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5e7cecbaadb83884793e05828cee59b210b24583b9c7425d0ba6a754fe22eb4e", size = 226763, upload-time = "2026-08-03T21:20:37.816Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b0/0b44f47c60b01b57b6e2bbd92343f13a85a1d93bc46ccf6e47e244acd99c/cffi-2.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:25792eac27877609e7bb06d42ff88278a6624fff2ba9bbb523c09616b117e80f", size = 225688, upload-time = "2026-08-03T21:20:38.959Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d2/3b7176cb570a1d3e27faf67b72f591af508036e0d8b2be2ef9af9e8c84bb/cffi-2.1.1-cp314-cp314t-win32.whl", hash = "sha256:8ef53b2de9bcb9197d31854256575d59dbac0cba72ac627bb291ef5eceb74be4", size = 182868, upload-time = "2026-08-03T21:20:40.388Z" },
+    { url = "https://files.pythonhosted.org/packages/56/78/31f00c1bcd97c9bbf55f1bfdf5bc809a5de8887473e90bb9960dca825e80/cffi-2.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:616f097f2fe415bc92a247f02e11f634e1f9e9a83d327e3c915c15089c87869e", size = 194104, upload-time = "2026-08-03T21:20:41.725Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/1b/58496f2ed0a35de575250c02a43ab3cc2c04d494a88fed31c1cabc0fd176/cffi-2.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ad2c86c495b899d862ea0f4b42891b8713a3bd45dd4105c7fd51c2a72f39f3a5", size = 186402, upload-time = "2026-08-03T21:20:43.042Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/8f/9ebe220eab48a093d1a5a5e339ab0dc7316eef3bb04d63c42f0251b61f50/cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:dddad92b554513a31f272570678ba307fb9f618f05e3d4a5eacafff9eae03e1d", size = 194043, upload-time = "2026-08-03T21:20:48.179Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/69/844bad3ece306c4782c2ecb93597035b6690d48704b803914c199da1e8b3/cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:da0e573f9f97159390c89d9f1a9e41908b66d408cc5b58d08cf3847d844c531b", size = 196737, upload-time = "2026-08-03T21:20:49.457Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/8a/af668013284634733f02d683458a0728739c7d6ddb5e14cb0c20832266fe/cffi-2.1.1-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:fb92203a88b3d3053034db775110081c49d28be6551923805e039924093761e4", size = 184933, upload-time = "2026-08-03T21:20:50.639Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/75/2f5207ff6d1a613133b23a5203cc0c2a628313b5eb3974d7956ae3c57950/cffi-2.1.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2ae64be792b8966f2c69538199728b290e34726562896df1e5dc8ffd8d8188e8", size = 185002, upload-time = "2026-08-03T21:20:52.173Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/31/9e1313b0a6e30e91b3b3d3fff51ae99c857c07738e3afcce1f7334e1b7ab/cffi-2.1.1-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:507a24c282e0f42f8ed737cf048572cbf580468da5555764a8331735e9c736b6", size = 222271, upload-time = "2026-08-03T21:20:53.462Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e3/f6234a833e6e08c7007003074723c406559eecf9b48dfc97471e5a8eb7a0/cffi-2.1.1-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:246fa40ce8645a614ff682e0b70f37134e460eaf93a775e0cbe3cca585a67a80", size = 209919, upload-time = "2026-08-03T21:20:54.783Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/fc/5f74e293fced6edb51af3a46c4ccf6c23c9943774ecb375ddbd522c76add/cffi-2.1.1-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:471cee653ae88de62096552e6d24ccb4a5adb8c8c9f10b5054d0122c15bf2779", size = 208529, upload-time = "2026-08-03T21:20:56.066Z" },
+    { url = "https://files.pythonhosted.org/packages/44/16/29e6d01b388bef055ecd6ca8244b3f4d336bd09e92d5d892187b9601084e/cffi-2.1.1-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aeae0e330c9f6acd681f647d46cefd30c29f93e3392882e792e82080c9691399", size = 221630, upload-time = "2026-08-03T21:20:57.336Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/18/fa7f1f6857d5eb88a4ca99ffcbfb7c387a287ccc154c64a73e86314745d7/cffi-2.1.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:42a494cee34437f05546455144f2b5d9ac09b1face62bcfce597d2e521066688", size = 225134, upload-time = "2026-08-03T21:20:58.675Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/9f/e8e3dfa04a1b4c241f8c91faacad872b4d4efd051d49764ad4e2fd4b9fea/cffi-2.1.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:cc572dace3f60ef98d7b12ff411d20f5362feb31a0439eab0085bbfd349982d7", size = 223197, upload-time = "2026-08-03T21:20:59.968Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/7e/8debeb04f1ab9fe2a6963964cd6f1aaf7192627b83926586a6a4e089c9fa/cffi-2.1.1-cp315-cp315-win32.whl", hash = "sha256:4f42141fc14250de6dde5ee7ea4432be017252d91f19c5ad043c084cea629cac", size = 177683, upload-time = "2026-08-03T21:21:14.901Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/31/5158704cc474ab65c1647932e88be78dc0873f47130e253be38bcaf13d01/cffi-2.1.1-cp315-cp315-win_amd64.whl", hash = "sha256:e6e8cff14d6fb0be70a09c0bdc58096f501952d04624ebf867e0e56da2df8960", size = 187897, upload-time = "2026-08-03T21:21:16.108Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/4b/b3a2da8570c704ffc0f9762cdc3ec0f02c8573798e0b5cf7f11c82bbb70f/cffi-2.1.1-cp315-cp315-win_arm64.whl", hash = "sha256:27350daa11d4f10c540e6e89dada4c54feb7256ad03e9a4dc075ebad7ba360d1", size = 182935, upload-time = "2026-08-03T21:21:17.271Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ef/5443574510a1207e6f6bc38ba6e1f1de36cb48fef07b2728bb896a21f430/cffi-2.1.1-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:c26608d2222fb1e94487e4a387d85f13eb55d5ed725cb25a0c589ac4ee60e7bc", size = 188464, upload-time = "2026-08-03T21:21:01.163Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/ae/a56fa8c4686ad50e148fcbc8d3ae0d03915ff5c30d795058988c24118cef/cffi-2.1.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:4be96343e422f2dfcd12ab5c9f5aebe03f82f737c6bffeca6830b3875cb44aab", size = 188262, upload-time = "2026-08-03T21:21:02.382Z" },
+    { url = "https://files.pythonhosted.org/packages/53/b2/6187f46f2912276a3ae284076109cc5c8680482f11f766ccf26db4a86427/cffi-2.1.1-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:937c0052c05a31ca1daf18de3158eed4dbfcb9cc107adbea227728d647be701e", size = 223779, upload-time = "2026-08-03T21:21:03.553Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f6/c3ad28bd19f77047a03084424fbd4cbe997303267c14423737324be0385d/cffi-2.1.1-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:df423d40ee8654634421812bc3b196da3f9bd7d32929da813f8394c4348a5358", size = 211520, upload-time = "2026-08-03T21:21:04.863Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/cd/ccac9013a5bd9fd764de118674ab9c805b5ca10c19270d90ee273f8b2240/cffi-2.1.1-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a730a083190634c65cca36ba5f489531576ebd79bcd5c8e172130f6453127231", size = 210673, upload-time = "2026-08-03T21:21:06.223Z" },
+    { url = "https://files.pythonhosted.org/packages/52/86/2976131c639aead931c5bee5aba67e4b09fbeb8018b6f282f70803f923a7/cffi-2.1.1-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:363e05fa78e15116c3c32c210ee36884fd6b9afa6d440e47112c3bd511d64cb6", size = 223835, upload-time = "2026-08-03T21:21:07.539Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/0c/33a7aeab2f9c76918c52e084beb39c570db3588133412929e8ec06fab90b/cffi-2.1.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:770de9db11e84213beec501cfcaa013b019820ca881e03344dea5844f7876d94", size = 226705, upload-time = "2026-08-03T21:21:08.774Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/26/2cde30fdde421130bfc18f70395731a6e6b2053c6a1978a5258ff04e72fa/cffi-2.1.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:7da0c5eff80f0197f3b3d1232ec5a682a9325f4ae9016a78f5f5ca35f9ced1f5", size = 225539, upload-time = "2026-08-03T21:21:09.911Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/cd/a361394c94b2129d604bb846f624a8e88255a3ee33129c434a00d715e64f/cffi-2.1.1-cp315-cp315t-win32.whl", hash = "sha256:06c72bb76605a4b0cd0aad6930b69d4baf7dd5d806cfc409b824191099700e66", size = 182707, upload-time = "2026-08-03T21:21:11.226Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/b5/ba2b299993c26577d529b6ae29841f9e15b9fcf004d65f423f4fcf94ade9/cffi-2.1.1-cp315-cp315t-win_amd64.whl", hash = "sha256:d9c275eaacd24aa73f94ffd6de08fc3f932424d8b6c376f4bed7cde376fe7bc3", size = 193772, upload-time = "2026-08-03T21:21:12.39Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/29/35e016098c814cd93de9cd320c66b5bfba14dc6ecedd3cb518fa7c408c69/cffi-2.1.1-cp315-cp315t-win_arm64.whl", hash = "sha256:d18e5ac0f2f03f4f518d3e23db0f0cad7faa1da8620e9c09461d443bbf6e6692", size = 186360, upload-time = "2026-08-03T21:21:13.636Z" },
 ]
 
 [[package]]
@@ -621,6 +665,63 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "50.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/ad/5d6702db60b1e40b41ef513b6967ff5848f307d50f8449baf1634f5908f1/cryptography-50.0.1.tar.gz", hash = "sha256:5dd9bda1c12b4162f6ff568eeb5e0ff956c28d14406e875cfe8a63a2d414ff20", size = 880381, upload-time = "2026-08-25T19:45:45.499Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/19/797e2aaac9df6a66f1550f49979dc1b1e39ecd2077501c30efa81e8d5d67/cryptography-50.0.1-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:b8f852c65863251b9e3a1b8c150ce21e59b522dbb6a7d4bc80e680d38388e986", size = 4010153, upload-time = "2026-08-25T19:44:03.155Z" },
+    { url = "https://files.pythonhosted.org/packages/90/34/9ce9a62ed9dc82ca9fd6a34445b6904af56e5f38b3eae2ed32e49c36053d/cryptography-50.0.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:53e279950892dc102c6b4e52af03ae5ea92fac572a1ddab78ca73a997f62b69f", size = 4723133, upload-time = "2026-08-25T19:44:05.461Z" },
+    { url = "https://files.pythonhosted.org/packages/57/26/e6d4fc8512a51a5f9ee7bfdbfb853bce1197087df40c9ad993ad370b846f/cryptography-50.0.1-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ff838d62ec1bfce4f9ba7fa16f4a7b554cd8d0c299e6be37502161a660c84eef", size = 4712478, upload-time = "2026-08-25T19:44:07.375Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/de/d3cdc2815697aae84126cbd6a030ca7b6b452e28a88b501b836bd3aa7a86/cryptography-50.0.1-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e74591e283fe6eb956416c929eb58262a719fe0311fd9054c62c3350ed8760d8", size = 4730726, upload-time = "2026-08-25T19:44:09.294Z" },
+    { url = "https://files.pythonhosted.org/packages/55/32/38c0d344b98c06d34b5df8946565a9c0d6dbf32c8e0730a7f05f0a3c6cab/cryptography-50.0.1-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:5fe002589592ed749ce77fe0695fcbd3500dd61d7d6db5858a7544c612fa8e45", size = 5353524, upload-time = "2026-08-25T19:44:11.96Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/1b/82f0f0d8858d4432be1af790477edf62aef90324041aa07c57e57bef1af7/cryptography-50.0.1-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:51593d180cf6d179bde5c5d065bed81386b1f381656ae7d042b7ffc87a9895ad", size = 4746720, upload-time = "2026-08-25T19:44:14.051Z" },
+    { url = "https://files.pythonhosted.org/packages/29/ba/042ca458b8c64348c768284b5d23e69b92ed53d057ab779fee628564676d/cryptography-50.0.1-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:359e62deae718bce96170e223fdcb6357e4fbd3bb7a3a75f4430763532560e49", size = 4361866, upload-time = "2026-08-25T19:44:16.167Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3b/e96c1ef71edef71057c7e3c3d982ce8fda554e0c52d0cc19c18845cde3eb/cryptography-50.0.1-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e2ca8fd1b6b4b82a1c4cb02841d0837e3c12336c2e24b520ab8ab3b969733d8f", size = 4730028, upload-time = "2026-08-25T19:44:18.085Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/38/45abd72ef63f2e7d0754a6cacf97bd8b69512ace7f6130d24c39ece65da2/cryptography-50.0.1-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:76de83fbd91ac49c0feaaa983d0748fd7a53176afac5fb3bf7478d244f0eb527", size = 5308405, upload-time = "2026-08-25T19:44:20.197Z" },
+    { url = "https://files.pythonhosted.org/packages/85/66/6ccca4722987ddedaa7fc9c3f4708af7431f5535666c174350830888c6b7/cryptography-50.0.1-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:51afcfceb15597cf2635068e4ac9a56b2abde622edde17f37d85fd7b5306497a", size = 4746230, upload-time = "2026-08-25T19:44:22.376Z" },
+    { url = "https://files.pythonhosted.org/packages/13/0e/b1f92e013228111413f2e6743948b80bc24dfd3c1b87ba98ceea16f5df89/cryptography-50.0.1-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:be224a65493ec5b74a158ff22a5522ce4a5ca1e543c647a3a4730d4a09e5f959", size = 4862596, upload-time = "2026-08-25T19:44:24.472Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/22/c3654cccc856e9d682817b04ac3ee79731cb09ca6f95996a95c904de2883/cryptography-50.0.1-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9ebcdd5519be9b652a46f507817a74591774fc3d6923ac364e4dfa64e36b291b", size = 5014082, upload-time = "2026-08-25T19:44:26.709Z" },
+    { url = "https://files.pythonhosted.org/packages/42/8b/cb12b1b60c91b074ca6bf0fdd59aa8f10d8bc5f73af8faece86ef0421b37/cryptography-50.0.1-cp311-abi3-win_amd64.whl", hash = "sha256:aed8db4f6d71c51efb89530e12d9464e7bf2923d46c3205dc794a2a93f8c0648", size = 3842826, upload-time = "2026-08-25T19:44:28.784Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/f0/424cb557d99aa86ac55da5e2add02e2882e44047b6264f93ade1b975a993/cryptography-50.0.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:30a125032e5642a21ff816e021152bd4e7e94f03eff3f4b7fca41cd22bc3110f", size = 3973525, upload-time = "2026-08-25T19:44:30.7Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/72/3a2711d967977ab5fc80b782837c7e8d1ac7445e764c20c381a265c57ef3/cryptography-50.0.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a0b1a59e3a089064a0ec309e9428c8e3ae4e161419d20ac33600767e83fc658a", size = 4708817, upload-time = "2026-08-25T19:44:32.773Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/f2/bb1f56e10815b789df0b409a69fa4992ff3d3fef9c72747f4a6b26fed38e/cryptography-50.0.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8921d58f426793c5f1b47f0b59575780de9a095214958d0eb37d909593db8367", size = 4697300, upload-time = "2026-08-25T19:44:35.144Z" },
+    { url = "https://files.pythonhosted.org/packages/08/bd/ed5396be499ffcf8807a585bfe38b71a1fbdd1c342b4f9b6d0ef5162a946/cryptography-50.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a8f40ea47330e71b594a7e246898f93177c259490c63183dbaf9e571d71ed9a5", size = 4716039, upload-time = "2026-08-25T19:44:37.192Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/6e/1cf405c5c8e8df7545378048e954792f00b7f2367af8863ce8b8f3e10607/cryptography-50.0.1-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:a255449073358275b64b67d3f595f268bbef70e72b6edb65e0c70c735bf739c9", size = 5332388, upload-time = "2026-08-25T19:44:39.16Z" },
+    { url = "https://files.pythonhosted.org/packages/47/92/b4317e8c32c4f47b062f5398bd79106b220a124546f42be83bf32b761e2a/cryptography-50.0.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:8df2de9102026855887e4587084f6eabd80ed0f345b8ad8a7ac27ab9bf4723e0", size = 4730293, upload-time = "2026-08-25T19:44:41.298Z" },
+    { url = "https://files.pythonhosted.org/packages/39/0d/a1e7633e2c744d0f2983320a27e924ef2264c79c56e1a58d5fb0a1cfd413/cryptography-50.0.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:ac02b07824d4d1001bd4367599f839c19cb171924c796e52c23508ac14c2c0cc", size = 4346031, upload-time = "2026-08-25T19:44:43.245Z" },
+    { url = "https://files.pythonhosted.org/packages/88/dd/b215616f9bab3fc18510c78a4e5c9f362d77838503c363dc747c7d4f5c6f/cryptography-50.0.1-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:cbf74a81765ee67413503ca6e26dcc4f6f5a519822436cc0a1b97aab6c1b8a17", size = 4715344, upload-time = "2026-08-25T19:44:45.291Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/1b/ec3ebd31741d0e963612c4fe43caa39341b9b1e031e469820e42e4c83918/cryptography-50.0.1-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:16c5ecd954b3330ebfb6605eca4fd952da8bef376551d5cc264534e3770a9ee6", size = 5287201, upload-time = "2026-08-25T19:44:47.297Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/01/0127d11a762b31a9ee0221894f540318761783f3fdc4bc5d057698caebd5/cryptography-50.0.1-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:79bf008d1f9af6071c797ad133e39915dfee7614f18f18f4db9072eb715064a3", size = 4730023, upload-time = "2026-08-25T19:44:49.435Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/b9/e7425ebfb599241a0c1d7000f1b466c3062da66c19d9525031315dff7213/cryptography-50.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:330fbb252391c596f1ae42c5754449dc924e6ad012dca8efe0d703f9f2d12ec6", size = 4847362, upload-time = "2026-08-25T19:44:51.94Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/fd/60d0ddf4defa12e482c9d5e0f554384d6e8ab25341fd15f060028fd92e6a/cryptography-50.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:42be3bb70596b3abe4ac097b75be223e8b3ab614a0e5de068e3dcc54d71d6149", size = 4999247, upload-time = "2026-08-25T19:44:53.876Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/56/bc4f2b209e766c93372cfcd59b781a0b2b59700f62a969580415b699c2b2/cryptography-50.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:f74455bb086a85d5e81246412602aaa97ed095e504cd40dd261ef50be42205bf", size = 3825806, upload-time = "2026-08-25T19:44:56.209Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a9/ee16a903f13755e914d1eecc482fe64d1f10761c3960e5d8fa6837377aff/cryptography-50.0.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ca83d00d9e69cd5eb63f2e69c3a5a59e0cecae5ae14c6ae0b35830fe3b37bad0", size = 4035307, upload-time = "2026-08-25T19:44:58.305Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/a5/9ec7e81e8526c0d7a387d73386b2daed3f39e10d81a85930bd1b6bfba65c/cryptography-50.0.1-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:05ba322c4da95b262a212c345af888ef2c37c88c0509756ea00a0e6d68850f23", size = 4751900, upload-time = "2026-08-25T19:45:00.401Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/3c/0e77bd5ffcf078e9dd27d3074aad6c030d9b10d0bf69329d573c927a188c/cryptography-50.0.1-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e22dfed744bd4002e909464cb23d2f0b05c6f3113a79ef2e9864a53db737c733", size = 4738357, upload-time = "2026-08-25T19:45:02.786Z" },
+    { url = "https://files.pythonhosted.org/packages/27/3a/3c5f80daa4dcd47323c7af8a2fcb90de27a33564d4fcac69846c0972691a/cryptography-50.0.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4c4188f7c0cf655be5c06342b817ed0f9595b69ffa2b12026e5353eed29dea88", size = 4758474, upload-time = "2026-08-25T19:45:04.889Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/2b/214cf0cf93db9628c3c20c896b229f327f6fb1b20e4b3743d8ad3f00af8b/cryptography-50.0.1-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2ebbfb0f1fed745e91796e3e1080a1440423fdae8ece1b995a1d80883a409054", size = 5375862, upload-time = "2026-08-25T19:45:07.163Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/51/3f9701867a46b6c1740c9b52fc4d3bed6cbdcfedcc9b6e64305c07f39cff/cryptography-50.0.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:407fe2b6db00939c05c0e945e9914238f2f0a430974839429dafc82b1ee6bee5", size = 4772942, upload-time = "2026-08-25T19:45:09.396Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/5c/13ea642e08e2544d0f5396122055f4820cfacb3203562197b5967125ea97/cryptography-50.0.1-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:2b34d76a652ea2b6faf777c35df230c5637842cd904e04f16230c3f9f03e4361", size = 4383347, upload-time = "2026-08-25T19:45:11.659Z" },
+    { url = "https://files.pythonhosted.org/packages/84/d5/7d1fe1cb93f91c428093ff234e128c89ba8ea61a6f26aab406081f9b996e/cryptography-50.0.1-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:01f41478cf33fc605a6a089cd56d28b45c6c0b45a1928b61797f2621a04bac71", size = 4758050, upload-time = "2026-08-25T19:45:13.745Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/04/557fc5ead96a829e0bc812a3b9dc4a52a2f27e4f7f5950da7ff27653a805/cryptography-50.0.1-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:fc3ed7ebd2a8c96f5b166de0ab9b624996bef3b07bbeb19364dfb78222c22c80", size = 5332955, upload-time = "2026-08-25T19:45:16.193Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/eb/5d7124083e8d8cda8f5b348f544b71ad6f707ad63193758ef4d8e569da02/cryptography-50.0.1-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9dde0a357190eb3b1da1bb9ab750e9c85cba82ca5977aa0836cbb94e92611239", size = 4772694, upload-time = "2026-08-25T19:45:18.315Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8e/f1f955e0921dd2b6d22eae7e8d24a4c4b638d10735ffbf6a71f99eb0fcb8/cryptography-50.0.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd3718b960d0b5dd213cdf03f3bcb7000e69dda0de8b956061947ff6bcff5558", size = 4888413, upload-time = "2026-08-25T19:45:20.4Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/ab/89e2b798d2c3925f82e2bb72d5979f3d2f6da2dd22ef4a8cd8b70d920039/cryptography-50.0.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2a93d05e34d5f67fba6f891fe85d929999baa7195e853923ea6d7576c9e68c5e", size = 5044355, upload-time = "2026-08-25T19:45:22.353Z" },
+    { url = "https://files.pythonhosted.org/packages/99/89/87ef49ffe383ef4e147d27b7bf2088fb0b54ea409dd87b5a89442e5828a5/cryptography-50.0.1-cp39-abi3-win_amd64.whl", hash = "sha256:55d16b1ef3ee0958d893a977b19777887e546c9954ea81b200c3301a864013f2", size = 3875429, upload-time = "2026-08-25T19:45:24.418Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/27/8d207af749c453ee17ea087340b3f2b4adef75aadd1d277b1b129bdda84e/cryptography-50.0.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:9cb3cb952cf5a8abd50c782a98a89d71699715e802fe349704b47f2425b42a94", size = 3974350, upload-time = "2026-08-25T19:45:26.551Z" },
+    { url = "https://files.pythonhosted.org/packages/14/9a/6d3a4d7852e22d657438b7bf51f66102c7d71c0e1fafeec652281d0403e5/cryptography-50.0.1-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:5fe939deeb161024a6be98229c953b6591fef1f41214497a78fe793a244c017f", size = 4698675, upload-time = "2026-08-25T19:45:28.658Z" },
+    { url = "https://files.pythonhosted.org/packages/73/35/5c3717edf9e68a0550ce04e28eab493fe545eccd81742af03f6a75fe260b/cryptography-50.0.1-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:fb4b9672d389c738b175c4166e78310f8a70358886aacd9173ee03a85ffdc671", size = 4707410, upload-time = "2026-08-25T19:45:30.816Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/e0/e786934472e3ac4ecdecc7b129a0ca1a2a40dffdafcf2c3ea9d4397f8def/cryptography-50.0.1-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:d63ae8f6481fec907ac0f588eee8a90aefde112c633131fe540e5711ddbb5a4e", size = 4698378, upload-time = "2026-08-25T19:45:33.043Z" },
+    { url = "https://files.pythonhosted.org/packages/51/cf/5b3f53a0b74d122f023476ede40ba5d3e70d5cf475f73b899740d26a4fb2/cryptography-50.0.1-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:804728ce710890870f3aaa344b2e161172d258d768ac139d02cfd9092d0d94e6", size = 4706889, upload-time = "2026-08-25T19:45:35.086Z" },
+    { url = "https://files.pythonhosted.org/packages/71/44/711e61f7d014be825ef79b285b047292d1bf893732ac1bc030a351fb517f/cryptography-50.0.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:693c99b49bd37d0d096e4334c10232c77248c415b98d35236094cdf96d57258b", size = 3824006, upload-time = "2026-08-25T19:45:37.281Z" },
+]
+
+[[package]]
 name = "datasets"
 version = "4.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -699,6 +800,15 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
 name = "docstring-parser"
 version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -721,7 +831,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -953,16 +1063,41 @@ http = [
 
 [[package]]
 name = "google-auth"
-version = "2.40.3"
+version = "2.57.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cachetools" },
+    { name = "cryptography" },
     { name = "pyasn1-modules" },
-    { name = "rsa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/9b/e92ef23b84fa10a64ce4831390b7a4c2e53c0132568d99d4ae61d04c8855/google_auth-2.40.3.tar.gz", hash = "sha256:500c3a29adedeb36ea9cf24b8d10858e152f2412e3ca37829b3fa18e33d63b77", size = 281029, upload-time = "2025-06-04T18:04:57.577Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/3a/d3982b28d267880b5641f9a32c55d8062a9d2bad2d28d0274285391c89c2/google_auth-2.57.1.tar.gz", hash = "sha256:eb47b230fc6707eed4aee1c9cef55ec05bc1785eecba74ff8b572d531e921b1e", size = 372426, upload-time = "2026-09-04T00:50:27.593Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/63/b19553b658a1692443c62bd07e5868adaa0ad746a0751ba62c59568cd45b/google_auth-2.40.3-py2.py3-none-any.whl", hash = "sha256:1370d4593e86213563547f97a92752fc658456fe4514c809544f330fed45a7ca", size = 216137, upload-time = "2025-06-04T18:04:55.573Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/27/0f7247b8002a1404fdb5412aeb15fb0fe70288eb8f88a5873d1c0d8262cf/google_auth-2.57.1-py3-none-any.whl", hash = "sha256:ab439dee60a6856412bc058f13a68eb6a59c5b81526bb89cfdcf89ce9c0a48c9", size = 259974, upload-time = "2026-09-04T00:50:21.693Z" },
+]
+
+[package.optional-dependencies]
+requests = [
+    { name = "requests" },
+]
+
+[[package]]
+name = "google-genai"
+version = "2.22.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "google-auth", extra = ["requests"] },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "sniffio" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/37/f1/f2f31b2a6bd826bc2cb73068df880954a026474c03a4315637d20cc13965/google_genai-2.22.0.tar.gz", hash = "sha256:9fa3b5d9ddb635005d8ab2d6206fb2b3d7204b66965bbce7de13ecd1a866ebcd", size = 684719, upload-time = "2026-09-02T18:06:02.906Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/96/0120d214958cb54f2b9c48da9f564a0e6eae269e9dd702415fb1d0551cc7/google_genai-2.22.0-py3-none-any.whl", hash = "sha256:c514001c45470cc0a942440ae1b8215445d12bfb6c373aac94637127e1f74ec6", size = 1088792, upload-time = "2026-09-02T18:06:00.629Z" },
 ]
 
 [[package]]
@@ -1059,8 +1194,8 @@ name = "httpcore2"
 version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "h11", marker = "python_full_version < '3.14' or sys_platform != 'emscripten'" },
-    { name = "truststore", marker = "python_full_version < '3.14' or sys_platform != 'emscripten'" },
+    { name = "h11" },
+    { name = "truststore" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
 wheels = [
@@ -1329,6 +1464,7 @@ source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },
     { name = "anyio" },
+    { name = "google-genai" },
     { name = "httpx" },
     { name = "inspect-ai" },
     { name = "nest-asyncio" },
@@ -1372,6 +1508,7 @@ requires-dist = [
     { name = "agent-client-protocol", specifier = ">=0.11.0" },
     { name = "anthropic", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "anyio" },
+    { name = "google-genai", specifier = ">=1.69.0" },
     { name = "griffe", marker = "extra == 'dev'", specifier = ">=2" },
     { name = "griffe", marker = "extra == 'doc'", specifier = ">=2" },
     { name = "httpx" },
@@ -1436,17 +1573,17 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.11'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "jedi", marker = "python_full_version < '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
-    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "stack-data", marker = "python_full_version < '3.11'" },
-    { name = "traitlets", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "exceptiongroup" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/85/31/10ac88f3357fc276dc8a64e8880c82e80e7459326ae1d0a211b40abf6665/ipython-8.37.0.tar.gz", hash = "sha256:ca815841e1a41a1e6b73a0b08f3038af9b2252564d01fc405356d34033012216", size = 5606088, upload-time = "2025-05-31T16:39:09.613Z" }
 wheels = [
@@ -1465,17 +1602,17 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.11'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
-    { name = "jedi", marker = "python_full_version >= '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
-    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
-    { name = "stack-data", marker = "python_full_version >= '3.11'" },
-    { name = "traitlets", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6e/71/a86262bf5a68bf211bcc71fe302af7e05f18a2852fdc610a854d20d085e6/ipython-9.5.0.tar.gz", hash = "sha256:129c44b941fe6d9b82d36fc7a7c18127ddb1d6f02f78f867f402e2e3adde3113", size = 4389137, upload-time = "2025-08-29T12:15:21.519Z" }
 wheels = [
@@ -1487,7 +1624,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -2882,7 +3019,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "(python_full_version < '3.14' and sys_platform == 'emscripten') or (python_full_version < '3.14' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -3953,18 +4090,6 @@ wheels = [
 ]
 
 [[package]]
-name = "rsa"
-version = "4.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyasn1" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
-]
-
-[[package]]
 name = "ruff"
 version = "0.12.11"
 source = { registry = "https://pypi.org/simple" }
@@ -4509,6 +4634,122 @@ wheels = [
 ]
 
 [[package]]
+name = "websockets"
+version = "16.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/f7/bc3a25c5ec26ce62ce487690becc2f3710bbc7b33338f005ad390db0b986/websockets-16.1.1.tar.gz", hash = "sha256:db234eda965dcce15df96bb9709f587cd87d4d52aaf0e80e2f34ec04c7670c57", size = 182204, upload-time = "2026-07-17T22:51:05.858Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/e7/d1671fb984f9dd844e1da5288070c7c23c9eaba3082d3871aae19c3ab8b9/websockets-16.1.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:49ae99bdfcae803a885c926bf14f886196e84925395bb3f568fef5c0f0979d7d", size = 179570, upload-time = "2026-07-17T22:48:24.032Z" },
+    { url = "https://files.pythonhosted.org/packages/99/f5/70df723bf571f5e0b1b845e0a4ff1c966eeb84f667599fc251caa37d15a3/websockets-16.1.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5bfd1ac19b1b9986a9c95a82d5e23a391ebb09e12c34d7be6094b86efcc35731", size = 177252, upload-time = "2026-07-17T22:48:25.775Z" },
+    { url = "https://files.pythonhosted.org/packages/90/72/2f14b2e167170b8bf1c8bb7f9b0d78000f470d41a2085a91f33e3917b6c9/websockets-16.1.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9246a0d063cfcbcc85f2359dd6876d681213f4790832272aa16641b4ed5d64d4", size = 177530, upload-time = "2026-07-17T22:48:27.337Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/18/a17e2f0cde02dc10154c808deed7e1d8528afff93612f70d3f0a5b19b011/websockets-16.1.1-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1214e673c404684b9bf7154f5cf43b45025b1a6160fac3a9e438e9c1a97e22cb", size = 186038, upload-time = "2026-07-17T22:48:28.756Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/b0/41de283899cf5929d637b72a508cdbc9aa40dc0f317c6b77613fd1000488/websockets-16.1.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:90001d893bc368e302ef168d82130b4e4fdd27b85fa094682df9b667c2d48838", size = 187278, upload-time = "2026-07-17T22:48:30.328Z" },
+    { url = "https://files.pythonhosted.org/packages/50/61/874aab5257e027f9f61b5004cec65e592babca7942b1bc09f38e72b7f1fd/websockets-16.1.1-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:130937b167a52af203c8d58e78d67705874e82759862e3b9671a452fec4abc87", size = 189936, upload-time = "2026-07-17T22:48:31.896Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/1a/42173913ac5519607220849ed417c864d77384e4119f06dbba964a50f096/websockets-16.1.1-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9c9f23004a3d40e89c01a7955d186a6cc83418d93b749701944ce2de3e95a1f3", size = 187796, upload-time = "2026-07-17T22:48:33.344Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/f4/37c1840bd89b529479aec41470b97b7c683b107ca90b6399ac5afb99dedf/websockets-16.1.1-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f55f0b01956a094c8587146d9558c91937e78789c333860ffaf35931a6e5dbc4", size = 186481, upload-time = "2026-07-17T22:48:34.843Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/70/652d9b964adcfbeb056f42e0ca6bece34d108fe75534e74df20643cae199/websockets-16.1.1-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6aaface73b9c71974c6497366d8b9628357f6c9749e09c4ea3610176c63f2ae3", size = 184351, upload-time = "2026-07-17T22:48:36.307Z" },
+    { url = "https://files.pythonhosted.org/packages/13/f1/af3850e5d48d482921985be72ebcb169c6180b3a77b57bd612deebcee23b/websockets-16.1.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:dc0fad4933f427acd5b1cec210f3ea6dce7089e1724e4b9ec6ef47c6c04d1b3b", size = 186791, upload-time = "2026-07-17T22:48:37.762Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/40/1a4e3ed4969ec378dcad337e5f1472c5e292cb3e733bc392f0dc2e230abd/websockets-16.1.1-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:f2769a0344a09e9ccf5b3cce538bc75a51b53eff3275d3896310c8552049195d", size = 185413, upload-time = "2026-07-17T22:48:39.127Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/3e/4e3fa1afe8f1a6a780434cd9ba8eb422632b044eff3dd73f6af67523c147/websockets-16.1.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:f70541f3104339f59f830522d94ebadb1bf47426287381623443d8bb1cdbf33d", size = 187178, upload-time = "2026-07-17T22:48:40.676Z" },
+    { url = "https://files.pythonhosted.org/packages/71/ab/dd742766aa5dda7f349be0de49e4d565b84cf6f7f7fa02e07692f0f2bdd9/websockets-16.1.1-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:dc385593a42e31cd6fb60c19f0ecb015b386603818fc2c6c274fb42bd2bb4165", size = 185051, upload-time = "2026-07-17T22:48:42.098Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/f5/76438c6560f416f1c0a7f587679fb97cc6e99ed336011d43ce2002dd27c1/websockets-16.1.1-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:387e8e4aa5df2f90b198fa3cad3478822a89cf905b6a6d6c97dc3664689640cc", size = 185846, upload-time = "2026-07-17T22:48:43.472Z" },
+    { url = "https://files.pythonhosted.org/packages/62/12/5c0320f2127823d27b2d56d611d31b0b284ad4edcb41364d66bf4c92b537/websockets-16.1.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:fd46fff7eb62c24804d234f0051c7a8ea81285ad63e0337d3dcf33ca82aee58a", size = 186066, upload-time = "2026-07-17T22:48:44.884Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/97/875986b857b955c3f9dd192cb8a1af81254dfb2ea22cc9590f0a1e020b8b/websockets-16.1.1-cp310-cp310-win32.whl", hash = "sha256:7883388947767080f094950b342b30d35a2a06b849cd967c422fa0db72b40ea9", size = 179940, upload-time = "2026-07-17T22:48:46.481Z" },
+    { url = "https://files.pythonhosted.org/packages/54/82/1013a5fe7ddae8e102bc3b4b39db81d8d28fd02100a324ce6ede8cd832b1/websockets-16.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:d57685547e0060cc6fd90ee6a28405d6bd395e525545f13c8d7cd99c78afd79f", size = 180239, upload-time = "2026-07-17T22:48:48.043Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/03/47debfe28e9d6d354be5d777b67fd44c359b9eb299a5d103500bd7cc3e37/websockets-16.1.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d0fcf657e9f13ff4b177960ab2200237b12994232dfb6df16f1cfe1d4339f93c", size = 179566, upload-time = "2026-07-17T22:48:49.596Z" },
+    { url = "https://files.pythonhosted.org/packages/72/93/31efa1ed78c17e5cfc229fd449e3966e1b9cc15753204cd585cc8dd01f4a/websockets-16.1.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b852788aa51764e2d8e4cf5493d559326bcae5e38d16ba25ffa322b034df272a", size = 177250, upload-time = "2026-07-17T22:48:50.942Z" },
+    { url = "https://files.pythonhosted.org/packages/01/4a/542378ab3972b0c1cf1df3df3eff9591cea0d30c58c3aa3c4ddbc244e787/websockets-16.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1427fb4cf0d72f66333e2cacc3ff5f575bf2d7008166ce991a4a470b21d51a22", size = 177528, upload-time = "2026-07-17T22:48:52.59Z" },
+    { url = "https://files.pythonhosted.org/packages/33/d9/162321f63c7eed558e9e1798ed7a1e34a4f6dab51f35419e4ed7a4907979/websockets-16.1.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:da4ca1a9d72f9030b3146b8d7022719a9f3d478f61efe6f7dd51d243f61c51b2", size = 186859, upload-time = "2026-07-17T22:48:53.915Z" },
+    { url = "https://files.pythonhosted.org/packages/de/09/87df740f7430ce564bd52402e9c9458d4d0459cc7d2ee29e530c8204851b/websockets-16.1.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:86d7f0f8bdb25d2c632b72527325e4776430fd5bc61b9118de4e2b8ddb5f5b01", size = 188095, upload-time = "2026-07-17T22:48:55.384Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/12/3d2703af7cc095f3c81904c92208cc1ae79affbc67376944b50ee9301f73/websockets-16.1.1-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:7dfcad78ea1492ee3a9ec765cb7f51bbc17d477107aaf6b22abf7b2558d1c5a0", size = 191385, upload-time = "2026-07-17T22:48:56.742Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/69/986aa0234a964a00f5149cfc46e136e96c8faad1c783474550f40d31aef4/websockets-16.1.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:fb9a0a6dc3d1b3986cb88091b6899f0396651e0f74e2c9766ab8d6ffc3842e29", size = 188653, upload-time = "2026-07-17T22:48:58.134Z" },
+    { url = "https://files.pythonhosted.org/packages/35/6b/10f9d03e3970a69ba67bd3b46b87a929b586d0300fadbfe14f57c1f85490/websockets-16.1.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:29dfa8114c4a620c69591c5973860f768eac29d3fd6904f37f34266cb219c512", size = 187426, upload-time = "2026-07-17T22:48:59.515Z" },
+    { url = "https://files.pythonhosted.org/packages/56/db/bb3aad62bf63d8bb3f0634b2eabffcfb3677a34bd19492110ff6869cf703/websockets-16.1.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6ff9417c0ada4d0f7d212f928303e5579bdf3ace4c802fa4afabb30995da58c3", size = 184882, upload-time = "2026-07-17T22:49:00.916Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/4c/c09a2ea9bfbeccce52fdc383e5f28af4bc8843338aabac28c81489af6120/websockets-16.1.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8fe0b50da2d84535fb4f7b4bfa951280f97ce3d558a0443b541166d609e67b57", size = 187584, upload-time = "2026-07-17T22:49:02.283Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/8b/31bb4eb4d9eaacf1fdd39d115772a8aeaedfc19b5dc262e57ffbc8a9d42c/websockets-16.1.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:34420aaa64440ebd51ac72ca8a45ef4626429438c9b02e633ae412ed43f925d3", size = 186174, upload-time = "2026-07-17T22:49:03.973Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e4/dc02d725610a1ad49e193ef91a548194d71bdc6cdf27da83067dd1f73995/websockets-16.1.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:a6a61aff018180c9c50b7b0da33bfd29d378af3497429c95006c589a23a11648", size = 187986, upload-time = "2026-07-17T22:49:05.553Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/73/30ed84c8bfd14c73d4af29d5ed9323c3073b48e0b7b23b67070f4e7fd59b/websockets-16.1.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:04fd29a0e2fe9414a95b00e92c67ae51bf900c50c0f8a4b2dafdad621f49ea1d", size = 185565, upload-time = "2026-07-17T22:49:06.959Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/d3/4be8d4959f51e31b4f8fc0ece12b45bd3b6c0d15ea23b9990d9c11fc805f/websockets-16.1.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:5c31aa7e39ee3e8a358573257f1c0bb5c52430d1b637030dd9c8cc2c282926be", size = 186598, upload-time = "2026-07-17T22:49:08.293Z" },
+    { url = "https://files.pythonhosted.org/packages/26/fa/abb38597a52d84ed9cfacadc7a0c6f2db282c0ab23cdf72b58a666a21227/websockets-16.1.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d14bfb217eb4701e850f1525c9d29d79c44794cdf1c299ead25f39f8c78dea81", size = 186834, upload-time = "2026-07-17T22:49:09.766Z" },
+    { url = "https://files.pythonhosted.org/packages/59/80/1119ad08a228b90c4eb77fbe48df7836731a605f5f881ba701ca826a4a65/websockets-16.1.1-cp311-cp311-win32.whl", hash = "sha256:2e28e602bb13da44fbe518c1781a88e3b9d4c3d48d02c9bad83e546164336f57", size = 179940, upload-time = "2026-07-17T22:49:11.196Z" },
+    { url = "https://files.pythonhosted.org/packages/71/b2/e511c1c6f64a95c2f3fc54bffda0e14eaa7e9442be605c29270f7589b918/websockets-16.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:7421fad442de870a8cbf2287d1cad7e706ece0dbfeba5e911df132cbdc1cb56a", size = 180239, upload-time = "2026-07-17T22:49:12.519Z" },
+    { url = "https://files.pythonhosted.org/packages/17/9d/681cda21c9eee743203a6cb79b9d3d05adad9aa60ec660c6c9bf4dd619ca/websockets-16.1.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:cc97814dfb786a83b6e2dc2e79351e1b83e6d715647d6887fcabd83026417a00", size = 179600, upload-time = "2026-07-17T22:49:13.92Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/8d/6195a88b45e8d2a8f745fc2046e36f885a3c9763e6767d2c46229bf9510c/websockets-16.1.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e047dc87ef7ca50f4d309bf775ad4a71711c58556d75d7bd0604b2317f43e94b", size = 177272, upload-time = "2026-07-17T22:49:15.453Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e3/fe2d498c64dea0095c9a9f9a351af4cd6eef31b618395582bc1f38ba45ff/websockets-16.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:01fbdcbac298efe19360b94bc0039c8f746f0220ba570f327577bfee81059175", size = 177542, upload-time = "2026-07-17T22:49:16.875Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ed/f1831681fce0e3242346e5458486003c5f124ed69e5e0b847fd029db4973/websockets-16.1.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0f62863e8a00a6d33c3d6566ec0b89f23787b747ffe0c3bc71ec0e76b82c94b1", size = 187137, upload-time = "2026-07-17T22:49:18.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/79/4ff9dcc1bb46f6b4c536936dde1fd60f9b564f3304307274db97f4c9496d/websockets-16.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8087e82f842609734c9b5a1330464f8e94e346ba0e18c832c08bafa4b0d63c15", size = 188374, upload-time = "2026-07-17T22:49:19.65Z" },
+    { url = "https://files.pythonhosted.org/packages/62/c3/5c49b6efb36cab733d23773f6de575e1dba65736ead17d5d2b2a1daef779/websockets-16.1.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2bb5d041a8307d2e18782e7ce777f6fdb1e8c2f5d09291484b18c294b789d9aa", size = 191155, upload-time = "2026-07-17T22:49:21.331Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f6/56ccceda3a4838d18f1d40821480da4775397e8b1eecf4031e20c50e2e90/websockets-16.1.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1db4de4a0e95673f7545d393c49eeb0c2f18ac1ef93073218c79d5cdb2ee75ab", size = 189011, upload-time = "2026-07-17T22:49:22.889Z" },
+    { url = "https://files.pythonhosted.org/packages/86/d6/ad5286241a2bce1107e2798d3bfbd62cf79aee167bdb654f8cb1e9dbf949/websockets-16.1.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f17dbe07eb3ea7f99e4df9b7e0efefe80fbf30d37a8cc4d561a0aed310bc8847", size = 187766, upload-time = "2026-07-17T22:49:24.339Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/67/d65c970b7e347fdca69479beb7811c2060529956730a7a4e3ae7c66b0e31/websockets-16.1.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4b57693728576d84ede0a77987ab16881b783d2cd9f1dc180a8fbbc3f79c4428", size = 185173, upload-time = "2026-07-17T22:49:25.743Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/5b/14af3cd4ee69d8ea9baca58f3dc3cfb1ba78332a347fd478cb096549d60e/websockets-16.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2a636ff1e7a5c4edf71ef0e79adae7f25dba93b4fcbe3dc958733477ffeb0eaf", size = 187809, upload-time = "2026-07-17T22:49:27.147Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/11/be301710d70de97e3e7b3586e6d492c9c06d6a61bf1c2202c36cf0c75607/websockets-16.1.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:d6bec75c290fe484a8ba4cacdf838501e17c06ecfbbf31eede81a9e431bd7751", size = 186412, upload-time = "2026-07-17T22:49:28.611Z" },
+    { url = "https://files.pythonhosted.org/packages/db/07/fe1435bf6fe738a3d3b54dbe0c18dabf12cba4d909ac8b58b539ce27c1f4/websockets-16.1.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:54509b8e92fee4453e152b7558ddef37ce9705a044922f2095a6105e3f80c96f", size = 188290, upload-time = "2026-07-17T22:49:29.965Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/0a/81f394aff8efcbb01208c1ced77df0a3c7fcce584a88c7273663697946c2/websockets-16.1.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:f0aa4aad3b1b69ad3fd85a0fd0952ec64331c762bd77ec51cc814170873890b2", size = 185844, upload-time = "2026-07-17T22:49:31.447Z" },
+    { url = "https://files.pythonhosted.org/packages/39/5c/dd485b995473f415510251fe9bd708f2d24458f439fce958daf8d66dc7c6/websockets-16.1.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:42290eb6db4ccaca7012656738214f8514082fb6fa40cdeb61bb9a471b52e383", size = 186823, upload-time = "2026-07-17T22:49:33.104Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/0b/f78de76ff446f1e66af12b43c48a35f31744de93cfdec2f4ea67d5d7bbf1/websockets-16.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:53260c8930da5771cec89439bff99c20c8cb03ddb9588b980697355a83cd4bd3", size = 187102, upload-time = "2026-07-17T22:49:34.616Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a1/4cf892007778eaf84ad162bfc98046e0ed89b63ac55949e3236626b2a23f/websockets-16.1.1-cp312-cp312-win32.whl", hash = "sha256:1d27fa8462ad6a1cb36206a3d0640b2333340def181fae11ed7f9adeaa5c0747", size = 179943, upload-time = "2026-07-17T22:49:36.213Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/de/6abe251d28c3a3f217096575400b27750b18e0b1d2fff3a2a239960fea07/websockets-16.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:b436f6ec4fc3a6b4237c84d3f83170ed2b40bb584222f0ac47a0c8a5921980c7", size = 180243, upload-time = "2026-07-17T22:49:37.626Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/fd/6ec6c6d2850aea25b1b2aa9901a016980bb87d01e89b3eb00470b1b5d471/websockets-16.1.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ab59169ace05dcb49a1d4118f0bde139557adf45091bd85747e36bf5de984dd1", size = 179587, upload-time = "2026-07-17T22:49:38.959Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/d8/1d299d2dd34087db39831a34cc645ef8a6f89d78efada6983093513cd81c/websockets-16.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5e3b7d601f6f84156b08cc4a5e541c2b50ad7b36cfc302b657a12477c904a5df", size = 177272, upload-time = "2026-07-17T22:49:40.293Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/86/0a70d3ae2f0f2256bb41302d9804dbca65d4360281e7feb3e1f94102ac46/websockets-16.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cd2ca96a082a36964aca83e992f72abeb61b7306c1a6cba4c7d06a7b93750cac", size = 177530, upload-time = "2026-07-17T22:49:41.786Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/c2/c676c69444d9db448b3f0a55a98dcc534affce0bce961d9d2f0b8499b10a/websockets-16.1.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f5d497865f05bb222cab7016c6034542e84e5f29f49c6fd3f4939cda7197b5b8", size = 187197, upload-time = "2026-07-17T22:49:43.658Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/13/88137fbaf726ebe29d62c1117fa11fa2bbb6209dc79d4ad738efbe36a2aa/websockets-16.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bae954c382e013d5ea5b190d2830526bfa45ad121c326da0049b8c769f185db6", size = 188433, upload-time = "2026-07-17T22:49:45.147Z" },
+    { url = "https://files.pythonhosted.org/packages/01/6d/46c2f2ce6751cb26f39293e1ecbf8544cb01321397cd476c2756b98c216d/websockets-16.1.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e09f753a169951eb4f28c2c774f71069304f66e7277e0f5a2892423599cfa854", size = 189868, upload-time = "2026-07-17T22:49:46.581Z" },
+    { url = "https://files.pythonhosted.org/packages/29/2b/170a9e8097636cfde4dc3c592b6e00b18a44a2f5407606d96ca542dd5838/websockets-16.1.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:024193f8551a2b0eafbdd160911012c4e6c228c28430c84433253299a9e42d6a", size = 189059, upload-time = "2026-07-17T22:49:47.972Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/48/f0d4ebc9ab4b473b8861b9e20fdb663d515d42f7befdf62cdb60fee7a1ec/websockets-16.1.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:aabe464bfd13bd25f4821faf111da6fefdc389f870265a53105580e45b0a2e49", size = 187814, upload-time = "2026-07-17T22:49:49.344Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ba/39a41d3ae8e72696a9492581900611c5a91e2b07563b0bcd2523adea9854/websockets-16.1.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a28fcbc9b6baf54a2e23f8655f308e4ccc6afdd7266f8fe7954f320dcda0f785", size = 185229, upload-time = "2026-07-17T22:49:50.787Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/36/ac15b604f850d1907f0a85ed721cefe47cd45034b3620069b829746cccbe/websockets-16.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:79eace538c6a97e96d0d03d4f9d314f9677f5ed85a8a984992ffd90b13cb8a56", size = 187874, upload-time = "2026-07-17T22:49:52.228Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/f3/3fbd5d71d59299c3770faa5884d4f45070236ca5a35ab3a61830812c409a/websockets-16.1.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:496af849a472b531f758dbd4d61338f5000538cb1a7b3d20d9d32a264517f509", size = 186469, upload-time = "2026-07-17T22:49:53.776Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/fc/dd90349bba58af2a53ef2ddd9c32716c81eb6d59a0687939fff561860878/websockets-16.1.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5283810d2646741a0d8da2aa733d6aefa0545809afccb2a5d105a26bc45125f1", size = 188347, upload-time = "2026-07-17T22:49:55.202Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/f3/f73ba86427682da59b78c11d77ba56d5b801c32e84afe79b274bbd6a9bb2/websockets-16.1.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:4e3b680b1e0a27457e727a0d572fd81dffa87b6dbf8b228ab57da64f7d85aead", size = 185903, upload-time = "2026-07-17T22:49:56.75Z" },
+    { url = "https://files.pythonhosted.org/packages/34/7c/f95eb20e80104173b3a0a092291f89ea4047ef6e608e0a57ca06eb14eecb/websockets-16.1.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:69159730a823dde3ea8d08783e8d47ef135a6d7e8d44eb127e32b321c9db8e3e", size = 186855, upload-time = "2026-07-17T22:49:58.467Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/35/dd875b3e050ff232d60fa377707f890e369f74d134f1be32e8f68879747c/websockets-16.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ed5bb271084b46530ee2ddc0410537a9961152c5ccba2fc98c5276d992ccba87", size = 187140, upload-time = "2026-07-17T22:50:00.016Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/dc/5cbfcb41824502f6af93b8f3943a4d06c67c23c7d2e31eb18748c4a5b2a7/websockets-16.1.1-cp313-cp313-win32.whl", hash = "sha256:cfb70b4eb56cac4da0a83588f3ad50d46beb0690391082f3d4e2d488c70b68ea", size = 179928, upload-time = "2026-07-17T22:50:01.685Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c1/71e5deb5b7f8f226997ab64908c184ac3105c0155ce2d486f318e5dd08a8/websockets-16.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:d9531d9cbeac99af6f038fb1bc351403531f7d634a2c2e10e2f7c854c6ed5b68", size = 180242, upload-time = "2026-07-17T22:50:03.117Z" },
+    { url = "https://files.pythonhosted.org/packages/73/a2/ba78a164eeea4620df4a4df4bd2ed6017438c4655cc0f36f2c0bc0432355/websockets-16.1.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:443aefe96b7fdb132e2a70806cca1f2af49bb3f28e47abcd7c2e9dcf4d8fa1b8", size = 179635, upload-time = "2026-07-17T22:50:05.001Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/08/d26d7a7628cd4ac34cbbdb63ac80914ca842ed8e42938c40a53567806df3/websockets-16.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6456ff333092d509127d75a638cb411afae8ff17f092635015d1902efec8a293", size = 177320, upload-time = "2026-07-17T22:50:06.427Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/45/ebec83e6269536aa5932533c67b0af5c781f3e73fdbcd68672dcf43f4f44/websockets-16.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fce6c48559c86d1ac3632ccb1bebc7d5442fbe79bd9bb0e40379ee54be2a4051", size = 177544, upload-time = "2026-07-17T22:50:07.834Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d5/abc614d2297f6c1c3e01e61260364457a47c25cc1cf6a879038902bc6aa8/websockets-16.1.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:92b820d345f7a3fc7b8163949ee92df910f290c3fc517b3d5301c78065adafe1", size = 187270, upload-time = "2026-07-17T22:50:09.275Z" },
+    { url = "https://files.pythonhosted.org/packages/52/71/4c99af3b87dff1b2927981f6876607d4acb45338c665242168d3982f7758/websockets-16.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2a606d9c24035242a3e256e9d5b77ed9cd6bccfcb7cf993e5ca3c0f6f68fb6a7", size = 188509, upload-time = "2026-07-17T22:50:10.722Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/b4/5c8ca14b0df7eb84ed0524165c5359150210140817a3312aee57bf62a1cf/websockets-16.1.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:414e596c75f74e0994084694189d7dc9229fb278e33064d6784b73ffbba3ca31", size = 189882, upload-time = "2026-07-17T22:50:12.293Z" },
+    { url = "https://files.pythonhosted.org/packages/25/c1/bedfba9e70557129cb8083748d167bdcc01483dedf0f0df143676df05cbe/websockets-16.1.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:536676848fc5961aca9d20389951f59169508f765637a172403dc5434d722fa0", size = 189114, upload-time = "2026-07-17T22:50:13.789Z" },
+    { url = "https://files.pythonhosted.org/packages/df/09/aa835b2787835aebd839114be5de51b797cb480b63ba42b26d34dfe147cb/websockets-16.1.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:97fd3a0e8b53efa41970ac1dff3d8cf0d2884cadeb4caaf95db7ad1526926ee3", size = 187861, upload-time = "2026-07-17T22:50:15.179Z" },
+    { url = "https://files.pythonhosted.org/packages/20/26/f6408330694dbc9830857d9d23bc14ac4f6875127a480cfdda8d5ca21198/websockets-16.1.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7b1b19636af86a3c7995d4d028dbe376f39b4bf31541146f9c123582a6c94562", size = 185286, upload-time = "2026-07-17T22:50:16.741Z" },
+    { url = "https://files.pythonhosted.org/packages/17/9a/e0675e70dd8a80762cf35bb18799d3f290a4890ffe6439bc51d222796083/websockets-16.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:41c8e77f17294c0ac18008a7309b99b34ee72247ef10b6dff4c3f8b5ac29896b", size = 187935, upload-time = "2026-07-17T22:50:18.213Z" },
+    { url = "https://files.pythonhosted.org/packages/33/c1/3234cfb86afde01b81e9bddcc6e534c440975d60a13991259e833069ab3e/websockets-16.1.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:9f63bcef7f4b02b06b35fc01c93b96c43b5e88e1e8868676caacf493d5a31f3a", size = 186444, upload-time = "2026-07-17T22:50:19.67Z" },
+    { url = "https://files.pythonhosted.org/packages/89/87/9c15206e1d778923d8daa9657de07aa62ea815e13448319c98458c37b281/websockets-16.1.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:dab9eb87869da2d6ed3af3f3adf28414baae6ec9d4df355ffc18889132f3436c", size = 188409, upload-time = "2026-07-17T22:50:21.28Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/00/cf5de5c67676de2d3eef8b2a518f168f6796595447a5b7161ba0d012915c/websockets-16.1.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:43e3a9fdd7cbf7ba6040c31fae0faf84ca1474fef777c4e37912f1540f854499", size = 185958, upload-time = "2026-07-17T22:50:22.719Z" },
+    { url = "https://files.pythonhosted.org/packages/62/c0/731b6ddede2e4136912ec4cff2cffbda35af73546be4762c3d7bd3bd79af/websockets-16.1.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:056ae37939ed7e9974f364f5864e76e49182622d8f9751ac1903c0d09b013985", size = 186911, upload-time = "2026-07-17T22:50:24.108Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/7f/39c634472c4469a24a7c09cecddffb08fac6d0e74f73881a94ee8a40a196/websockets-16.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a0eadbbf2c30f01efa58e1f110eb6fa293261f6b0b1aa38f7f48707107690af9", size = 187204, upload-time = "2026-07-17T22:50:25.548Z" },
+    { url = "https://files.pythonhosted.org/packages/26/89/9667c256c256dafcc62d21328ce7a40067da857969b68ee9af375b0aaf72/websockets-16.1.1-cp314-cp314-win32.whl", hash = "sha256:195c978b065fa40910582464f99d6b15c8b314c68e0546549a55ed83f4735328", size = 179603, upload-time = "2026-07-17T22:50:27.086Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/dd/1c099d6c0fc5deb6b46ccdbb6981fdb4b12c917869cb3952408409dc18db/websockets-16.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:4e8d01cc3bcae7bbf8167f944aeafefed590fae5693552bba9794a9df68371cc", size = 179948, upload-time = "2026-07-17T22:50:28.521Z" },
+    { url = "https://files.pythonhosted.org/packages/35/25/9956b2d5e0529d5d23924f21bba1440d4c5c88a562e4f08550871ffa97a7/websockets-16.1.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:0ffd3031ea8bda8d61762e84220186105ba3b748b3c8da2ae4f7816fac03e573", size = 179963, upload-time = "2026-07-17T22:50:29.982Z" },
+    { url = "https://files.pythonhosted.org/packages/17/06/55ffc976c488b6aee9ea05761ff7c4e88e7c1fd82818c8ca7b556ad2f90c/websockets-16.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:84a2cef8deffbd9ab8ee0ea546a2a6a7030c28f44e6cdd4547dbfeb489eb8999", size = 177497, upload-time = "2026-07-17T22:50:31.396Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e8/f7dac2e980bacc92bdc26cebae4ae4d50cae5380732c50980598fc0bbae4/websockets-16.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3df13f73af9b3b38ab1195eb299ecb67a4330c911c97ae04043ff74085728abe", size = 177698, upload-time = "2026-07-17T22:50:32.829Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/39/26762f734113e22da2b942c3aca85798e0c0405d64c256549540ff31e5a1/websockets-16.1.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:23253dd5bcae3f9aaee0a1d30967a8dbd52e5d3cff93a2e5b84df57b77d4750d", size = 187561, upload-time = "2026-07-17T22:50:34.24Z" },
+    { url = "https://files.pythonhosted.org/packages/11/94/c3f330851806b9b02138b774d593478323e73c99238681b4b93efe64e02d/websockets-16.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c1c5705e314449e3308872fe084b8571ce078ee4fc55a98a769bdefe5917392", size = 188732, upload-time = "2026-07-17T22:50:36.088Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/f2/eb2c450f052de334ae33cf200ece6e87b0e14d186807074e4eb1cd2cdea2/websockets-16.1.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:69e52d175a0a7d1e13b4b67ad41c560b7d98e8c6f6126eb0bda496c784faf8c7", size = 190872, upload-time = "2026-07-17T22:50:38.008Z" },
+    { url = "https://files.pythonhosted.org/packages/70/31/2ac8cecf3a74f7fed9132129fc3d90b3998a1554570c11a69b2a8c20332d/websockets-16.1.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1f79c89b5eb034d1722938a891916582f8f7f503f58ca22518a63c3f2cd18499", size = 189305, upload-time = "2026-07-17T22:50:39.53Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/cf/8ab19650d3c0d4562c92e70ab47c257c4aa5c6a713ed87fe63766b31fefc/websockets-16.1.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:39f2a024af5c345ffe8fcf1ee18c049c024c94df393bb09b044a6917c77bde43", size = 188033, upload-time = "2026-07-17T22:50:40.912Z" },
+    { url = "https://files.pythonhosted.org/packages/66/d7/a49a38a6127a4acb134fb1912b215d900cc657605cff32445bf519f3acc4/websockets-16.1.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:952303a7318d4cbe1011400839bb2051c9f84fa0a35923267f5daba34b15d458", size = 185748, upload-time = "2026-07-17T22:50:42.559Z" },
+    { url = "https://files.pythonhosted.org/packages/95/3e/ad1fa40388c7f2e0bb2c7930d0090b6c5498594bd1cdaec18864df3d9e97/websockets-16.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:249116b4a76063d930a46391ad56e135c286e4562a18309029fc2c73f4ed4c62", size = 188285, upload-time = "2026-07-17T22:50:43.974Z" },
+    { url = "https://files.pythonhosted.org/packages/35/b8/d5db28ca264b9104f82196f92dc8843e35fd391f763d42e4ad358f5bc97e/websockets-16.1.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:61922544a0587a13fd3f53e4c0e5e606510c7b0d9d22c8444e5fae22a06b38cb", size = 186777, upload-time = "2026-07-17T22:50:45.474Z" },
+    { url = "https://files.pythonhosted.org/packages/42/9c/726cb39d0cc43ae848dce4aa2acb04eecc6738b1264ec6d700bf6bcfb9f8/websockets-16.1.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:46dcaa042cd1de6c59e7d9269fa63ff7572b6df40510600b678f0826b3c7af51", size = 188682, upload-time = "2026-07-17T22:50:46.973Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c7/1168704de8c2dd483edabe4a22cbe4465dd8be8dd95561d214f9fe092871/websockets-16.1.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:38565aca3e01ea8734e578fb2118dade0ecb0250533f29e22b8d1a7a196cf4d0", size = 186377, upload-time = "2026-07-17T22:50:48.413Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/40/f9ff2d630ffce4e7dfea0b2288e1caf9ebbf9ff8a9ec9396136ce8b94935/websockets-16.1.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:42f599f4d48c7e1a3338fdaac3acd075be3b3cf02d4b274f3bf2767aedd3d217", size = 187148, upload-time = "2026-07-17T22:50:49.845Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/71/e177c8299f78d7cbe2d14df228643c10c70c0e86e108e092056bbcc16e46/websockets-16.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dcc04fedf83effaeb9cce98abc9469bb1b42ef85f03e01c8c1f4438ef7555737", size = 187578, upload-time = "2026-07-17T22:50:51.619Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b2/b6987faf330f5af5c787a2610124c2e8403d51724f9001ec4fff6311fe7a/websockets-16.1.1-cp314-cp314t-win32.whl", hash = "sha256:8483c2096363120eea8b07c06ae7304d520f686665fffd4811fad423930a65d7", size = 179729, upload-time = "2026-07-17T22:50:53.269Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/6e/fbac6ed878dd362fbad7d415fa4f84d38e3e33fed8cde45c64e783acf826/websockets-16.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:bcce07e23e5769375158f5efdcdafa8d5cd014b93c6683865b840ed65b96f231", size = 180072, upload-time = "2026-07-17T22:50:54.969Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ed/71fea6e141590cafc40b14dc5943b0845606bee87bdb52a21b6a73eb4311/websockets-16.1.1-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:820fb8450edddae3812fd58cbc08e2bf22812cb248ecb5f06dbb82119a56e869", size = 177185, upload-time = "2026-07-17T22:50:56.665Z" },
+    { url = "https://files.pythonhosted.org/packages/01/ec/00e7eeca200facf9266a83e4cbbf1bed0e67fba1d4d45031d3e5b3d81b5c/websockets-16.1.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:125f22dbefaf1554fea66fc83851490edb284ce4f501d37ffed2752f418332d9", size = 177459, upload-time = "2026-07-17T22:50:58.197Z" },
+    { url = "https://files.pythonhosted.org/packages/75/fd/5774c4b33f7c0d8f0c51809c8b3a93456c48e3543579262cfa64eb5f522e/websockets-16.1.1-pp311-pypy311_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:30bbe120437b5648a77d3519b7024ea09530e0b5b18d3698c5a0ae536fe0cc2e", size = 178294, upload-time = "2026-07-17T22:50:59.641Z" },
+    { url = "https://files.pythonhosted.org/packages/37/c3/48e2c03d2bd79bb45948841c592d24156312dd5f58cdf8f549febe652fb6/websockets-16.1.1-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b6b9dadbef0cccd9f4c4ee96b08898afa73e26803bbe0f6aeb5bb12b0074206d", size = 179190, upload-time = "2026-07-17T22:51:01.129Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/3f/73e511ecf2496ceac57dd4ed8388efe2bcf0769338a2dbf242c8366ae87e/websockets-16.1.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56cd5fc4f10a9ea8aa0804bddb7b42506cf9e136046f3b4c27de8fec9e2ecba5", size = 180330, upload-time = "2026-07-17T22:51:02.603Z" },
+    { url = "https://files.pythonhosted.org/packages/be/4d/2d0d67834092e354d2b0498f014a41249a89556bc406cf86f3e1557bb463/websockets-16.1.1-py3-none-any.whl", hash = "sha256:6abbd3e82c731c8e531714466acd5d87b5e88ac3243465337ba71d68e23ae7e3", size = 173814, upload-time = "2026-07-17T22:51:04.184Z" },
+]
+
+[[package]]
 name = "wheel"
 version = "0.45.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4817,7 +5058,7 @@ name = "zipfile-zstd"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zstandard", marker = "python_full_version < '3.14'" },
+    { name = "zstandard" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f7/2a/2e0941bc0058d10ab37d8c578b94a19f611f6ae54f124140f2fb451f0932/zipfile-zstd-0.0.4.tar.gz", hash = "sha256:c1498e15b7922a3d1af0ea55df8b11b2af4e8f7e0e80e414e25d66899f7def89", size = 4603, upload-time = "2021-12-08T07:38:16.245Z" }
 wheels = [


### PR DESCRIPTION
**Draft on purpose.** This agent calls `sandbox_agent_bridge(..., state_filter=...)`, which is not in any released `inspect_ai` — it comes from UKGovernmentBEIS/inspect_ai#5309, still open. Until that merges and ships, this PR does not work against the `inspect_ai>=0.3.261` floor it declares, and the floor is deliberately left alone: bumping it to a version that does not exist yet would be worse than the honest mismatch. Opening it now to get review on the shape while the Core side is in flight. Same posture as #134.

### What it adds

`antigravity_cli()` runs the released Antigravity CLI (`agy`, pinned 1.1.27) as an Inspect agent, alongside the existing `antigravity()` SDK executor. It is a separate agent, not an alias: the SDK executor is unattended-only and configured differently.

The CLI reaches the model through `sandbox_agent_bridge` on `GOOGLE_GEMINI_BASE_URL`, authenticating with a placeholder `GEMINI_API_KEY` that satisfies its client-side check. No Google credential enters the sandbox and nothing intercepts TLS. That is what makes this workable where #85 was not — `agy` 1.1.13 added the endpoint override, so the two blockers craig-meridian named there (a real OAuth token copied into the sandbox; a mitmproxy in front of a private Vertex wire format) no longer have to exist. The old `provision_antigravity_home` path is gone; in-sandbox state is synthesised, not copied from the host.

`state_filter` is what the agent needs from Core. The CLI issues auxiliary requests (conversation titles) on the same bridge as the task conversation, and without a way to say which requests are eligible, those land in `AgentState` and displace the real conversation. The predicate is the agent's own conversation identity, so canonical state holds the task thread and the auxiliary responses still return, still emit events, and still count usage.

### Verification

Native CLI suite against Core #5309's branch: 12 passed (`pytest tests/test_antigravity_cli.py --runslow`), covering real command and MCP round trips in Docker, canonical identity with a late title, retry and re-entry, and accumulated Centaur state. Fast suite: 487 passed, 97 skipped. `mypy` is clean against that Core; against released `inspect_ai` it reports exactly one error, the `state_filter` keyword — which is the dependency gap above, not a separate defect.

I have driven this end to end against a real Google endpoint outside this repo, including tool execution and a scored submission, and on a Kubernetes host over SSH.

### Agent review

- Reviewers: two fresh-context passes on Claude Opus 5 — a security/correctness pass and a maintainability pass. Neither saw the authoring conversation.
- Findings: 2 blockers, both fixed in `fix(antigravity_cli): close credential-boundary gaps in env merge and MCP config`.
  1. A caller's `env` could override `GOOGLE_GEMINI_BASE_URL` and `GEMINI_API_KEY` (a right-biased merge), so `env=os.environ.copy()` was enough to move generation onto Google's real endpoint or put a real key in the sandbox. Those two keys are now applied after the caller's `env` and cannot be overridden; everything else keeps the caller-wins contract `claude_code_agent_env` documents.
  2. `MCPServerConfigHTTP.headers` and stdio `env` were written verbatim into `$HOME/.gemini/config/mcp_config.json`, which the evaluated agent can read. An authenticated server now raises, naming `bridged_tools`. Worth saying plainly: `gemini_cli`, `opencode` and `kimi_code` write those same headers into their own in-sandbox config files today, so this is narrower than the guardrail in AGENTS.md implies — I have only changed the agent this PR adds.
- Also raised and not fixed here: `tests/test_antigravity_cli.py` is 1,477 lines spanning several concerns and should be split; and `docs/_snippets/agent_installation.md` hard-codes a Claude Code example that now renders on every agent's page, which predates this PR.
