### PR TITLE
fix: unattended CLI agents hang forever when an invocation never returns

### DIFF
--- a/docs/codex_cli.qmd
+++ b/docs/codex_cli.qmd
@@ -33,6 +33,7 @@ The following options are supported for customizing the behavior of the agent:
 | `model` | Model name to use for agent (defaults to main model for task). |
 | `filter` | Filter for intercepting bridged model requests. |
 | `retry_refusals` | Should refusals be retried? (pass number of times to retry) |
+| `exec_timeout` | Wall-time limit in seconds. Default: 1,800 (30 minutes); a healthy invocation exceeding it is terminated. `0` times out immediately; `None` is unbounded. |
 | `home_dir` | Home directory to use for codex cli. When set, AGENTS.md and the MCP configuration will be written here rather than to .codex
 | `cwd` | Working directory for {{< meta agent_name >}} session. |
 | `env` | Environment variables to set for {{< meta agent_name >}}. |

--- a/docs/gemini_cli.qmd
+++ b/docs/gemini_cli.qmd
@@ -27,6 +27,7 @@ The following options are supported for customizing the behavior of the agent:
 | `gemini_model` | Gemini model name to pass to CLI. This bypasses the auto-router. Use `"gemini-2.5-pro"` (default) or `"gemini-2.5-flash"`. |
 | `filter` | Filter for intercepting bridged model requests. |
 | `retry_refusals` | Should refusals be retried? (pass number of times to retry) |
+| `exec_timeout` | Wall-time limit in seconds. Default: 1,800 (30 minutes); a healthy invocation exceeding it is terminated. `0` times out immediately; `None` is unbounded. |
 | `cwd` | Working directory for {{< meta agent_name >}} session. |
 | `env` | Environment variables to set for {{< meta agent_name >}}. |
 | `version` | Version of {{< meta agent_name >}} to use (see [Installation](#installation) below for details) |

--- a/docs/kimi_code.qmd
+++ b/docs/kimi_code.qmd
@@ -26,6 +26,7 @@ The following options are supported for customizing the behavior of the agent:
 | `max_context_size` | Context window to configure for Kimi. Defaults to the bridged model's context length from Inspect model metadata; required when that metadata is unavailable. |
 | `filter` | Filter for intercepting bridged model requests. |
 | `retry_refusals` | Should refusals be retried? (pass number of times to retry) |
+| `exec_timeout` | Wall-time limit in seconds. Default: 1,800 (30 minutes); a healthy invocation exceeding it is terminated. `0` times out immediately; `None` is unbounded. |
 | `disallowed_tools` | Tool names to deny via {{< meta agent_name >}} permission rules. |
 | `cwd` | Working directory for {{< meta agent_name >}} session. |
 | `env` | Environment variables to set for {{< meta agent_name >}}. |

--- a/docs/mini_swe_agent.qmd
+++ b/docs/mini_swe_agent.qmd
@@ -21,6 +21,7 @@ The following options are supported for customizing the behavior of the agent:
 | `filter` | Filter for intercepting bridged model requests. |
 | `retry_refusals` | Should refusals be retried? (pass number of times to retry) |
 | `compaction` | Compaction strategy for managing context window overflow. |
+| `exec_timeout` | Wall-time limit in seconds. Default: 1,800 (30 minutes); a healthy invocation exceeding it is terminated. `0` times out immediately; `None` is unbounded. |
 | `cwd` | Working directory for {{< meta agent_name >}} session. |
 | `env` | Environment variables to set for {{< meta agent_name >}}. |
 | `user` | User to execute {{< meta agent_name >}} as in the sandbox. |

--- a/docs/opencode.qmd
+++ b/docs/opencode.qmd
@@ -26,6 +26,7 @@ The following options are supported for customizing the behavior of the agent:
 | `opencode_model` | OpenCode model identifier (`provider/model`) passed to the CLI. Default: `"anthropic/claude-sonnet-4-5"`. The actual model calls still go through the Inspect bridge; this just selects which provider client OpenCode uses to format the request. |
 | `filter` | Filter for intercepting bridged model requests. |
 | `retry_refusals` | Should refusals be retried? (pass number of times to retry) |
+| `exec_timeout` | Wall-time limit in seconds. Default: 1,800 (30 minutes); a healthy invocation exceeding it is terminated. `0` times out immediately; `None` is unbounded. |
 | `cwd` | Working directory for {{< meta agent_name >}} session. |
 | `env` | Environment variables to set for {{< meta agent_name >}}. |
 | `version` | Version of {{< meta agent_name >}} to use (see [Installation](#installation) below for details) |

--- a/src/inspect_swe/_codex_cli/codex_cli.py
+++ b/src/inspect_swe/_codex_cli/codex_cli.py
@@ -32,7 +32,6 @@ from inspect_ai.tool import (
 )
 from inspect_ai.util import SandboxEnvironment, checkpointer, store
 from inspect_ai.util import sandbox as sandbox_env
-from inspect_ai.util._sandbox import ExecRemoteAwaitableOptions
 from typing_extensions import Unpack
 
 from inspect_swe._util._async import is_callable_coroutine
@@ -43,7 +42,12 @@ from inspect_swe._util.mcp_ready import (
 )
 from inspect_swe._util.messages import build_user_prompt, collect_user_images
 from inspect_swe._util.path import join_path
-from inspect_swe._util.sandbox import resolve_agent_cwd, sandbox_exec
+from inspect_swe._util.sandbox import (
+    DEFAULT_CLI_EXEC_TIMEOUT_SECONDS,
+    resolve_agent_cwd,
+    run_unattended_agent,
+    sandbox_exec,
+)
 from inspect_swe._util.toml import to_toml
 from inspect_swe._util.trace import trace
 
@@ -111,6 +115,7 @@ def codex_cli(
     filter: GenerateFilter | None = None,
     retry_refusals: int | None = None,
     home_dir: str | None = None,
+    exec_timeout: float | None = DEFAULT_CLI_EXEC_TIMEOUT_SECONDS,
     cwd: str | None = None,
     env: dict[str, str] | None = None,
     user: str | None = None,
@@ -185,6 +190,9 @@ def codex_cli(
         filter: Filter for intercepting bridged model requests.
         retry_refusals: Should refusals be retried? (pass number of times to retry)
         home_dir: Home directory to use for codex cli. If set, AGENTS.md, skills, and the MCP configuration will be written here.
+        exec_timeout: Wall-time limit in seconds for each unattended Codex CLI
+            invocation. Defaults to 30 minutes; an invocation that exceeds it is
+            terminated. `0` times out immediately; `None` disables the deadline.
         cwd: Working directory to run codex cli within.
         env: Environment variables to set for codex cli
         user: User to execute codex cli with.
@@ -715,24 +723,25 @@ def codex_cli(
                             required=True,
                         )
 
-                    result = await sbox.exec_remote(
-                        cmd=["bash", "-c", 'exec 0</dev/null; "$@"', "bash"]
-                        + agent_cmd,
-                        options=ExecRemoteAwaitableOptions(
-                            cwd=agent_cwd, env=agent_env, user=user, concurrency=False
-                        ),
-                        stream=False,
-                    )
+                    try:
+                        result = await run_unattended_agent(
+                            sbox,
+                            ["bash", "-c", 'exec 0</dev/null; "$@"', "bash"]
+                            + agent_cmd,
+                            cwd=agent_cwd,
+                            env=agent_env,
+                            user=user,
+                            timeout=exec_timeout,
+                            agent_name="Codex",
+                        )
+                        if debug:
+                            debug_output.append(result.stdout)
+                            debug_output.append(result.stderr)
 
-                    # record output for debug
-                    if debug:
-                        debug_output.append(result.stdout)
-                        debug_output.append(result.stderr)
-
-                    # close any sub-agent spans left open by this attempt so the
-                    # span tree stays balanced across restarts and on error
-                    # (Codex doesn't carry sub-agent spans across resumes)
-                    consumer.reset()
+                    finally:
+                        # Codex does not carry sub-agent spans across resumes.
+                        # Close any spans left open when the subprocess errors or times out.
+                        consumer.reset()
 
                     # raise for error
                     if not result.success:

--- a/src/inspect_swe/_gemini_cli/gemini_cli.py
+++ b/src/inspect_swe/_gemini_cli/gemini_cli.py
@@ -19,7 +19,6 @@ from inspect_ai.tool import MCPServerConfig, Skill, install_skills, read_skills
 from inspect_ai.tool._mcp._config import MCPServerConfigHTTP
 from inspect_ai.util import sandbox as sandbox_env
 from inspect_ai.util import store
-from inspect_ai.util._sandbox import ExecRemoteAwaitableOptions
 
 from inspect_swe._util._async import is_callable_coroutine
 from inspect_swe._util.centaur import CentaurOptions, run_centaur
@@ -29,7 +28,11 @@ from inspect_swe._util.mcp_ready import (
 )
 from inspect_swe._util.messages import build_user_prompt
 from inspect_swe._util.path import join_path
-from inspect_swe._util.sandbox import resolve_agent_cwd
+from inspect_swe._util.sandbox import (
+    DEFAULT_CLI_EXEC_TIMEOUT_SECONDS,
+    resolve_agent_cwd,
+    run_unattended_agent,
+)
 from inspect_swe._util.trace import trace
 
 from .agentbinary import ensure_gemini_cli_setup
@@ -55,6 +58,7 @@ def gemini_cli(
     gemini_model: str = "gemini-2.5-pro",
     filter: GenerateFilter | None = None,
     retry_refusals: int | None = None,
+    exec_timeout: float | None = DEFAULT_CLI_EXEC_TIMEOUT_SECONDS,
     cwd: str | None = None,
     env: dict[str, str] | None = None,
     user: str | None = None,
@@ -91,6 +95,9 @@ def gemini_cli(
             calls still go through the inspect bridge, but this disables the router.
         filter: Filter for intercepting bridged model requests
         retry_refusals: Should refusals be retried? (pass number of times to retry)
+        exec_timeout: Wall-time limit in seconds for each unattended Gemini CLI
+            invocation. Defaults to 30 minutes; an invocation that exceeds it is
+            terminated. `0` times out immediately; `None` disables the deadline.
         cwd: Working directory to run gemini cli within
         env: Environment variables to set for gemini cli
         user: User to execute gemini cli with
@@ -266,16 +273,14 @@ def gemini_cli(
                             timeout=mcp_ready_timeout,
                             required=True,
                         )
-                    result = await sbox.exec_remote(
-                        cmd=["bash", "-c", 'exec 0</dev/null; "$@"', "bash"]
-                        + agent_cmd,
-                        options=ExecRemoteAwaitableOptions(
-                            cwd=agent_cwd,
-                            env=agent_env,
-                            user=user,
-                            concurrency=False,
-                        ),
-                        stream=False,
+                    result = await run_unattended_agent(
+                        sbox,
+                        ["bash", "-c", 'exec 0</dev/null; "$@"', "bash"] + agent_cmd,
+                        cwd=agent_cwd,
+                        env=agent_env,
+                        user=user,
+                        timeout=exec_timeout,
+                        agent_name="Gemini",
                     )
 
                     # track debug output

--- a/src/inspect_swe/_kimi_code/kimi_code.py
+++ b/src/inspect_swe/_kimi_code/kimi_code.py
@@ -43,7 +43,6 @@ from inspect_ai.tool import (
 )
 from inspect_ai.util import sandbox as sandbox_env
 from inspect_ai.util import store
-from inspect_ai.util._sandbox import ExecRemoteAwaitableOptions
 
 from inspect_swe._util._async import is_callable_coroutine
 from inspect_swe._util.centaur import CentaurOptions, run_centaur
@@ -55,7 +54,11 @@ from inspect_swe._util.messages import build_user_prompt
 from inspect_swe._util.trace import trace
 
 from .._util.agentbinary import ensure_agent_binary_installed
-from .._util.sandbox import resolve_agent_cwd
+from .._util.sandbox import (
+    DEFAULT_CLI_EXEC_TIMEOUT_SECONDS,
+    resolve_agent_cwd,
+    run_unattended_agent,
+)
 from .._util.toml import _format_value
 from .agentbinary import kimi_code_binary_source
 
@@ -123,6 +126,7 @@ def kimi_code(
     model_aliases: dict[str, str | Model] | None = None,
     filter: GenerateFilter | None = None,
     retry_refusals: int | None = None,
+    exec_timeout: float | None = DEFAULT_CLI_EXEC_TIMEOUT_SECONDS,
     disallowed_tools: Sequence[str] | None = None,
     cwd: str | None = None,
     env: dict[str, str] | None = None,
@@ -162,6 +166,9 @@ def kimi_code(
         model_aliases: Optional mapping of model names to Model instances or model name strings.
         filter: Filter for intercepting bridged model requests
         retry_refusals: Should refusals be retried? (pass number of times to retry)
+        exec_timeout: Wall-time limit in seconds for each unattended Kimi Code
+            invocation. Defaults to 30 minutes; an invocation that exceeds it is
+            terminated. `0` times out immediately; `None` disables the deadline.
         disallowed_tools: Tool names to deny via Kimi permission rules
         cwd: Working directory to run kimi within
         env: Environment variables to set for kimi
@@ -366,16 +373,14 @@ def kimi_code(
                     # BLOCKING_MCP_ENV and codex via required=true; kimi has
                     # no equivalent knob.
 
-                    result = await sbox.exec_remote(
-                        cmd=["bash", "-c", 'exec 0</dev/null; "$@"', "bash"]
-                        + agent_cmd,
-                        options=ExecRemoteAwaitableOptions(
-                            cwd=agent_cwd,
-                            env=agent_env,
-                            user=user,
-                            concurrency=False,
-                        ),
-                        stream=False,
+                    result = await run_unattended_agent(
+                        sbox,
+                        ["bash", "-c", 'exec 0</dev/null; "$@"', "bash"] + agent_cmd,
+                        cwd=agent_cwd,
+                        env=agent_env,
+                        user=user,
+                        timeout=exec_timeout,
+                        agent_name="Kimi Code",
                     )
 
                     if debug:

--- a/src/inspect_swe/_mini_swe_agent/mini_swe_agent.py
+++ b/src/inspect_swe/_mini_swe_agent/mini_swe_agent.py
@@ -22,13 +22,16 @@ from inspect_ai.model import (
 from inspect_ai.scorer import score
 from inspect_ai.util import sandbox as sandbox_env
 from inspect_ai.util import store
-from inspect_ai.util._sandbox import ExecRemoteAwaitableOptions
 
 from .._util._async import is_callable_coroutine
 from .._util.agentwheel import AgentWheelSource, ensure_agent_wheel_installed
 from .._util.centaur import CentaurOptions, run_centaur
 from .._util.messages import build_user_prompt
-from .._util.sandbox import resolve_agent_cwd
+from .._util.sandbox import (
+    DEFAULT_CLI_EXEC_TIMEOUT_SECONDS,
+    resolve_agent_cwd,
+    run_unattended_agent,
+)
 from .._util.trace import trace
 from .setup import (
     RESUMABLE_AGENT_PATH,
@@ -61,6 +64,7 @@ def mini_swe_agent(
     filter: GenerateFilter | None = None,
     retry_refusals: int | None = None,
     compaction: CompactionStrategy | None = None,
+    exec_timeout: float | None = DEFAULT_CLI_EXEC_TIMEOUT_SECONDS,
     cwd: str | None = None,
     env: dict[str, str] | None = None,
     user: str | None = None,
@@ -97,6 +101,10 @@ def mini_swe_agent(
         filter: Filter for intercepting bridged model requests.
         retry_refusals: Should refusals be retried? (pass number of times to retry)
         compaction: Compaction strategy for managing context window overflow.
+        exec_timeout: Wall-time limit in seconds for each unattended
+            mini-swe-agent invocation. Defaults to 30 minutes; an invocation that
+            exceeds it is terminated. `0` times out immediately; `None` disables
+            the deadline.
         cwd: Working directory to run mini-swe-agent within.
         env: Environment variables to set for mini-swe-agent.
         user: User to execute mini-swe-agent with.
@@ -222,16 +230,14 @@ def mini_swe_agent(
                     }
                     agent_cmd = cmd + ["--task", agent_prompt]
 
-                    result = await sbox.exec_remote(
-                        cmd=["bash", "-c", 'exec 0</dev/null; "$@"', "bash"]
-                        + agent_cmd,
-                        options=ExecRemoteAwaitableOptions(
-                            cwd=agent_cwd,
-                            env=run_env,
-                            user=user,
-                            concurrency=False,
-                        ),
-                        stream=False,
+                    result = await run_unattended_agent(
+                        sbox,
+                        ["bash", "-c", 'exec 0</dev/null; "$@"', "bash"] + agent_cmd,
+                        cwd=agent_cwd,
+                        env=run_env,
+                        user=user,
+                        timeout=exec_timeout,
+                        agent_name="mini-swe-agent",
                     )
 
                     # track debug output

--- a/src/inspect_swe/_opencode/opencode.py
+++ b/src/inspect_swe/_opencode/opencode.py
@@ -19,7 +19,6 @@ from inspect_ai.tool import MCPServerConfig, Skill, install_skills, read_skills
 from inspect_ai.tool._mcp._config import MCPServerConfigHTTP
 from inspect_ai.util import sandbox as sandbox_env
 from inspect_ai.util import store
-from inspect_ai.util._sandbox import ExecRemoteAwaitableOptions
 
 from inspect_swe._util._async import is_callable_coroutine
 from inspect_swe._util.centaur import CentaurOptions, run_centaur
@@ -28,7 +27,11 @@ from inspect_swe._util.mcp_ready import (
     wait_for_mcp_endpoints,
 )
 from inspect_swe._util.messages import build_user_prompt
-from inspect_swe._util.sandbox import resolve_agent_cwd
+from inspect_swe._util.sandbox import (
+    DEFAULT_CLI_EXEC_TIMEOUT_SECONDS,
+    resolve_agent_cwd,
+    run_unattended_agent,
+)
 from inspect_swe._util.trace import trace
 
 from .agentbinary import ensure_opencode_setup
@@ -54,6 +57,7 @@ def opencode(
     opencode_model: str = "anthropic/claude-sonnet-4-5",
     filter: GenerateFilter | None = None,
     retry_refusals: int | None = None,
+    exec_timeout: float | None = DEFAULT_CLI_EXEC_TIMEOUT_SECONDS,
     cwd: str | None = None,
     env: dict[str, str] | None = None,
     user: str | None = None,
@@ -90,6 +94,9 @@ def opencode(
             client OpenCode uses to format the request.
         filter: Filter for intercepting bridged model requests
         retry_refusals: Should refusals be retried? (pass number of times to retry)
+        exec_timeout: Wall-time limit in seconds for each unattended OpenCode
+            invocation. Defaults to 30 minutes; an invocation that exceeds it is
+            terminated. `0` times out immediately; `None` disables the deadline.
         cwd: Working directory to run opencode within
         env: Environment variables to set for opencode
         user: User to execute opencode with
@@ -293,16 +300,14 @@ def opencode(
                             required=True,
                         )
 
-                    result = await sbox.exec_remote(
-                        cmd=["bash", "-c", 'exec 0</dev/null; "$@"', "bash"]
-                        + agent_cmd,
-                        options=ExecRemoteAwaitableOptions(
-                            cwd=agent_cwd,
-                            env=agent_env,
-                            user=user,
-                            concurrency=False,
-                        ),
-                        stream=False,
+                    result = await run_unattended_agent(
+                        sbox,
+                        ["bash", "-c", 'exec 0</dev/null; "$@"', "bash"] + agent_cmd,
+                        cwd=agent_cwd,
+                        env=agent_env,
+                        user=user,
+                        timeout=exec_timeout,
+                        agent_name="OpenCode",
                     )
 
                     if debug:

--- a/src/inspect_swe/_util/sandbox.py
+++ b/src/inspect_swe/_util/sandbox.py
@@ -3,6 +3,8 @@ from pathlib import PurePosixPath
 from typing import Literal, TypeAlias, cast
 
 from inspect_ai.util import SandboxEnvironment
+from inspect_ai.util._sandbox import ExecRemoteAwaitableOptions
+from inspect_ai.util._subprocess import ExecResult
 
 logger = getLogger(__name__)
 
@@ -12,6 +14,8 @@ SandboxPlatform: TypeAlias = Literal[
 """Target platform identifier for sandbox binary and wheel downloads."""
 
 SANDBOX_INSTALL_DIR = "/var/tmp/.5c95f967ca830048"
+
+DEFAULT_CLI_EXEC_TIMEOUT_SECONDS = 30.0 * 60.0
 
 
 async def detect_sandbox_platform(sandbox: SandboxEnvironment) -> SandboxPlatform:
@@ -104,3 +108,41 @@ async def sandbox_exec(
     if not result.success:
         raise RuntimeError(f"Error executing sandbox command {cmd}: {result.stderr}")
     return result.stdout.strip()
+
+
+async def run_unattended_agent(
+    sandbox: SandboxEnvironment,
+    cmd: list[str],
+    *,
+    cwd: str,
+    env: dict[str, str],
+    user: str | None,
+    timeout: float | None,
+    agent_name: str,
+) -> ExecResult[str]:
+    """Run an unattended CLI command with a configured process lifetime.
+
+    ``exec_remote`` kills the sandbox process before raising ``TimeoutError`` when
+    the configured deadline expires. ``None`` disables the deadline. Translating
+    the timeout to ``RuntimeError`` lets Inspect record it as a regular sample error
+    and apply ``retry_on_error`` rather than treating it as an eval working-time
+    limit.
+    """
+    try:
+        return await sandbox.exec_remote(
+            cmd=cmd,
+            options=ExecRemoteAwaitableOptions(
+                cwd=cwd,
+                env=env,
+                user=user,
+                concurrency=False,
+                timeout=timeout,
+            ),
+            stream=False,
+        )
+    except TimeoutError as ex:
+        if timeout is None:
+            raise
+        raise RuntimeError(
+            f"{agent_name} CLI execution timed out after {timeout:g} seconds."
+        ) from ex

--- a/tests/test_cli_exec_timeout.py
+++ b/tests/test_cli_exec_timeout.py
@@ -1,0 +1,256 @@
+from collections.abc import AsyncGenerator, Generator
+from contextlib import asynccontextmanager, contextmanager
+from subprocess import Popen
+from sys import executable
+from typing import TypeVar, cast, final
+from unittest.mock import patch
+
+import anyio
+import pytest
+from inspect_ai.agent import AgentState
+from inspect_ai.model import ChatMessageUser
+from inspect_ai.util import SandboxEnvironment
+from inspect_ai.util._sandbox import ExecRemoteAwaitableOptions
+from inspect_ai.util._sandbox import exec_remote as core_exec_remote
+from inspect_ai.util._subprocess import ExecResult
+from inspect_swe._codex_cli.codex_cli import codex_cli
+from pydantic import BaseModel
+
+T = TypeVar("T")
+
+
+@final
+class _FakeCheckpointer:
+    attempt: str = ""
+
+    async def __aenter__(self) -> "_FakeCheckpointer":
+        return self
+
+    async def __aexit__(
+        self,
+        _exc_type: object,
+        _exc_value: object,
+        _traceback: object,
+    ) -> None:
+        return None
+
+    def track(self, _key: str, _value: object, default: T) -> T:
+        return default
+
+
+@final
+class _FakeBridge:
+    state: AgentState
+    port: int
+    mcp_server_configs: list[object]
+
+    def __init__(self, state: AgentState) -> None:
+        self.state = state
+        self.port = 3001
+        self.mcp_server_configs = []
+
+
+@final
+class _FakeStore:
+    values: dict[str, int]
+
+    def __init__(self) -> None:
+        self.values = {}
+
+    def get(self, key: str, default: int) -> int:
+        return self.values.get(key, default)
+
+    def set(self, key: str, value: int) -> None:
+        self.values[key] = value
+
+
+ModelT = TypeVar("ModelT", bound=BaseModel)
+
+
+@final
+class _CoreKillSandbox:
+    _tools_user: str | None
+    process: Popen[bytes] | None
+    exit_code: int | None
+    kill_rpc_count: int
+
+    def __init__(self) -> None:
+        self._tools_user = None
+        self.process = None
+        self.exit_code = None
+        self.kill_rpc_count = 0
+
+    @contextmanager
+    def no_events(self) -> Generator[None, None, None]:
+        yield
+
+    async def write_file(self, _path: str, _content: str) -> None:
+        return None
+
+    async def exec(self, cmd: list[str], **_: object) -> ExecResult[str]:
+        assert cmd
+        return ExecResult(success=True, returncode=0, stdout="", stderr="")
+
+    async def exec_remote(
+        self,
+        cmd: list[str],
+        *,
+        options: ExecRemoteAwaitableOptions,
+        stream: bool,
+    ) -> ExecResult[str]:
+        assert stream is False
+        return await core_exec_remote.exec_remote_awaitable(
+            cast(SandboxEnvironment, self),
+            cmd,
+            sandbox_default_poll_interval=0.001,
+            options=options,
+        )
+
+    async def exec_model_request(
+        self,
+        *,
+        method: str,
+        params: dict[str, object],
+        result_type: type[ModelT],
+        **_kwargs: object,
+    ) -> ModelT:
+        if method == "exec_remote_start":
+            assert params["command"]
+            self.process = Popen([executable, "-c", "import time; time.sleep(60)"])
+            return result_type.model_validate({"pid": self.process.pid})
+        if method == "exec_remote_poll":
+            return result_type.model_validate(
+                {"state": "running", "seq": 0, "stdout": "", "stderr": ""}
+            )
+        if method == "exec_remote_kill":
+            assert self.process is not None
+            self.kill_rpc_count += 1
+            self.process.kill()
+            self.exit_code = self.process.wait(timeout=1)
+            return result_type.model_validate({"seq": 0, "stdout": "", "stderr": ""})
+        raise AssertionError(f"Unexpected RPC method: {method}")
+
+    def cleanup(self) -> None:
+        if self.process is not None and self.process.poll() is None:
+            self.process.kill()
+            self.process.wait(timeout=1)
+
+
+@final
+class _FastSandbox:
+    timeout: float | None
+
+    def __init__(self) -> None:
+        self.timeout = None
+
+    async def write_file(self, _path: str, _content: str) -> None:
+        return None
+
+    async def exec(self, cmd: list[str], **_: object) -> ExecResult[str]:
+        assert cmd
+        return ExecResult(success=True, returncode=0, stdout="", stderr="")
+
+    async def exec_remote(
+        self,
+        cmd: list[str],
+        *,
+        options: ExecRemoteAwaitableOptions,
+        stream: bool,
+    ) -> ExecResult[str]:
+        assert cmd
+        assert stream is False
+        self.timeout = options.timeout
+        return ExecResult(
+            success=True,
+            returncode=0,
+            stdout="stdout-marker",
+            stderr="stderr-marker",
+        )
+
+
+def _agent_state() -> AgentState:
+    return AgentState(messages=[ChatMessageUser(content="Solve the task.")])
+
+
+@asynccontextmanager
+async def _sandbox_agent_bridge(
+    state: AgentState,
+    **_kwargs: object,
+) -> AsyncGenerator[_FakeBridge, None]:
+    yield _FakeBridge(state)
+
+
+async def _ensure_binary(*_args: object, **_kwargs: object) -> str:
+    return "codex"
+
+
+async def _resolve_cwd(*_args: object, **_kwargs: object) -> str:
+    return "/workdir"
+
+
+async def _resolve_model(*_args: object, **_kwargs: object) -> str:
+    return "gpt-5"
+
+
+def _run_codex(
+    sandbox: _CoreKillSandbox | _FastSandbox,
+    *,
+    exec_timeout: float | None = None,
+    debug: bool = False,
+) -> AgentState:
+    from inspect_swe._codex_cli import codex_cli as codex_module
+
+    with (
+        patch.object(codex_module, "checkpointer", return_value=_FakeCheckpointer()),
+        patch.object(codex_module, "sandbox_agent_bridge", _sandbox_agent_bridge),
+        patch.object(codex_module, "sandbox_env", return_value=sandbox),
+        patch.object(codex_module, "ensure_agent_binary_installed", _ensure_binary),
+        patch.object(codex_module, "resolve_agent_cwd", _resolve_cwd),
+        patch.object(codex_module, "resolve_codex_model", _resolve_model),
+        patch.object(codex_module, "store", return_value=_FakeStore()),
+    ):
+        if exec_timeout is None:
+            agent = codex_cli(debug=debug)
+        else:
+            agent = codex_cli(exec_timeout=exec_timeout, debug=debug)
+        return anyio.run(agent, _agent_state())
+
+
+def test_codex_exec_timeout_kills_real_core_process() -> None:
+    sandbox = _CoreKillSandbox()
+
+    try:
+        with (
+            patch.object(
+                core_exec_remote, "exec_model_request", sandbox.exec_model_request
+            ),
+            pytest.raises(
+                RuntimeError,
+                match="Codex CLI execution timed out after 0.01 seconds",
+            ),
+        ):
+            _ = _run_codex(sandbox, exec_timeout=0.01)
+
+        assert sandbox.kill_rpc_count == 1
+        assert sandbox.exit_code == -9
+    finally:
+        sandbox.cleanup()
+
+
+def test_codex_debug_trace_includes_cli_output() -> None:
+    sandbox = _FastSandbox()
+    traced: list[str] = []
+
+    with patch("inspect_swe._codex_cli.codex_cli.trace", traced.append):
+        _ = _run_codex(sandbox, debug=True)
+
+    assert traced == ["Codex CLI Debug Output:\nstdout-marker\nstderr-marker"]
+
+
+def test_codex_exec_timeout_leaves_fast_cli_invocation_unchanged() -> None:
+    sandbox = _FastSandbox()
+
+    result = _run_codex(sandbox)
+
+    assert result.messages[-1].text == "Solve the task."
+    assert sandbox.timeout == 1800.0


### PR DESCRIPTION
An unattended CLI agent invocation that never returns had no deadline. The sample did not fail — it stalled, holding its sandbox and producing no tokens, until something outside the eval noticed. We observed runs sitting at 16–23 hours at zero tokens.

Five agents took the same shape: Codex, Gemini, Kimi Code, OpenCode and mini-swe-agent each awaited the sandbox executor directly.

## The change

Each of the five factories takes `exec_timeout: float | None = 1800.0` (30 minutes) and routes its unattended invocation through a shared `run_unattended_agent` helper. When the deadline passes, the sandbox process is killed and the caller sees a `RuntimeError` naming the agent and the elapsed limit.

The normalization from `TimeoutError` to `RuntimeError` is deliberate and the reason is the point of the fix: Inspect treats a bare `TimeoutError` as a working-time limit, which ends the sample rather than recording a normal error. As a `RuntimeError`, the timeout becomes an ordinary sample error, so `retry_on_error` applies and the eval can recover from a single wedged invocation instead of losing the run. The original exception is chained, so nothing about the cause is lost.

`None` leaves an invocation unbounded for callers who want the previous behaviour.

## What is deliberately untouched

Claude Code's streaming path uses `ExecRemoteStreamingOptions` with `stream=True` and is not an unattended awaitable invocation, so it is out of scope here.

## Tests

`tests/test_cli_exec_timeout.py` drives the real awaitable executor and iterator rather than a simulated cancellation, and asserts the timeout surfaces as a `RuntimeError` after the deadline rather than hanging. Runtime signature inspection in the suite confirms all five factories declare the parameter with the same default.

### Agent review

- Reviewer: a frontier-class model in a fresh context, different from the author, 2 passes
- Findings: 2, both blocking, both fixed and independently re-verified in the second pass — (1) Codex stdout/stderr debug accumulation was dropped by the refactor and is restored; (2) the first regression only simulated cancellation, and was replaced with one that exercises the real executor
- A third pass reviewed the composition this ships in and found nothing further

This change was authored by an AI agent (Claude) working under @sjawhar, in a separate session from the one opening this PR; both fresh-context review passes below were run against the authoring session's output.

Running in trajectory-labs-pbc/inspect_swe since release/2026-09-10.1.

Opened and updated by Claude on behalf of @sjawhar.
