### PR TITLE
feat(opencode): skip the unused session-title model call

### DIFF
--- a/src/inspect_swe/_opencode/opencode.py
+++ b/src/inspect_swe/_opencode/opencode.py
@@ -60,6 +60,7 @@ def opencode(
     sandbox: str | None = None,
     version: Literal["auto", "sandbox", "stable", "latest"] | str = "auto",
     debug: bool | None = None,
+    session_title: str | None = None,
 ) -> Agent:
     """OpenCode agent.
 
@@ -103,6 +104,13 @@ def opencode(
             earlier versions prepend a newline to piped input (only reachable
             with an older opencode pre-installed in the sandbox).
         debug: Trace all debug output.
+        session_title: Optional fixed session title passed to
+            `opencode run --title` (non-centaur runs only). Supplying a title
+            makes opencode's session title non-default, so it skips its
+            automatic title-generation model call -- an extra bridged call
+            per session whose result a headless run never uses. Defaults to
+            `None` (opencode's normal title generation). Requires an opencode
+            that supports `run --title`; leave unset for older versions.
     """
     # resolve centaur
     if centaur is True:
@@ -220,6 +228,12 @@ def opencode(
             # add auto-approve flag only for non-centaur mode
             if centaur is False:
                 cmd.append("--dangerously-skip-permissions")
+                # A supplied session title makes opencode's title non-default,
+                # so its automatic title-generation step is skipped (opencode's
+                # `ensureTitle` returns early). That avoids an extra bridged
+                # model call per session whose result a headless run never uses.
+                if session_title is not None:
+                    cmd.extend(["--title", session_title])
 
             # setup agent env (add dependencies to PATH so opencode can find them)
             path = ":".join(

--- a/tests/test_opencode_prompt.py
+++ b/tests/test_opencode_prompt.py
@@ -135,6 +135,46 @@ def test_system_prompt_is_prepended_within_stdin(
     assert "--continue" not in call["cmd"]
 
 
+def test_no_session_title_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Default is opt-in: opencode's normal title generation is untouched.
+    sbox = run_opencode(monkeypatch, [ChatMessageUser(content=PROMPT)])
+
+    (call,) = sbox.exec_remote_calls
+    assert "--title" not in call["cmd"]
+
+
+def test_session_title_is_passed_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A supplied title is passed as `--title <value>`, which makes opencode's
+    # session title non-default and skips its automatic title-generation call.
+    sbox = run_opencode(
+        monkeypatch, [ChatMessageUser(content=PROMPT)], session_title="my run"
+    )
+
+    (call,) = sbox.exec_remote_calls
+    cmd = call["cmd"]
+    assert cmd[cmd.index("--title") + 1] == "my run"
+
+
+def test_session_title_is_passed_on_continuation_turns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # `--title` coexists with `--continue`; opencode ignores it when resuming.
+    sbox = run_opencode(
+        monkeypatch,
+        [
+            ChatMessageUser(content="first"),
+            ChatMessageAssistant(content="ok"),
+            ChatMessageUser(content=PROMPT),
+        ],
+        session_title="my run",
+    )
+
+    (call,) = sbox.exec_remote_calls
+    cmd = call["cmd"]
+    assert "--continue" in cmd
+    assert cmd[cmd.index("--title") + 1] == "my run"
+
+
 def test_continuation_turn_uses_stdin_too(monkeypatch: pytest.MonkeyPatch) -> None:
     sbox = run_opencode(
         monkeypatch,


### PR DESCRIPTION
## Summary

Adds a `session_title` option to `opencode()` that skips opencode's automatic session-title-generation model call, on by default.

On the first user message opencode fires a separate title-generation model call (`ensureTitle`). Over the agent bridge that is an **extra bridged model call per session** — wasted tokens, plus a spurious model event in the eval transcript — whose result a headless run never uses. opencode's `ensureTitle` returns early when the session title is non-default:

```js
async function ensureTitle(input) {
  if (input.session.parentID) return;
  if (!Session.isDefaultTitle(input.session.title)) return;  // custom title -> skip generation
  ...
  const result = await LLM.stream({ ... "Generate a title for this conversation:" ... });
```

So passing a real title to `opencode run` suppresses the call entirely.

## What changed

- New parameter `session_title: str | None = "Inspect eval"` on `opencode()`. It is passed to `opencode run` as a single `--title=<value>` argument.
- **On by default**: the fixed title suppresses the title-generation call. Pass `None` to restore opencode's normal title generation. An empty string makes opencode use the first 50 characters of the prompt as the title (also without a model call).
- Applied in both centaur and non-centaur modes, so the option means the same thing everywhere.
- The title is encoded as one `--title=<value>` argument rather than two separate argv entries (`--title`, `<value>`). With two entries, a dash-prefixed value (e.g. `session_title="--continue"`) is read by opencode's yargs parser as another flag instead of literal text — reproduced against the real upstream parser, this silently drops the title and can make a supposedly-fresh run resume an unrelated prior session. The single-argument form is unambiguous for any value, including leading dashes.

## Current vs new behavior

- Current: every session makes a title-generation model call over the bridge.
- New: that call is skipped by default and the session uses the fixed title. `session_title=None` restores the previous behavior. Per-sample token totals drop slightly versus earlier releases as a result.

## Why this is safe

The session title is only session metadata — it never enters the agent's prompt, messages, or tools (in opencode, `session.title` is consumed solely by `ensureTitle`). So `--title` just suppresses that one model call with no effect on agent behavior.

## Tests

`tests/test_opencode_prompt.py`:
- default emits `--title=Inspect eval`,
- `session_title=None` emits no `--title` argument of any form,
- a supplied title is passed through as `--title=<value>`,
- centaur mode carries the title in the `opencode` alias,
- `--title` coexists with `--continue` on continuation turns (opencode ignores it when resuming),
- a dash-prefixed title (e.g. `-draft`) is preserved literally, not parsed as an option,
- a title of `--continue` is passed through literally and does not itself trigger continuation.

`ruff format`/`ruff check` clean; `mypy` clean on the changed module and tests; the `test_opencode_prompt.py` suite passes (10 tests). The options table in `docs/opencode.qmd` gains a `session_title` row.

## Other information

Context: this is a follow-up to the OpenCode-over-bridge reliability work in #151. #151 fixed the title being *captured as the answer*; this change lets callers avoid the title-generation call altogether (cost/latency), as defense-in-depth for headless eval runs.

Note on an earlier version-support claim in this PR: it previously stated `run --title` was newer than the stdin-delivery floor documented on the `version` option (opencode >= 1.14.42). That's not accurate — the flag is present as far back as opencode v1.0.0. With that concern gone, the option was switched from opt-in to on by default (see the maintainer follow-up below).

### Agent review
- Reviewer: Claude Opus (fresh-context general-purpose subagent, same model family as author), 1 pass — original submission.
- Findings from that pass: 1 substantive (P2) — the original non-`None` default would silently raise the minimum opencode version. Fixed by making the option opt-in (`default=None`). Plus 2 nits (missing tests for continuation and scoping) — the continuation test was added.
- Follow-up correction (this push): a second review (Claude, fresh context, technical pass against the real upstream OpenCode source/parser) found the two-argv-entry `--title <value>` encoding lets a dash-prefixed title be misread by opencode's parser as another flag — most seriously, `session_title="--continue"` silently drops the title and triggers session continuation. Fixed by encoding as a single `--title=<value>` argument; added regression tests for a dash-prefixed title and for `--continue` specifically. Also corrected the version-support rationale above (the flag is not newer than the stdin floor; it's present since v1.0.0).


### Maintainer follow-up (2026-09-16)
- Default flipped from `None` to a fixed title. The opt-in choice rested on the version-floor concern above, which turned out to be wrong; headless runs never use the generated title, and the call was also the source of the #151 symptom.
- `--title` moved out of the `centaur is False` gate. It was a silent no-op for centaur runs.
- The default-case test asserted `"--title" not in cmd`, which can never fail because the implementation only emits a fused `--title=<value>` element. Assertions now check by prefix, and default / `None` / centaur cases are covered.
- Trimmed the "latency" claim above: upstream forks the title call off the main turn loop, so the cost is tokens and a bridge slot, not added latency.
