### PR TITLE
test: give mini_swe_agent multi-turn evals 600s and report limit hits explicitly

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -201,18 +201,31 @@ def run_example(
     # would clip honest runs. 500k still trips a runaway inside ~3 minutes,
     # ahead of the time limit, while sitting well clear of real usage.
     #
-    # gemini_cli gets double the time: its healthy multi-turn runs (multi_call,
-    # skills) already take ~300s, so any burst of Gemini API retries pushes it
-    # over the limit and fails the run with a truncated transcript rather than
-    # an obvious timeout (e.g. meridianlabs-ai/actions run 33373083766, where 8
-    # HTTP retries left only 1 of the expected 4+ user messages). 600s still
-    # sits well under the 900s pytest --timeout backstop in the nightly.
+    # gemini_cli and mini_swe_agent get double the time. gemini_cli's healthy
+    # multi-turn runs (multi_call, skills) already take ~300s, so any burst of
+    # Gemini API retries pushes it over the limit and fails the run with a
+    # truncated transcript rather than an obvious timeout (e.g.
+    # meridianlabs-ai/actions run 33373083766, where 8 HTTP retries left only
+    # 1 of the expected 4+ user messages). mini_swe_agent reached the same
+    # regime with gpt-5-mini: it drives ~10 sequential reasoning calls for the
+    # four multi_call questions, healthy runs range 95-200s, and run
+    # 34455110720 hit 300s with the same 8-retry / 1-user-message signature.
+    # The allowance is keyed on the agent, not the example, so it deliberately
+    # widens the runaway window for every mini_swe_agent example (as it
+    # already does for gemini_cli).
+    #
+    # 600s leaves ~300s under the nightly's 900s pytest --timeout, but the
+    # margin is thinner than it looks: Inspect starts the sample clock after
+    # sandbox init, so docker pull/start/teardown come out of that 300s, and
+    # scoring gets a further time_limit / 2. That scoring grant is moot today
+    # (no example defines a scorer), but adding one would put the worst case
+    # at exactly 900s -- revisit the limits if that happens.
     return eval(
         example_file,
         model=model,
         limit=1,
         task_args=task_args,
-        time_limit=600 if agent == "gemini_cli" else 300,
+        time_limit=600 if agent in ("gemini_cli", "mini_swe_agent") else 300,
         token_limit=500_000,
     )
 

--- a/tests/test_multi_call.py
+++ b/tests/test_multi_call.py
@@ -39,6 +39,7 @@ def test_claude_code_system_prompt_not_duplicated(sandbox: str) -> None:
     )[0]
     assert log.samples
     sample = log.samples[0]
+    _assert_sample_completed(sample)
 
     counts = _env_block_counts(sample)
     assert counts, "expected at least one model call carrying the system prompt"
@@ -46,6 +47,23 @@ def test_claude_code_system_prompt_not_duplicated(sandbox: str) -> None:
     assert max(counts) == 1, (
         f"system prompt duplicated in a resumed-turn request: per-call "
         f"'# Environment' counts were {counts}"
+    )
+
+
+def _assert_sample_completed(sample: EvalSample) -> None:
+    """Fail loudly if the sample was cut short by a limit or an error.
+
+    The multi_call solver only copies the agent's messages back into the sample
+    after all four turns complete, so a sample interrupted by a limit keeps just
+    the original input. Without this guard that surfaces downstream as a
+    misleading ``assert 1 >= 4`` (or, for the system-prompt regression test,
+    passes vacuously with a single turn's worth of model calls).
+    """
+    assert sample.limit is None, (
+        f"sample hit a {sample.limit.type} limit ({sample.limit.limit})"
+    )
+    assert sample.error is None, (
+        f"sample errored: {sample.error.message}\n{sample.error.traceback}"
     )
 
 
@@ -127,6 +145,7 @@ def check_multi_call(
     log = run_example("multi_call", agent, model, sandbox=sandbox)[0]
     assert log.samples
     sample = log.samples[0]
+    _assert_sample_completed(sample)
 
     user_messages = [m for m in sample.messages if isinstance(m, ChatMessageUser)]
     assistant_messages = [


### PR DESCRIPTION
## Problem

The nightly slow run [meridianlabs-ai/actions#34455110720](https://github.com/meridianlabs-ai/actions/actions/runs/34455110720) failed on `tests/test_multi_call.py::test_mini_swe_agent_multi_call_openai[docker]` with:

```
AssertionError: assert 1 >= 4
```

The real cause was the eval's 300s `time_limit`: the captured stdout shows `total time: 0:05:03`, `Samples: 0/1`, `HTTP retries: 8`, and 17k reasoning tokens from gpt-5-mini (about 5x a healthy run). Because `examples/multi_call/task.py` only copies the agent's messages back into the sample after all four turns complete, an interrupted sample keeps just the original input and the failure surfaces as a message-count assertion.

This is not a regression: the run tested the same `inspect_ai` and `mini-swe-agent` versions as the previous night's passing run, and the only `inspect_swe` change in between (#142) touches `claude_code` only. Durations for this test over the last nine nightlies were 94, 130, 137, 122, 203, 145, 156, 197, and then 303s (fail): it routinely uses one to two thirds of its budget, so one bad OpenAI night pushes it over. It is the same signature already documented in `conftest.py` for gemini_cli (run 33373083766), which was fixed by giving gemini_cli 600s.

## Changes

- `tests/conftest.py`: `mini_swe_agent` gets the same 600s `time_limit` as `gemini_cli`; comment updated with the evidence. 600s still sits under the nightly's 900s pytest `--timeout`.
- `tests/test_multi_call.py`: new `_assert_sample_completed` helper asserts `sample.limit is None` and `sample.error is None` (with traceback) before any message inspection. Used by `check_multi_call` and by `test_claude_code_system_prompt_not_duplicated`, which shares the same 4-turn solver and would otherwise pass vacuously on a truncated run.

## Verification

- `ruff format`, `ruff check`, `mypy` (strict) clean.
- `test_mini_swe_agent_multi_call_openai[docker]` run locally with `--runslow` against this branch: passed in 103s (and 118s on an earlier run before the change). A runtime check confirmed the helper's messages render as `sample hit a time limit (600.0)` / `sample errored: ...` and pass on a clean sample.

### Agent review
- Reviewer: Claude Opus 5 via a fresh-context general-purpose subagent (different model from the author, Claude Fable 5.1), 1 pass over the committed diff plus the surrounding conftest / solver code and the installed inspect_ai.
- Findings: 5, all fixed:
  1. `test_claude_code_system_prompt_not_duplicated` shares the 4-turn solver but lacked the guard and would pass vacuously on a truncated run: hoisted the asserts into `_assert_sample_completed` and call it from both tests.
  2. "600s sits well under 900s" overstated headroom (sample clock starts after sandbox init; scoring gets `time_limit / 2`): comment rewritten to state the real margin and the scorer caveat.
  3. Comment implied the allowance was multi_call-scoped while the ternary keys on the agent: comment now says the widening to all mini_swe_agent examples is deliberate.
  4. Error message dropped the traceback: now included.
  5. Message asserted an unverified cause ("before completing all turns"): reworded to state only the limit hit.
- Reviewer also confirmed `EvalSampleLimit.type/.limit` and `EvalError.message/.traceback` attribute names, mypy-strict cleanliness, that a healthy run never sets `sample.limit` (so the other agents' tests are unaffected), and that an errored sample remains in `log.samples` so the error assert is reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
